### PR TITLE
Add deleted status to moderation

### DIFF
--- a/src/app/common/mongoose/moderation.serializer.ts
+++ b/src/app/common/mongoose/moderation.serializer.ts
@@ -52,7 +52,7 @@ export class ModerationSerializer extends Serializer<ModerationData> {
 		}
 		// if user is populated that means we should populate the history, otherwise only status is returned
 		const includeHistory = isArray(doc.history) && doc.history[0] && this._populated(doc.history[0], '_created_by');
-		const moderationData: ModerationData = pick(doc, ['is_approved', 'is_refused', 'auto_approved']) as ModerationData;
+		const moderationData: ModerationData = pick(doc, ['is_approved', 'is_refused', 'is_deleted', 'auto_approved']) as ModerationData;
 		if (includeHistory) {
 			moderationData.history = doc.history.map(h => {
 				return {

--- a/src/app/common/mongoose/moderation.spec.js
+++ b/src/app/common/mongoose/moderation.spec.js
@@ -26,7 +26,7 @@ const ApiClient = require('../../../test/api.client');
 const api = new ApiClient();
 
 let res;
-describe.only('The VPDB moderation feature', () => {
+describe('The VPDB moderation feature', () => {
 
 	let game, backglass, release;
 

--- a/src/app/games/game.api.cache.spec.js
+++ b/src/app/games/game.api.cache.spec.js
@@ -328,7 +328,7 @@ describe('The game cache', () => {
 
 			// create release and cache list
 			const release = await api.releaseHelper.createRelease('moderator');
-			res = await api.get('/v1/games').then(res => res.expectHeader('x-cache-api', 'miss'));
+			res = await api.get('/v1/games?per_page=100').then(res => res.expectHeader('x-cache-api', 'miss'));
 			const numDownloads = res.data.find(g => g.id === release.game.id).counter.downloads;
 
 			// download release
@@ -339,7 +339,7 @@ describe('The game cache', () => {
 				.then(res => res.expectStatus(200));
 
 			// it's a hit but counter is updated
-			res = await api.get('/v1/games').then(res => res.expectHeader('x-cache-api', 'hit'));
+			res = await api.get('/v1/games?per_page=100').then(res => res.expectHeader('x-cache-api', 'hit'));
 			expect(res.data.find(g => g.id === release.game.id).counter.downloads).to.be(numDownloads + 1);
 		});
 


### PR DESCRIPTION
Hide moderated entities in case something went wrong during submission, without the need to reject. 

### Todo
- [x] Add tests for undelete

Closes #229.