### PR TITLE
Add password reset

### DIFF
--- a/config/settings.browserstack.js
+++ b/config/settings.browserstack.js
@@ -18,7 +18,8 @@ module.exports = {
 		apiTokenLifetime: 3600000,
 		storageTokenLifetime: 60000,
 		secret: 'do-not-run-this-config-in-production!',
-		loginBackoff: { delay: [ 0 ], keep: 0 },
+		loginBackoff: { delay: [ 0 ], keep: 0, key: 'auth', errorCode: 'too_many_failed_logins' },
+		passwordResetBackoff: { delay: [ 0 ], keep: 0, key: 'reset', errorCode: 'too_many_failed_password_resets' },
 		email: {
 			confirmUserEmail: false,
 			sender: { email: 'server@vpdb.local', name: 'VPDB Server' },

--- a/config/settings.dist.js
+++ b/config/settings.dist.js
@@ -129,7 +129,25 @@ module.exports = {
 			 *
 			 * If set to 0, it will only block until the next successful login.
 			 */
-			keep: 3600 * 24
+			keep: 3600 * 24,
+
+			/**
+			 * This is what makes this backoff config independent from others,
+			 * it's the prefix for the Redis keys.
+			 */
+			key: 'auth',
+
+			/**
+			 * The error code in case of denial.
+			 */
+			errorCode: 'too_many_failed_logins'
+		},
+
+		passwordResetBackoff: {
+			delay: [ 0, 0, 0, 0, 0, 5, 10, 15, 20, 30, 60, 120, 180, 300 ],
+			keep: 3600 * 24,
+			key: 'reset',
+			errorCode: 'too_many_failed_password_resets'
 		},
 
 		/**

--- a/config/settings.protractor.js
+++ b/config/settings.protractor.js
@@ -18,7 +18,8 @@ module.exports = {
 		apiTokenLifetime: 3600000,
 		storageTokenLifetime: 60000,
 		secret: 'do-not-run-this-config-in-production!',
-		loginBackoff: { delay: [ 0 ], keep: 0 },
+		loginBackoff: { delay: [ 0 ], keep: 0, key: 'auth', errorCode: 'too_many_failed_logins' },
+		passwordResetBackoff: { delay: [ 0 ], keep: 0, key: 'reset', errorCode: 'too_many_failed_password_resets' },
 		email: {
 			confirmUserEmail: false,
 			sender: { email: 'server@vpdb.local', name: 'VPDB Server' },

--- a/config/settings.test.js
+++ b/config/settings.test.js
@@ -29,7 +29,8 @@ module.exports = {
 		apiTokenLifetime: 3600000,
 		storageTokenLifetime: 60000,
 		secret: 'do-not-run-this-config-in-production!',
-		loginBackoff: { delay: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 ], keep: 0 },
+		loginBackoff: { delay: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 5 ], keep: 0, key: 'auth', errorCode: 'too_many_failed_logins' },
+		passwordResetBackoff: { delay: [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 5 ], keep: 0, key: 'reset', errorCode: 'too_many_failed_password_resets' },
 		email: {
 			confirmUserEmail: true,
 			sender: { email: 'server@vpdb.local', name: 'VPDB Server' },

--- a/src/app/authentication/authentication.api.ts
+++ b/src/app/authentication/authentication.api.ts
@@ -49,7 +49,7 @@ export class AuthenticationApi extends Api {
 		try {
 
 			// this resource is lock-protected
-			await this.ipLockAssert(ctx);
+			await this.ipLockAssert(ctx, config.vpdb.loginBackoff);
 
 			// try to authenticate locally
 			const localUser = await this.authenticateLocally(ctx);
@@ -73,10 +73,10 @@ export class AuthenticationApi extends Api {
 			await this.authenticateUser(ctx, authenticatedUser, how);
 
 			// potentially unlock ip block
-			await this.ipLockOnSuccess(ctx);
+			await this.ipLockOnSuccess(ctx, config.vpdb.loginBackoff);
 
 		} catch (err) {
-			await this.ipLockOnFail(ctx, err);
+			await this.ipLockOnFail(ctx, config.vpdb.loginBackoff, err);
 		}
 	}
 

--- a/src/app/comments/comment.api.spec.js
+++ b/src/app/comments/comment.api.spec.js
@@ -64,25 +64,25 @@ describe('The VPDB `Comment` API', () => {
 			await api
 				.as('member')
 				.post('/v1/releases/' + restrictedRelease.id + '/comments', { message: '123' })
-				.then(res => res.expectError(404, 'no such release'));
+				.then(res => res.expectError(404, 'is restricted'));
 
 			// as author
 			await api
 				.as('author')
 				.post('/v1/releases/' + restrictedRelease.id + '/comments', { message: '123' })
-				.then(res => res.expectError(404, 'no such release'));
+				.then(res => res.expectError(404, 'is restricted'));
 
 			// as uploader
 			await api
 				.as('contributor')
 				.post('/v1/releases/' + restrictedRelease.id + '/comments', { message: '123' })
-				.then(res => res.expectError(404, 'no such release'));
+				.then(res => res.expectError(404, 'is restricted'));
 
 			// as moderator
 			await api
 				.as('moderator')
 				.post('/v1/releases/' + restrictedRelease.id + '/comments', { message: '123' })
-				.then(res => res.expectError(404, 'no such release'));
+				.then(res => res.expectError(404, 'is restricted'));
 		});
 
 		it('should fail when posting an empty message', async () => {

--- a/src/app/comments/comment.api.ts
+++ b/src/app/comments/comment.api.ts
@@ -57,7 +57,7 @@ export class CommentApi extends Api {
 			}
 			game = release._game as GameDocument;
 			if (game.isRestricted('release')) {
-				throw new ApiError('No such release with ID "%s"', ctx.params.id).status(404);
+				throw new ApiError('Release with ID "%s" is restricted', ctx.params.id).status(404);
 			}
 			let comment = new state.models.Comment({
 				_from: ctx.state.user._id,

--- a/src/app/common/email-templates/email-update-confirmation.handlebars
+++ b/src/app/common/email-templates/email-update-confirmation.handlebars
@@ -4,7 +4,7 @@ Looks like you were changing your email address at VPDB. Please let us know that
 
     {{{ confirmationUrl }}}
 
-Once you have done that, you'll get all email to this new address.
+Once you have done that, you’ll get all email to this new address.
 
 Have a nice day!
 

--- a/src/app/common/email-templates/password-reset-request.handlebars
+++ b/src/app/common/email-templates/password-reset-request.handlebars
@@ -1,0 +1,11 @@
+Hi {{{ user.name }}},
+
+Someone, probably you, requested to reset your password at VPDB. You can do that by clicking on the link below.
+
+    {{{ confirmationUrl }}}
+
+If it wasn’t you, you can ignore this email.
+
+Have a nice day!
+
+    -The VPDB Server.

--- a/src/app/common/email-templates/password-reset-success.handlebars
+++ b/src/app/common/email-templates/password-reset-success.handlebars
@@ -1,0 +1,7 @@
+Hi {{{ user.name }}},
+
+Just writing you to let you know that your password at VPDB has been successfully reset.
+
+Cheers!
+
+    -The VPDB Server.

--- a/src/app/common/mailer.ts
+++ b/src/app/common/mailer.ts
@@ -60,6 +60,19 @@ class Mailer {
 		});
 	}
 
+	public async resetPasswordRequest(requestState: RequestState, user: UserDocument, email: string, token: string): Promise<SentMessageInfo> {
+		return this.sendEmail(requestState, user, 'Password reset at VPDB', 'password-reset-request', {
+			user,
+			confirmationUrl: settings.webUri('/reset-password/' + token),
+		}, undefined, email);
+	}
+
+	public async resetPasswordSuccess(requestState: RequestState, user: UserDocument): Promise<SentMessageInfo> {
+		return this.sendEmail(requestState, user, 'Your password has been reset', 'password-reset-success', {
+			user,
+		});
+	}
+
 	public async welcomeLocal(requestState: RequestState, user: UserDocument): Promise<SentMessageInfo> {
 		return this.sendEmail(requestState, user, 'Welcome to VPDB!', 'welcome-local', { user });
 	}
@@ -355,9 +368,10 @@ class Mailer {
 	 * @param {string} template Name of the Handlebars template, without path or extension
 	 * @param {object} templateData Data passed to the Handlebars renderer
 	 * @param {string} [enabledFlag] If set, user profile must have this preference set to true
+	 * @param {string} [emailAddress] If set, this email as the recipient's email instead of the user's default.
 	 * @return Promise<SentMessageInfo>
 	 */
-	private async sendEmail(requestState: RequestState, user: UserDocument, subject: string, template: string, templateData: object, enabledFlag: string = null): Promise<SentMessageInfo> {
+	private async sendEmail(requestState: RequestState, user: UserDocument, subject: string, template: string, templateData: object, enabledFlag?: string, emailAddress?: string): Promise<SentMessageInfo> {
 
 		const what = template.replace(/-/g, ' ');
 		if (!this.emailEnabled(user, enabledFlag)) {
@@ -372,7 +386,7 @@ class Mailer {
 		// setup email
 		const email: Mail.Options = {
 			from: { name: config.vpdb.email.sender.name, address: config.vpdb.email.sender.email },
-			to: { name: user.name, address: user.email },
+			to: { name: user.name, address: emailAddress || user.email },
 			subject,
 			text,
 		};

--- a/src/app/common/slackbot.ts
+++ b/src/app/common/slackbot.ts
@@ -383,7 +383,7 @@ export class SlackBot {
 				username: botName,
 				icon_url: 'https://github.com/vpdb/website/raw/master/src/static/favicon/android-chrome-256x256.png',
 				mrkdwn: true,
-				text: message
+				text: message,
 			});
 		} catch (err) {
 			logger.error(err, 'Error sending raw message to slack.');

--- a/src/app/common/slackbot.ts
+++ b/src/app/common/slackbot.ts
@@ -327,6 +327,12 @@ export class SlackBot {
 			case 'change_password':
 				msg.msg = 'Changed password.';
 				break;
+			case 'reset_password':
+				msg.msg = 'Reset password.';
+				break;
+			case 'request_reset_password':
+				msg.msg = 'Requested password to be reset.';
+				break;
 			case 'create_local_account':
 				msg.msg = 'Added local credentials.';
 				break;

--- a/src/app/common/typings/config.d.ts
+++ b/src/app/common/typings/config.d.ts
@@ -132,28 +132,13 @@ export interface VpdbConfig {
 		 * When the user fails to login with user/pass or token, block logins for
 		 * the IP address.
 		 */
-		loginBackoff: {
+		loginBackoff: VpdbBackoffConfig,
 
-			/**
-			 * How long the IP address is blocked. Index in array is number of
-			 * seconds to wait for the nth time. If n > array length, the last
-			 * delay is applied.
-			 */
-			delay: number[],
-
-			/**
-			 * Keep counter during this time in seconds. That means that once
-			 * the user fails to login, the counter will continue to increase
-			 * during that time even if a successful login occurs.
-			 *
-			 * The goal of this is to avoid an attacker being able to create an
-			 * account, brute-force a few entries, reset backoff time by
-			 * logging in, and repeat.
-			 *
-			 * This screws up the tests however, so we here we can disable it.
-			 */
-			keep: number,
-		},
+		/**
+		 * When the user fails to reset or request to reset the password, block
+		 * logins for the IP address
+		 */
+		passwordResetBackoff: VpdbBackoffConfig,
 
 		/**
 		 * Various mail settings.
@@ -568,4 +553,38 @@ export interface VpdbPlanCategoryCost {
 	table: number;
 	'*': number;
 	[key: string]: number;
+}
+
+export interface VpdbBackoffConfig {
+
+	/**
+	 * This is what makes this backoff config independent from others,
+	 * it's the prefix for the Redis keys.
+	 */
+	key: string;
+
+	/**
+	 * The error code in case of denial.
+	 */
+	errorCode: string;
+
+	/**
+	 * How long the IP address is blocked. Index in array is number of
+	 * seconds to wait for the nth time. If n > array length, the last
+	 * delay is applied.
+	 */
+	delay: number[];
+
+	/**
+	 * Keep counter during this time in seconds. That means that once
+	 * the user fails to login, the counter will continue to increase
+	 * during that time even if a successful login occurs.
+	 *
+	 * The goal of this is to avoid an attacker being able to create an
+	 * account, brute-force a few entries, reset backoff time by
+	 * logging in, and repeat.
+	 *
+	 * This screws up the tests however, so we here we can disable it.
+	 */
+	keep: number;
 }

--- a/src/app/games/game.restrictions.spec.js
+++ b/src/app/games/game.restrictions.spec.js
@@ -157,7 +157,7 @@ describe('The VPDB restriction feature', function() {
 			request.post('/api/v1/releases/' + restrictedRelease.id + '/comments')
 				.as('moderator')
 				.send({ message: msg })
-				.end(hlp.status(404, 'no such release', done));
+				.end(hlp.status(404, 'is restricted', done));
 		});
 
 		it('should fail retrieving release details of a restricted release as anonymous', function(done) {

--- a/src/app/media/medium.api.ts
+++ b/src/app/media/medium.api.ts
@@ -22,11 +22,11 @@ import { Types } from 'mongoose';
 
 import { acl } from '../common/acl';
 import { Api } from '../common/api';
+import { apiCache } from '../common/api.cache';
 import { ApiError } from '../common/api.error';
 import { logger } from '../common/logger';
 import { Context } from '../common/typings/context';
 import { state } from '../state';
-import { apiCache } from '../common/api.cache';
 
 export class MediumApi extends Api {
 

--- a/src/app/profile/profile.api.acl.spec.js
+++ b/src/app/profile/profile.api.acl.spec.js
@@ -55,6 +55,14 @@ describe('The ACLs of the `Profile` API', function() {
 		it('should deny updates of user profile', function(done) {
 			request.patch('/api/v1/profile').send({}).end(hlp.status(401, done));
 		});
+
+		it('should allow password reset requests', function(done) {
+			request.post('/api/v1/profile/request-password-reset').send({}).end(hlp.status(422, done));
+		});
+
+		it('should allow password resets', function(done) {
+			request.post('/api/v1/profile/password-reset').send({}).end(hlp.status(422, done));
+		});
 	});
 
 	describe('for logged clients (role member)', function() {
@@ -65,6 +73,14 @@ describe('The ACLs of the `Profile` API', function() {
 
 		it('should allow access to user logs', function(done) {
 			request.get('/api/v1/profile/logs').as('member').end(hlp.status(200, done));
+		});
+
+		it('should allow password reset requests', function(done) {
+			request.post('/api/v1/profile/request-password-reset').as('member').send({}).end(hlp.status(422, done));
+		});
+
+		it('should allow password resets', function(done) {
+			request.post('/api/v1/profile/password-reset').as('member').send({}).end(hlp.status(422, done));
 		});
 	});
 

--- a/src/app/profile/profile.api.router.ts
+++ b/src/app/profile/profile.api.router.ts
@@ -35,6 +35,8 @@ export class ProfileApiRouter implements ApiRouter {
 		this.router.get('/v1/profile',               api.auth(api.view.bind(api), 'user', 'view', [ Scope.ALL, Scope.COMMUNITY ]));
 		this.router.patch('/v1/profile',             api.auth(api.update.bind(api), 'user', 'update', [ Scope.ALL ]));
 		this.router.get('/v1/profile/confirm/:tkn', api.confirm.bind(api));
+		this.router.post('/v1/profile/request-password-reset', api.requestResetPassword.bind(api));
+		this.router.post('/v1/profile/password-reset',         api.resetPassword.bind(api));
 
 		const logApi = new LogUserApi();
 		this.router.get('/v1/profile/logs',          api.auth(logApi.list.bind(api), 'user', 'view', [ Scope.ALL ]));

--- a/src/app/profile/profile.api.ts
+++ b/src/app/profile/profile.api.ts
@@ -17,7 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-import { assign, pick, uniq, isString } from 'lodash';
+import { assign, isString, pick, uniq } from 'lodash';
 import randomString from 'randomstring';
 
 import { acl } from '../common/acl';
@@ -280,7 +280,7 @@ export class ProfileApi extends Api {
 				password_reset: {
 					token,
 					expires_at: new Date(Date.now() + 86400000), // 1d valid
-				}
+				},
 			} }).exec();
 
 		// log
@@ -293,7 +293,6 @@ export class ProfileApi extends Api {
 			/* istanbul ignore next: Test case is above */
 			this.success(ctx, { message: 'Email sent.' });
 		}
-
 
 		// send password reset mail
 		this.noAwait(async () => {

--- a/src/app/releases/release.api.ts
+++ b/src/app/releases/release.api.ts
@@ -133,6 +133,8 @@ export class ReleaseApi extends ReleaseAbstractApi {
 			} else {
 				await mailer.releaseSubmitted(ctx.state, ctx.state.user, release);
 			}
+
+			// update game modification date
 			await (release._game as GameDocument).update({ modified_at: new Date() });
 		});
 	}

--- a/src/app/users/user.api.ts
+++ b/src/app/users/user.api.ts
@@ -49,7 +49,7 @@ export class UserApi extends Api {
 	public async create(ctx: Context) {
 
 		// blocked ips can't create new users
-		await this.ipLockAssert(ctx);
+		await this.ipLockAssert(ctx, config.vpdb.loginBackoff);
 
 		const postedUser: UserDocument = assignIn<UserDocument>(pick(ctx.request.body, 'username', 'password', 'email'), {
 			is_local: true,

--- a/src/app/users/user.document.d.ts
+++ b/src/app/users/user.document.d.ts
@@ -33,9 +33,12 @@ export interface UserDocument extends MetricsDocument {
 	roles?: string[];
 	_plan?: string;
 	is_local?: boolean;
-	providers?: UserProviders;
 	password_hash?: string;
 	password_salt?: string;
+	password_reset?: {
+		token: string;
+		expires_at: Date;
+	};
 	thumb?: string;
 	location?: string;
 	preferences?: UserPreferences;
@@ -53,7 +56,7 @@ export interface UserDocument extends MetricsDocument {
 		subscribed_releases: string[];
 		api_key: string;
 	};
-
+	providers?: UserProviders;
 	provider?: string;
 	provider_id?: string;
 	gravatar_id?: string;
@@ -98,6 +101,11 @@ export interface UserDocument extends MetricsDocument {
 	 * @return {boolean} True if at least one role matches, false otherwise.
 	 */
 	hasRole?(role: string | string[]): boolean;
+
+	/**
+	 * Returns the names of the OAuth provider the user has logged in.
+	 */
+	getProviderNames?(): string[];
 }
 
 export interface UserPreferences extends Document {

--- a/src/app/users/user.schema.ts
+++ b/src/app/users/user.schema.ts
@@ -364,7 +364,7 @@ userSchema.methods.getProviderNames = function(): string[] {
 			default:
 				const ips = config.vpdb.passport.ipboard.find(i => i.id === providerId);
 				if (ips) {
-					names.push(ips.name)
+					names.push(ips.name);
 				}
 				break;
 		}

--- a/src/scripts/check-db.ts
+++ b/src/scripts/check-db.ts
@@ -21,8 +21,8 @@ import mongoose from 'mongoose';
 import { endPoints } from '../app/common/api.endpoints';
 import { logger } from '../app/common/logger';
 import { config } from '../app/common/settings';
-import { state } from '../app/state';
 import { slackbot } from '../app/common/slackbot';
+import { state } from '../app/state';
 
 const slackEnabled = false;
 
@@ -148,9 +148,9 @@ async function checkDatabase(ignoreLogEvents = true): Promise<string[]> {
 
 	// log user
 	const logUser = await state.models.LogUser.find({}).exec();
-	for (const log of logUser) {
-		messages.push(...assert('LogEvent', log._id, '_actor', log._actor, await state.models.User.findById(log._actor).exec()));
-		messages.push(...assert('LogEvent', log._id, '_user', log._user, await state.models.User.findById(log._user).exec()));
+	for (const l of logUser) {
+		messages.push(...assert('LogEvent', l._id, '_actor', l._actor, await state.models.User.findById(l._actor).exec()));
+		messages.push(...assert('LogEvent', l._id, '_user', l._user, await state.models.User.findById(l._user).exec()));
 	}
 
 	// media
@@ -293,12 +293,12 @@ function assert(parentModel: string, parentId: any, refField: string, refId: any
 	} else if (refId && !refResult) {
 		const message = `*[${parentModel}]* Document \`${parentId.toString()}\` is missing reference \`${refId.toString()}\` of field \`${refField}\`.`;
 		log(message);
-		return [message]
+		return [message];
 	}
 	return [];
 }
 
-function assertOneOrMore(parentModel: string, parentId: any, fields: { refField: string, refId: any }[], message = 'one or more references'): string[] {
+function assertOneOrMore(parentModel: string, parentId: any, fields: Array<{ refField: string, refId: any }>, message = 'one or more references'): string[] {
 	const populatedFields = fields.filter(f => !!f.refId);
 	if (populatedFields.length === 0) {
 		const warn = `*[${parentModel}]* Document \`${parentId.toString()}\` must have ${message} within [ \`${fields.map(f => f.refField).join('`, `')}\` ] but none found.`;
@@ -308,7 +308,7 @@ function assertOneOrMore(parentModel: string, parentId: any, fields: { refField:
 	return [];
 }
 
-function assertOne(parentModel: string, parentId: any, fields: { refField: string, refId: any }[]) {
+function assertOne(parentModel: string, parentId: any, fields: Array<{ refField: string, refId: any }>) {
 	const populatedFields = fields.filter(f => !!f.refId);
 	const warn = assertOneOrMore(parentModel, parentId, fields, 'exactly one reference');
 	if (warn.length === 0 && populatedFields.length > 1) {


### PR DESCRIPTION
This adds an API to reset a user's password. It works like that:

1. The user requests a password reset for a given email
2. An email is sent with a link to reset
3. The link contains a token, with which the user can set a new password

### Notes
- The API returns if the email is unknown (no "*If* we found your email, we've sent you one" message)
- If the email is registered with an OAuth account that doesn't have a password, the name of the OAuth provider is returned.
- The token is valid for 24 hours.
- There is no "forgot email" link. The email has to be known.

### Todo
- [x] Rate limit the reset and request endpoint

This PR closes #264.