### PR TITLE
Add proper support for original games

### DIFF
--- a/deploy/hooks/common
+++ b/deploy/hooks/common
@@ -2,6 +2,7 @@
 
 ################ config start ################
 
+LD_PRELOAD=/var/www/server/production/current/node_modules/sharp/vendor/lib/libz.so
 KEEP_DEPLOYMENTS=5
 DEPLOY_ROOT=/var/www/server
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "vpdb",
-	"version": "v3.1.1",
+	"version": "v3.1.2-SNAPSHOT",
 	"description": "Virtual Pinball Database",
 	"main": "src/app/index.ts",
 	"repository": {

--- a/src/app/common/acl.ts
+++ b/src/app/common/acl.ts
@@ -80,7 +80,7 @@ export async function init(): Promise<void> {
 				{ resources: 'builds',        permissions: ['add', 'delete-own'] },
 				{ resources: 'comments',      permissions: ['add', 'update-own'] },
 				{ resources: 'files',         permissions: ['download', 'delete-own', 'upload'] },
-				{ resources: 'games',         permissions: ['rate', 'star'] },
+				{ resources: 'games',         permissions: ['rate', 'star', 'add-og'] },
 				{ resources: 'game_requests', permissions: ['add', 'delete-own'] },
 				{ resources: 'media',         permissions: ['add', 'delete-own', 'star'] },
 				{ resources: 'messages',      permissions: ['receive'] },

--- a/src/app/common/acl.ts
+++ b/src/app/common/acl.ts
@@ -80,7 +80,7 @@ export async function init(): Promise<void> {
 				{ resources: 'builds',        permissions: ['add', 'delete-own'] },
 				{ resources: 'comments',      permissions: ['add', 'update-own'] },
 				{ resources: 'files',         permissions: ['download', 'delete-own', 'upload'] },
-				{ resources: 'games',         permissions: ['rate', 'star', 'add-og'] },
+				{ resources: 'games',         permissions: ['rate', 'star', 'add-og', 'update-own'] },
 				{ resources: 'game_requests', permissions: ['add', 'delete-own'] },
 				{ resources: 'media',         permissions: ['add', 'delete-own', 'star'] },
 				{ resources: 'messages',      permissions: ['receive'] },

--- a/src/app/common/mongoose/moderation.spec.js
+++ b/src/app/common/mongoose/moderation.spec.js
@@ -323,6 +323,15 @@ describe('The VPDB moderation feature', () => {
 				.then(res => res.expectStatus(200));
 		});
 
+		it('should succeed when only requesting own releases', async () => {
+			res = await api
+				.as('member')
+				.withQuery({ fields: 'moderation', show_mine_only: 1 })
+				.get('/v1/releases')
+				.then(res => res.expectStatus(200));
+			expect(res.data.find(r => r.id === release.id).moderation).to.be.ok();
+		});
+
 	});
 
 	describe('when listing moderated backglasses', () => {
@@ -467,6 +476,16 @@ describe('The VPDB moderation feature', () => {
 			res = await api.as('moderator').withQuery({ moderation: 'manually_approved' }).get('/v1/releases').then(res => res.expectStatus(200));
 			expect(res.data.find(b => b.id === release.id)).not.to.be.ok();
 		});
+
+		it('should list a moderated release when requesting own releases', async () => {
+			res = await api
+				.as('member')
+				.withQuery({ fields: 'moderation', show_mine_only: 1 })
+				.get('/v1/releases')
+				.then(res => res.expectStatus(200));
+			expect(res.data.find(r => r.id === release.id)).to.be.ok();
+		});
+
 	});
 
 	describe('when retrieving pending backglass details', () => {

--- a/src/app/games/game.api.acl.spec.js
+++ b/src/app/games/game.api.acl.spec.js
@@ -52,6 +52,10 @@ describe('The ACLs of the `Game` API', function() {
 			request.post('/api/v1/games').send({}).end(hlp.status(401, done));
 		});
 
+		it('should deny access to game edition', function(done) {
+			request.patch('/api/v1/games/mb').send({}).end(hlp.status(401, done));
+		});
+
 		it('should deny access to game deletion', function(done) {
 			request.del('/api/v1/games/mb').end(hlp.status(401, done));
 		});
@@ -73,6 +77,10 @@ describe('The ACLs of the `Game` API', function() {
 
 		it('should allow access to game creation with original type', function(done) {
 			request.post('/api/v1/games').send({ game_type: 'og' }).as('member').end(hlp.status(422, done));
+		});
+
+		it('should allow access to game edition', function(done) {
+			request.patch('/api/v1/games/mb').send({}).as('member').end(hlp.status(404, done));
 		});
 
 		it('should deny access to game deletion', function(done) {

--- a/src/app/games/game.api.acl.spec.js
+++ b/src/app/games/game.api.acl.spec.js
@@ -67,8 +67,12 @@ describe('The ACLs of the `Game` API', function() {
 			request.head('/api/v1/games/mb').as('member').end(hlp.status(404, done));
 		});
 
-		it('should deny access to game creation', function(done) {
-			request.post('/api/v1/games').send({}).as('member').end(hlp.status(403, done));
+		it('should deny access to game creation with non-original type', function(done) {
+			request.post('/api/v1/games').send({ game_type: 'ss' }).as('member').end(hlp.status(403, done));
+		});
+
+		it('should allow access to game creation with original type', function(done) {
+			request.post('/api/v1/games').send({ game_type: 'og' }).as('member').end(hlp.status(422, done));
 		});
 
 		it('should deny access to game deletion', function(done) {

--- a/src/app/games/game.api.router.ts
+++ b/src/app/games/game.api.router.ts
@@ -41,7 +41,7 @@ export class GameApiRouter implements ApiRouter {
 		this.router.get('/v1/games',       api.list.bind(api));
 		this.router.head('/v1/games/:id',  api.head.bind(api));
 		this.router.get('/v1/games/:id',   api.view.bind(api));
-		this.router.patch('/v1/games/:id',  api.auth(api.update.bind(api), 'games', 'update', [ Scope.ALL ]));
+		this.router.patch('/v1/games/:id',  api.auth(api.update.bind(api), 'games', 'update-own', [ Scope.ALL ]));
 		this.router.post('/v1/games',       api.auth(api.create.bind(api), 'games', 'add-og', [ Scope.ALL ]));
 		this.router.delete('/v1/games/:id', api.auth(api.del.bind(api), 'games', 'delete', [ Scope.ALL ]));
 

--- a/src/app/games/game.api.router.ts
+++ b/src/app/games/game.api.router.ts
@@ -42,7 +42,7 @@ export class GameApiRouter implements ApiRouter {
 		this.router.head('/v1/games/:id',  api.head.bind(api));
 		this.router.get('/v1/games/:id',   api.view.bind(api));
 		this.router.patch('/v1/games/:id',  api.auth(api.update.bind(api), 'games', 'update', [ Scope.ALL ]));
-		this.router.post('/v1/games',       api.auth(api.create.bind(api), 'games', 'add', [ Scope.ALL ]));
+		this.router.post('/v1/games',       api.auth(api.create.bind(api), 'games', 'add-og', [ Scope.ALL ]));
 		this.router.delete('/v1/games/:id', api.auth(api.del.bind(api), 'games', 'delete', [ Scope.ALL ]));
 
 		const ratingApi = new RatingApi();

--- a/src/app/games/game.api.spec.js
+++ b/src/app/games/game.api.spec.js
@@ -343,6 +343,19 @@ describe('The VPDB `game` API', () => {
 			expect(res.data.find(g => g.id === og.id)).to.be.ok();
 		});
 
+		it('should list the game without release when fetching own content', async () => {
+			const og = await api.gameHelper.createOriginalGame('member');
+			res = await api.as('member').get('/v1/games?show_mine_only=1').then(res => res.expectStatus(200));
+			expect(res.data.find(g => g.id === og.id)).to.be.ok();
+		});
+
+		it('should list the game with unapproved release when fetching own content', async () => {
+			const og = await api.gameHelper.createOriginalGame('member');
+			await api.releaseHelper.createReleaseForGame('member', og);
+			res = await api.as('member').get('/v1/games?show_mine_only=1').then(res => res.expectStatus(200));
+			expect(res.data.find(g => g.id === og.id)).to.be.ok();
+		});
+
 	});
 
 	describe('when viewing a game', () => {

--- a/src/app/games/game.api.spec.js
+++ b/src/app/games/game.api.spec.js
@@ -310,6 +310,9 @@ describe('The VPDB `game` API', () => {
 			expect(res.data.length).to.be.above(0);
 			expect(res.data.find(g => g.id === game.id)).to.be.ok();
 		});
+
+		it('should list pending releases when "show_mine_only" is set');
+
 	});
 
 	describe('when listing original games', () => {

--- a/src/app/games/game.api.ts
+++ b/src/app/games/game.api.ts
@@ -372,6 +372,7 @@ export class GameApi extends Api {
 		}
 
 		const sort = this.sortParams(ctx, { title: 1 }, {
+			created_at: '-created_at',
 			popularity: '-metrics.popularity',
 			rating: '-rating.score',
 			title: 'title_sortable',

--- a/src/app/games/game.api.ts
+++ b/src/app/games/game.api.ts
@@ -173,6 +173,12 @@ export class GameApi extends Api {
 		if (!game) {
 			throw new ApiError('No such game with ID "%s".', ctx.params.id).status(404);
 		}
+
+		// validate permission
+		if (!game._created_by.equals(ctx.state.user._id) && !(await acl.isAllowed(ctx.state.user.id, 'games', 'update'))) {
+			throw new ApiError('You can only update games you have added yourself.').status(403);
+		}
+
 		const oldGame = cloneDeep(game) as GameDocument;
 
 		// fail if invalid fields provided

--- a/src/app/games/game.api.ts
+++ b/src/app/games/game.api.ts
@@ -360,11 +360,16 @@ export class GameApi extends Api {
 			}
 		}
 
-		// don't show original games without attached release
-		query.push({ $or: [
-			{ game_type: { $ne: 'og'} },
-			{ 'counter.releases': { $gte: 1 } },
-		]});
+		if (ctx.query.show_mine_only && ctx.state.user) {
+			query.push({ _created_by: ctx.state.user._id });
+
+		} else {
+			// don't show original games without attached release
+			query.push({ $or: [
+				{ game_type: { $ne: 'og'} },
+				{ 'counter.releases': { $gte: 1 } },
+			]});
+		}
 
 		const sort = this.sortParams(ctx, { title: 1 }, {
 			popularity: '-metrics.popularity',

--- a/src/app/games/game.api.ts
+++ b/src/app/games/game.api.ts
@@ -354,6 +354,12 @@ export class GameApi extends Api {
 			}
 		}
 
+		// don't show original games without attached release
+		query.push({ $or: [
+			{ game_type: { $ne: 'og'} },
+			{ 'counter.releases': { $gte: 1 } },
+		]});
+
 		const sort = this.sortParams(ctx, { title: 1 }, {
 			popularity: '-metrics.popularity',
 			rating: '-rating.score',

--- a/src/app/games/game.api.ts
+++ b/src/app/games/game.api.ts
@@ -74,6 +74,11 @@ export class GameApi extends Api {
 	 */
 	public async create(ctx: Context) {
 
+		// validate permission
+		if (ctx.request.body.game_type !== 'og' && !(await acl.isAllowed(ctx.state.user.id, 'games', 'add'))) {
+			throw new ApiError('As a member you can only create original games').status(403);
+		}
+
 		const game = await state.models.Game.getInstance(ctx.state, assign(ctx.request.body, {
 			_created_by: ctx.state.user._id,
 			created_at: new Date(),

--- a/src/app/games/game.api.ts
+++ b/src/app/games/game.api.ts
@@ -76,7 +76,7 @@ export class GameApi extends Api {
 
 		// validate permission
 		if (ctx.request.body.game_type !== 'og' && !(await acl.isAllowed(ctx.state.user.id, 'games', 'add'))) {
-			throw new ApiError('As a member you can only create original games').status(403);
+			throw new ApiError('Your role can only create original games').status(403);
 		}
 
 		const game = await state.models.Game.getInstance(ctx.state, assign(ctx.request.body, {

--- a/src/app/games/game.serializer.ts
+++ b/src/app/games/game.serializer.ts
@@ -59,6 +59,8 @@ export class GameSerializer extends Serializer<GameDocument> {
 		game.game_type = doc.game_type;
 		game.counter = doc.counter;
 		game.rating = doc.rating;
+		game.description = doc.description;
+		game.instructions = doc.instructions;
 
 		// restrictions
 		const restrictions: GameRestrictions = {};

--- a/src/app/games/game.serializer.ts
+++ b/src/app/games/game.serializer.ts
@@ -59,8 +59,7 @@ export class GameSerializer extends Serializer<GameDocument> {
 		game.game_type = doc.game_type;
 		game.counter = doc.counter;
 		game.rating = doc.rating;
-		game.description = doc.description;
-		game.instructions = doc.instructions;
+		game.created_at = doc.created_at;
 
 		// restrictions
 		const restrictions: GameRestrictions = {};
@@ -97,7 +96,7 @@ export class GameSerializer extends Serializer<GameDocument> {
 
 	protected _detailed(ctx: Context, doc: GameDocument, opts: SerializerOptions): GameDocument {
 		const game = Object.assign({}, this._simple(ctx, doc, opts), pick(doc,
-			[ 'created_at', 'designers', 'features', 'keywords', 'metrics', 'notes', 'pinside', 'short', 'themes']));
+			[ 'created_at', 'designers', 'features', 'keywords', 'metrics', 'notes', 'pinside', 'short', 'themes', 'description', 'instructions']));
 		game.owner = ipdb.owners[doc.ipdb.mfg] || doc.manufacturer;
 		return game;
 	}

--- a/src/app/releases/release.api.ts
+++ b/src/app/releases/release.api.ts
@@ -244,7 +244,16 @@ export class ReleaseApi extends ReleaseAbstractApi {
 			}
 
 			// moderation && restricted games
-			let query = await state.models.Release.applyRestrictions(ctx, await state.models.Release.handleModerationQuery(ctx, []));
+			let query;
+			if (ctx.query.show_mine_only && ctx.state.user) {
+				// if logged and show_mine_only requested, don't filter by restrictions or moderation query but return all owned
+				query = [ { $or: [
+					{ _created_by: ctx.state.user._id },
+					{ 'authors._user': ctx.state.user._id },
+				] } ];
+			} else {
+				query = await state.models.Release.applyRestrictions(ctx, await state.models.Release.handleModerationQuery(ctx, []));
+			}
 
 			// filters
 			const qb = new ReleaseListQueryBuilder();

--- a/src/app/releases/release.api.ts
+++ b/src/app/releases/release.api.ts
@@ -230,7 +230,9 @@ export class ReleaseApi extends ReleaseAbstractApi {
 			const serializerOpts = this.parseQueryThumbOptions(ctx);
 
 			if (fields.includes('moderation')) {
-				await state.models.Release.assertModerationField(ctx);
+				if (!ctx.query.show_mine_only) {
+					await state.models.Release.assertModerationField(ctx);
+				}
 				serializerOpts.includedFields = ['moderation'];
 			}
 

--- a/src/test/game.helper.js
+++ b/src/test/game.helper.js
@@ -48,8 +48,36 @@ class GameHelper {
 		const backglass = await this.fileHelper.createBackglass(user, { keep: true });
 		const res = await this.api
 			.as(user)
-			.markTeardown()
+			.markRootTeardown()
 			.post('/v1/games', assign(this.getGame({ _backglass: backglass.id }), game))
+			.then(res => res.expectStatus(201));
+		return res.data;
+	}
+
+	/**
+	 * Creates a new original game. Automatically marks game for deletion after test.
+	 * @param user
+	 * @param game
+	 * @returns {Promise<Object>}
+	 */
+	async createOriginalGame(user, game) {
+		const backglass = await this.fileHelper.createBackglass(user, { keep: true });
+		const generatedGame = this.getGame({ _backglass: backglass.id });
+		generatedGame.game_type = 'og';
+		delete generatedGame.ipdb;
+		delete generatedGame.themes;
+		delete generatedGame.designers;
+		delete generatedGame.artists;
+		delete generatedGame.features;
+		delete generatedGame.notes;
+		delete generatedGame.model_number;
+		delete generatedGame.toys;
+		delete generatedGame.slogans;
+		delete generatedGame.produced_units;
+		const res = await this.api
+			.as(user)
+			.markRootTeardown()
+			.post('/v1/games', assign(generatedGame, game))
 			.then(res => res.expectStatus(201));
 		return res.data;
 	}

--- a/src/test/legacy/release-helper.js
+++ b/src/test/legacy/release-helper.js
@@ -33,7 +33,7 @@ exports.createReleaseForGame = function(user, request, game, opts, done) {
 							version: opts.version || '1.0.0'
 						}
 					],
-					authors: [ { _user: hlp.getUser(user).id, roles: [ 'Table Creator' ] } ]
+					authors: [ { _user: hlp.getUser(opts.author || user).id, roles: [ 'Table Creator' ] } ]
 				})
 				.end(function (err, res) {
 					hlp.doomRelease(user, res.body.id);


### PR DESCRIPTION
While the data structure and API for original games were already available, there were still a few tweaks needed:

- Return `description` and `instructions` of the game in the game payload
- Give members (not only contributors) the permission to create original games (and edit them)
- Don't list empty original games until they get an attached release
- Some cache changes were needed, because now adding a release now changes the actual game list, not only the counters (see previous point)

Additionally, users can now list games and releases they have created, even if they don't publicly show up due to emulation type restrictions or missing moderation approval.

Finally, the game test suite was refactored to use the new async toolset.