### PR TITLE
Fix/download counter inconsistency

### DIFF
--- a/src/app/common/mongoose/metrics.plugin.ts
+++ b/src/app/common/mongoose/metrics.plugin.ts
@@ -282,12 +282,6 @@ declare module 'mongoose' {
 		 * @see getParentModel()
 		 */
 		getParentId(): string;
-
-		/**
-		 * Returns the id of the top-most parent that has its own collection.
-		 */
-		//getParentId(): string;
-
 	}
 
 	// statics

--- a/src/app/releases/release.api.spec.js
+++ b/src/app/releases/release.api.spec.js
@@ -530,7 +530,9 @@ describe('The VPDB `Release` API', () => {
 
 			res = await api.get(`/v1/releases/${release.id}`).then(res => res.expectStatus(200));
 			expect(res.data.versions[0].files[0].counter.downloads).to.be(0);
+			expect(res.data.versions[0].counter.downloads).to.be(0);
 			expect(res.data.versions[1].files[0].counter.downloads).to.be(1);
+			expect(res.data.versions[1].counter.downloads).to.be(1);
 
 			// check cached version while we're at it
 			await api
@@ -543,7 +545,9 @@ describe('The VPDB `Release` API', () => {
 				.then(res => res.expectStatus(200));
 			res = await api.get(`/v1/releases/${release.id}`).then(res => res.expectHeader('x-cache-api', 'hit').expectStatus(200));
 			expect(res.data.versions[0].files[0].counter.downloads).to.be(0);
+			expect(res.data.versions[0].counter.downloads).to.be(0);
 			expect(res.data.versions[1].files[0].counter.downloads).to.be(2);
+			expect(res.data.versions[1].counter.downloads).to.be(2);
 
 		});
 

--- a/src/app/releases/release.storage.spec.js
+++ b/src/app/releases/release.storage.spec.js
@@ -238,7 +238,7 @@ describe('The VPDB `Release` storage API', () => {
 				.as('creator')
 				.withQuery(({ body: JSON.stringify(body) }))
 				.withHeader('Accept', 'application/zip')
-				.responseAs('arraybuffer')
+				.responseAsBuffer()
 				.get('/v1/releases/' + release.id)
 				.then(res => res.expectStatus(200));
 

--- a/src/app/releases/release.ts
+++ b/src/app/releases/release.ts
@@ -100,7 +100,7 @@ export class Release {
 	public static getLinkedFiles(release: ReleaseDocument | ReleaseDocument[]): FileDocument[] {
 		let files: FileDocument[] = [];
 		if (isArray(release)) {
-			[files] = release.map(Release.getLinkedFiles);
+			files = flatten(release.map(Release.getLinkedFiles));
 			return files || [];
 		}
 		if (release.versions && release.versions.length > 0) {
@@ -123,16 +123,16 @@ export class Release {
 	public static getLinkedReleaseFiles(release: ReleaseDocument | ReleaseDocument[]): ReleaseVersionFileDocument[] {
 		let releaseVersionFiles: ReleaseVersionFileDocument[] = [];
 		if (isArray(release)) {
-			[ releaseVersionFiles ] = release.map(Release.getLinkedReleaseFiles);
+			releaseVersionFiles = flatten(release.map(Release.getLinkedReleaseFiles));
 			return releaseVersionFiles || [];
 		}
 		if (release.versions && release.versions.length > 0) {
-			[releaseVersionFiles] = release.versions.map(v => {
+			releaseVersionFiles = flatten(release.versions.map(v => {
 				if (v.files && v.files.length > 0) {
 					return v.files;
 				}
 				return [];
-			});
+			}));
 		}
 		return releaseVersionFiles.filter(f => !!f && f.file);
 	}


### PR DESCRIPTION
Updating download counters of releases with multiple files and versions resulted in database incoherence. This PR uses [array filters](https://docs.mongodb.com/manual/reference/method/Bulk.find.arrayFilters/) to explicitly match an embedded document.