### PR TITLE
Add types to ROM files

### DIFF
--- a/data/rom-types.json
+++ b/data/rom-types.json
@@ -1,0 +1,43126 @@
+{
+  "cv_10": {
+    "g11_100.rom": {
+      "filename": "g11_100.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "s6v0_4.rom": {
+      "filename": "s6v0_4.rom",
+      "type": "sound"
+    },
+    "s2v1_0.rom": {
+      "filename": "s2v1_0.rom",
+      "type": "sound"
+    },
+    "s5v0_4.rom": {
+      "filename": "s5v0_4.rom",
+      "type": "sound"
+    },
+    "s3v0_4.rom": {
+      "filename": "s3v0_4.rom",
+      "type": "sound"
+    },
+    "s4v0_4.rom": {
+      "filename": "s4v0_4.rom",
+      "type": "sound"
+    }
+  },
+  "bk2k_pa5": {
+    "bk2k_u26.pa5": {
+      "filename": "bk2k_u26.pa5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u27.pa5": {
+      "filename": "bk2k_u27.pa5",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "flashgda": {
+    "7526fn.u6": {
+      "filename": "7526fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-23_2.732": {
+      "filename": "834-23_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-20_2.532": {
+      "filename": "834-20_2.532",
+      "type": "sound"
+    },
+    "834-18_5.532": {
+      "filename": "834-18_5.532",
+      "type": "sound"
+    }
+  },
+  "flashgfa": {
+    "7526fn.u6": {
+      "filename": "7526fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-23_2.732": {
+      "filename": "834-23_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-36_5.532": {
+      "filename": "834-36_5.532",
+      "type": "sound"
+    },
+    "834-35_2.532": {
+      "filename": "834-35_2.532",
+      "type": "sound"
+    }
+  },
+  "flashgva": {
+    "7526fn.u6": {
+      "filename": "7526fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-23_2.732": {
+      "filename": "834-23_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-09_7.532": {
+      "filename": "834-09_7.532",
+      "type": "sound"
+    },
+    "834-05_3.532": {
+      "filename": "834-05_3.532",
+      "type": "sound"
+    },
+    "834-07_5.532": {
+      "filename": "834-07_5.532",
+      "type": "sound"
+    },
+    "834-08_6.532": {
+      "filename": "834-08_6.532",
+      "type": "sound"
+    },
+    "834-03_1.532": {
+      "filename": "834-03_1.532",
+      "type": "sound"
+    },
+    "834-06_4.532": {
+      "filename": "834-06_4.532",
+      "type": "sound"
+    },
+    "834-04_2.532": {
+      "filename": "834-04_2.532",
+      "type": "sound"
+    },
+    "834-02_4.532": {
+      "filename": "834-02_4.532",
+      "type": "sound"
+    }
+  },
+  "eballdla": {
+    "7526fn.u6": {
+      "filename": "7526fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-15_2.732": {
+      "filename": "838-15_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-10_5.532": {
+      "filename": "838-10_5.532",
+      "type": "sound"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    }
+  },
+  "embryona": {
+    "7526fn.u6": {
+      "filename": "7526fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "841-06_2.732": {
+      "filename": "841-06_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "841-02_5.532": {
+      "filename": "841-02_5.532",
+      "type": "sound"
+    },
+    "841-01_4.716": {
+      "filename": "841-01_4.716",
+      "type": "sound"
+    }
+  },
+  "fball_ia": {
+    "7526fn.u6": {
+      "filename": "7526fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "839-12_2.732": {
+      "filename": "839-12_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "839-01_2.532": {
+      "filename": "839-01_2.532",
+      "type": "sound"
+    },
+    "839-02_5.532": {
+      "filename": "839-02_5.532",
+      "type": "sound"
+    }
+  },
+  "hexagone": {
+    "hexagone.bin": {
+      "filename": "HEXAGONE.BIN",
+      "type": "main"
+    },
+    "u4_ce.bin": {
+      "filename": "u4_ce.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "435.cpu": {
+      "filename": "435.CPU",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u5_cf.bin": {
+      "filename": "u5_cf.bin",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "dracula": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wildfyre": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "dm_h6b": {
+    "dman_h6b.rom": {
+      "filename": "dman_h6b.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm.2": {
+      "filename": "dm.2",
+      "type": "sound"
+    },
+    "dm.6": {
+      "filename": "dm.6",
+      "type": "sound"
+    },
+    "dm.3": {
+      "filename": "dm.3",
+      "type": "sound"
+    },
+    "dm.9": {
+      "filename": "dm.9",
+      "type": "sound"
+    },
+    "dm.8": {
+      "filename": "dm.8",
+      "type": "sound"
+    },
+    "dm.7": {
+      "filename": "dm.7",
+      "type": "sound"
+    },
+    "dm.5": {
+      "filename": "dm.5",
+      "type": "sound"
+    },
+    "dm.4": {
+      "filename": "dm.4",
+      "type": "sound"
+    }
+  },
+  "pop_la4": {
+    "popsndl2.u2": {
+      "filename": "popsndl2.u2",
+      "type": "sound"
+    },
+    "peye_la4.rom": {
+      "filename": "peye_la4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "popsndl2.u5": {
+      "filename": "popsndl2.u5",
+      "type": "sound"
+    },
+    "popsndl2.u6": {
+      "filename": "popsndl2.u6",
+      "type": "sound"
+    },
+    "popsndl2.u3": {
+      "filename": "popsndl2.u3",
+      "type": "sound"
+    },
+    "popsndl2.u4": {
+      "filename": "popsndl2.u4",
+      "type": "sound"
+    },
+    "popsndl2.u7": {
+      "filename": "popsndl2.u7",
+      "type": "sound"
+    }
+  },
+  "pop_lx5": {
+    "popsndl2.u2": {
+      "filename": "popsndl2.u2",
+      "type": "sound"
+    },
+    "popsndl2.u5": {
+      "filename": "popsndl2.u5",
+      "type": "sound"
+    },
+    "popsndl2.u6": {
+      "filename": "popsndl2.u6",
+      "type": "sound"
+    },
+    "popsndl2.u3": {
+      "filename": "popsndl2.u3",
+      "type": "sound"
+    },
+    "popsndl2.u4": {
+      "filename": "popsndl2.u4",
+      "type": "sound"
+    },
+    "popsndl2.u7": {
+      "filename": "popsndl2.u7",
+      "type": "sound"
+    },
+    "peye_lx5.rom": {
+      "filename": "peye_lx5.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "punk": {
+    "674-s2.snd": {
+      "filename": "674-s2.snd",
+      "type": "sound"
+    },
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "674.cpu": {
+      "filename": "674.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "674-s1.snd": {
+      "filename": "674-s1.snd",
+      "type": "sound"
+    }
+  },
+  "mcastffp": {
+    "mgic_fr.1e": {
+      "filename": "mgic_fr.1e",
+      "type": "sound"
+    },
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mgic_fr.1g": {
+      "filename": "mgic_fr.1g",
+      "type": "sound"
+    },
+    "mgic_fr.1d": {
+      "filename": "mgic_fr.1d",
+      "type": "sound"
+    },
+    "mcastfp.ic1": {
+      "filename": "mcastfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "mcastlef": {
+    "mgic_fr.1e": {
+      "filename": "mgic_fr.1e",
+      "type": "sound"
+    },
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mgic_fr.1g": {
+      "filename": "mgic_fr.1g",
+      "type": "sound"
+    },
+    "cpu.ic1": {
+      "filename": "cpu.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mgic_fr.1d": {
+      "filename": "mgic_fr.1d",
+      "type": "sound"
+    }
+  },
+  "jack2opn": {
+    "687.cpu": {
+      "filename": "687.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "687-s.snd": {
+      "filename": "687-s.snd",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "potc_115af": {
+    "potc0115af.bin": {
+      "filename": "potc0115af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wcup90": {
+    "snd_ic44.rom": {
+      "filename": "snd_ic44.rom",
+      "type": "sound"
+    },
+    "cpu_ic13.rom": {
+      "filename": "cpu_ic13.rom",
+      "type": "dmd"
+    },
+    "snd_ic06.rom": {
+      "filename": "snd_ic06.rom",
+      "type": "sound"
+    },
+    "snd_ic45.rom": {
+      "filename": "snd_ic45.rom",
+      "type": "sound"
+    },
+    "vid_ic91.rom": {
+      "filename": "vid_ic91.rom",
+      "type": "dmd"
+    },
+    "vid_ic15.rom": {
+      "filename": "vid_ic15.rom",
+      "type": "dmd"
+    },
+    "vid_ic61.rom": {
+      "filename": "vid_ic61.rom",
+      "type": "dmd"
+    },
+    "snd_ic46.rom": {
+      "filename": "snd_ic46.rom",
+      "type": "sound"
+    },
+    "vid_ic18.rom": {
+      "filename": "vid_ic18.rom",
+      "type": "dmd"
+    },
+    "vid_ic14.rom": {
+      "filename": "vid_ic14.rom",
+      "type": "dmd"
+    },
+    "vid_ic16.rom": {
+      "filename": "vid_ic16.rom",
+      "type": "dmd"
+    },
+    "vid_ic17.rom": {
+      "filename": "vid_ic17.rom",
+      "type": "dmd"
+    },
+    "snd_ic21.rom": {
+      "filename": "snd_ic21.rom",
+      "type": "sound"
+    },
+    "cpu_ic14.rom": {
+      "filename": "cpu_ic14.rom",
+      "type": "dmd"
+    }
+  },
+  "mousn_l1": {
+    "mous_u22.l1": {
+      "filename": "mous_u22.l1",
+      "type": "sound"
+    },
+    "u26-la1.rom": {
+      "filename": "u26-la1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "mous_u20.l2": {
+      "filename": "mous_u20.l2",
+      "type": "sound"
+    },
+    "mous_u4.l2": {
+      "filename": "mous_u4.l2",
+      "type": "sound"
+    },
+    "mous_u19.l2": {
+      "filename": "mous_u19.l2",
+      "type": "sound"
+    },
+    "u27-la1.rom": {
+      "filename": "u27-la1.rom",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "mousn_l4": {
+    "mous_u22.l1": {
+      "filename": "mous_u22.l1",
+      "type": "sound"
+    },
+    "mous_u20.l2": {
+      "filename": "mous_u20.l2",
+      "type": "sound"
+    },
+    "mous_u4.l2": {
+      "filename": "mous_u4.l2",
+      "type": "sound"
+    },
+    "mous_u19.l2": {
+      "filename": "mous_u19.l2",
+      "type": "sound"
+    },
+    "mous_u26.l4": {
+      "filename": "mous_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "mous_u27.l4": {
+      "filename": "mous_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "mousn_lu": {
+    "mous_u22.l1": {
+      "filename": "mous_u22.l1",
+      "type": "sound"
+    },
+    "u26-la1.rom": {
+      "filename": "u26-la1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "mous_u20.l2": {
+      "filename": "mous_u20.l2",
+      "type": "sound"
+    },
+    "mous_u4.l2": {
+      "filename": "mous_u4.l2",
+      "type": "sound"
+    },
+    "u27-lu1.rom": {
+      "filename": "u27-lu1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "mous_u19.l2": {
+      "filename": "mous_u19.l2",
+      "type": "sound"
+    }
+  },
+  "mousn_lx": {
+    "mous_u22.l1": {
+      "filename": "mous_u22.l1",
+      "type": "sound"
+    },
+    "mous_u20.l2": {
+      "filename": "mous_u20.l2",
+      "type": "sound"
+    },
+    "mous_u26.l4": {
+      "filename": "mous_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "mous_u19.lx": {
+      "filename": "mous_u19.lx",
+      "type": "sound"
+    },
+    "mous_u4.lx": {
+      "filename": "mous_u4.lx",
+      "type": "sound"
+    },
+    "mous_u27.l4": {
+      "filename": "mous_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "mb_05": {
+    "mb_s4.rom": {
+      "filename": "mb_s4.rom",
+      "type": "sound"
+    },
+    "mb_s6.rom": {
+      "filename": "mb_s6.rom",
+      "type": "sound"
+    },
+    "mb_s2.rom": {
+      "filename": "mb_s2.rom",
+      "type": "sound"
+    },
+    "mb_s7.rom": {
+      "filename": "mb_s7.rom",
+      "type": "sound"
+    },
+    "mb_s3.rom": {
+      "filename": "mb_s3.rom",
+      "type": "sound"
+    },
+    "mb_g11.0_5": {
+      "filename": "mb_g11.0_5",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mb_s5.rom": {
+      "filename": "mb_s5.rom",
+      "type": "sound"
+    }
+  },
+  "mb_10": {
+    "mb_s4.rom": {
+      "filename": "mb_s4.rom",
+      "type": "sound"
+    },
+    "mb_s6.rom": {
+      "filename": "mb_s6.rom",
+      "type": "sound"
+    },
+    "mb_g11.1_0": {
+      "filename": "mb_g11.1_0",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mb_s2.rom": {
+      "filename": "mb_s2.rom",
+      "type": "sound"
+    },
+    "mb_s7.rom": {
+      "filename": "mb_s7.rom",
+      "type": "sound"
+    },
+    "mb_s3.rom": {
+      "filename": "mb_s3.rom",
+      "type": "sound"
+    },
+    "mb_s5.rom": {
+      "filename": "mb_s5.rom",
+      "type": "sound"
+    }
+  },
+  "mb_106": {
+    "mb_s4.rom": {
+      "filename": "mb_s4.rom",
+      "type": "sound"
+    },
+    "mb_1_06.bin": {
+      "filename": "mb_1_06.bin",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mb_s6.rom": {
+      "filename": "mb_s6.rom",
+      "type": "sound"
+    },
+    "mb_s2.rom": {
+      "filename": "mb_s2.rom",
+      "type": "sound"
+    },
+    "mb_s7.rom": {
+      "filename": "mb_s7.rom",
+      "type": "sound"
+    },
+    "mb_s3.rom": {
+      "filename": "mb_s3.rom",
+      "type": "sound"
+    },
+    "mb_s5.rom": {
+      "filename": "mb_s5.rom",
+      "type": "sound"
+    }
+  },
+  "mb_106b": {
+    "mb_s4.rom": {
+      "filename": "mb_s4.rom",
+      "type": "sound"
+    },
+    "mb_s6.rom": {
+      "filename": "mb_s6.rom",
+      "type": "sound"
+    },
+    "mb_s2.rom": {
+      "filename": "mb_s2.rom",
+      "type": "sound"
+    },
+    "mb_s7.rom": {
+      "filename": "mb_s7.rom",
+      "type": "sound"
+    },
+    "mb_s3.rom": {
+      "filename": "mb_s3.rom",
+      "type": "sound"
+    },
+    "mb_106b.bin": {
+      "filename": "mb_106b.bin",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mb_s5.rom": {
+      "filename": "mb_s5.rom",
+      "type": "sound"
+    }
+  },
+  "halley": {
+    "hc_da3": {
+      "filename": "hc_da3",
+      "type": "sound"
+    },
+    "hc_s6": {
+      "filename": "hc_s6",
+      "type": "sound"
+    },
+    "hc_s4": {
+      "filename": "hc_s4",
+      "type": "sound"
+    },
+    "hc_da7": {
+      "filename": "hc_da7",
+      "type": "sound"
+    },
+    "hc_da2": {
+      "filename": "hc_da2",
+      "type": "sound"
+    },
+    "hc_s1": {
+      "filename": "hc_s1",
+      "type": "sound"
+    },
+    "hc_da8": {
+      "filename": "hc_da8",
+      "type": "sound"
+    },
+    "hc_da4": {
+      "filename": "hc_da4",
+      "type": "sound"
+    },
+    "hc_da0": {
+      "filename": "hc_da0",
+      "type": "sound"
+    },
+    "hc_s3": {
+      "filename": "hc_s3",
+      "type": "sound"
+    },
+    "hc_s7": {
+      "filename": "hc_s7",
+      "type": "sound"
+    },
+    "hc_sh": {
+      "filename": "hc_sh",
+      "type": "sound"
+    },
+    "hc_s2": {
+      "filename": "hc_s2",
+      "type": "sound"
+    },
+    "hc_s5": {
+      "filename": "hc_s5",
+      "type": "sound"
+    },
+    "hc_da6": {
+      "filename": "hc_da6",
+      "type": "sound"
+    },
+    "hc_da5": {
+      "filename": "hc_da5",
+      "type": "sound"
+    },
+    "halley.cpu": {
+      "filename": "halley.cpu",
+      "type": "main",
+      "romType": "jp"
+    },
+    "hc_da1": {
+      "filename": "hc_da1",
+      "type": "sound"
+    }
+  },
+  "halleya": {
+    "hc_da3": {
+      "filename": "hc_da3",
+      "type": "sound"
+    },
+    "hc_s6": {
+      "filename": "hc_s6",
+      "type": "sound"
+    },
+    "hc_s4": {
+      "filename": "hc_s4",
+      "type": "sound"
+    },
+    "hc_da7": {
+      "filename": "hc_da7",
+      "type": "sound"
+    },
+    "hc_da2": {
+      "filename": "hc_da2",
+      "type": "sound"
+    },
+    "hc_s1": {
+      "filename": "hc_s1",
+      "type": "sound"
+    },
+    "hc_da8": {
+      "filename": "hc_da8",
+      "type": "sound"
+    },
+    "hc_da4": {
+      "filename": "hc_da4",
+      "type": "sound"
+    },
+    "hc_da0": {
+      "filename": "hc_da0",
+      "type": "sound"
+    },
+    "hc_s3": {
+      "filename": "hc_s3",
+      "type": "sound"
+    },
+    "hc_s7": {
+      "filename": "hc_s7",
+      "type": "sound"
+    },
+    "hc_sh": {
+      "filename": "hc_sh",
+      "type": "sound"
+    },
+    "hc_s2": {
+      "filename": "hc_s2",
+      "type": "sound"
+    },
+    "hc_s5": {
+      "filename": "hc_s5",
+      "type": "sound"
+    },
+    "hc_da6": {
+      "filename": "hc_da6",
+      "type": "sound"
+    },
+    "hc_da5": {
+      "filename": "hc_da5",
+      "type": "sound"
+    },
+    "hc_pgm": {
+      "filename": "hc_pgm",
+      "type": "main",
+      "romType": "jp"
+    },
+    "hc_da1": {
+      "filename": "hc_da1",
+      "type": "sound"
+    }
+  },
+  "pfevr_l2": {
+    "pf-rom1.u19": {
+      "filename": "pf-rom1.u19",
+      "type": "main",
+      "romType": "s9"
+    },
+    "pf-rom2.u20": {
+      "filename": "pf-rom2.u20",
+      "type": "main",
+      "romType": "s9"
+    },
+    "cpu_u49.128": {
+      "filename": "cpu_u49.128",
+      "type": "sound"
+    }
+  },
+  "macgalxy": {
+    "galaxy1.bin": {
+      "filename": "galaxy1.bin",
+      "type": "main"
+    },
+    "galaxy2.bin": {
+      "filename": "galaxy2.bin",
+      "type": "main"
+    }
+  },
+  "stwr_102": {
+    "sw4mrom.a15": {
+      "filename": "sw4mrom.a15",
+      "type": "dmd"
+    },
+    "s-wars.u17": {
+      "filename": "s-wars.u17",
+      "type": "sound"
+    },
+    "s-wars.u21": {
+      "filename": "s-wars.u21",
+      "type": "sound"
+    },
+    "starcpua.102": {
+      "filename": "starcpua.102",
+      "type": "main",
+      "romType": "de"
+    },
+    "s-wars.u7": {
+      "filename": "s-wars.u7",
+      "type": "sound"
+    }
+  },
+  "stwr_103": {
+    "sw4mrom.a15": {
+      "filename": "sw4mrom.a15",
+      "type": "dmd"
+    },
+    "starcpua.103": {
+      "filename": "starcpua.103",
+      "type": "main",
+      "romType": "de"
+    },
+    "s-wars.u17": {
+      "filename": "s-wars.u17",
+      "type": "sound"
+    },
+    "s-wars.u21": {
+      "filename": "s-wars.u21",
+      "type": "sound"
+    },
+    "s-wars.u7": {
+      "filename": "s-wars.u7",
+      "type": "sound"
+    }
+  },
+  "stwr_104": {
+    "sw4mrom.a15": {
+      "filename": "sw4mrom.a15",
+      "type": "dmd"
+    },
+    "starcpua.104": {
+      "filename": "starcpua.104",
+      "type": "main",
+      "romType": "de"
+    },
+    "s-wars.u17": {
+      "filename": "s-wars.u17",
+      "type": "sound"
+    },
+    "s-wars.u21": {
+      "filename": "s-wars.u21",
+      "type": "sound"
+    },
+    "s-wars.u7": {
+      "filename": "s-wars.u7",
+      "type": "sound"
+    }
+  },
+  "stwr_e12": {
+    "sw4mrom.a15": {
+      "filename": "sw4mrom.a15",
+      "type": "dmd"
+    },
+    "s-wars.u17": {
+      "filename": "s-wars.u17",
+      "type": "sound"
+    },
+    "s-wars.u21": {
+      "filename": "s-wars.u21",
+      "type": "sound"
+    },
+    "starcpue.102": {
+      "filename": "starcpue.102",
+      "type": "main",
+      "romType": "de"
+    },
+    "s-wars.u7": {
+      "filename": "s-wars.u7",
+      "type": "sound"
+    }
+  },
+  "lotr": {
+    "lotrcpua.a00": {
+      "filename": "lotrcpua.a00",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspa.a00": {
+      "filename": "lotrdspa.a00",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "ij4_114": {
+    "indy0114a.bin": {
+      "filename": "indy0114a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_140l": {
+    "wpt1400l.bin": {
+      "filename": "wpt1400l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wcs_f10": {
+    "wcup_u6.rom": {
+      "filename": "wcup_u6.rom",
+      "type": "sound"
+    },
+    "wcup_u4.rom": {
+      "filename": "wcup_u4.rom",
+      "type": "sound"
+    },
+    "fwcs0_10.rom": {
+      "filename": "fwcs0_10.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wcup_u8.rom": {
+      "filename": "wcup_u8.rom",
+      "type": "sound"
+    },
+    "wcup_u3.rom": {
+      "filename": "wcup_u3.rom",
+      "type": "sound"
+    },
+    "wcup_u2.rom": {
+      "filename": "wcup_u2.rom",
+      "type": "sound"
+    },
+    "wcup_u5.rom": {
+      "filename": "wcup_u5.rom",
+      "type": "sound"
+    },
+    "wcup_u7.rom": {
+      "filename": "wcup_u7.rom",
+      "type": "sound"
+    }
+  },
+  "wcs_f50": {
+    "wcup_u6.rom": {
+      "filename": "wcup_u6.rom",
+      "type": "sound"
+    },
+    "wcup_u4.rom": {
+      "filename": "wcup_u4.rom",
+      "type": "sound"
+    },
+    "wcup_u8.rom": {
+      "filename": "wcup_u8.rom",
+      "type": "sound"
+    },
+    "wcup_u3.rom": {
+      "filename": "wcup_u3.rom",
+      "type": "sound"
+    },
+    "wcup_u2.rom": {
+      "filename": "wcup_u2.rom",
+      "type": "sound"
+    },
+    "fwcs0_50.rom": {
+      "filename": "fwcs0_50.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wcup_u5.rom": {
+      "filename": "wcup_u5.rom",
+      "type": "sound"
+    },
+    "wcup_u7.rom": {
+      "filename": "wcup_u7.rom",
+      "type": "sound"
+    }
+  },
+  "wcs_f62": {
+    "wcup_u6.rom": {
+      "filename": "wcup_u6.rom",
+      "type": "sound"
+    },
+    "wcup_u4.rom": {
+      "filename": "wcup_u4.rom",
+      "type": "sound"
+    },
+    "wcup_u8.rom": {
+      "filename": "wcup_u8.rom",
+      "type": "sound"
+    },
+    "wcup_u3.rom": {
+      "filename": "wcup_u3.rom",
+      "type": "sound"
+    },
+    "wcup_u2.rom": {
+      "filename": "wcup_u2.rom",
+      "type": "sound"
+    },
+    "wcup_u5.rom": {
+      "filename": "wcup_u5.rom",
+      "type": "sound"
+    },
+    "fwcs0_62.rom": {
+      "filename": "fwcs0_62.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wcup_u7.rom": {
+      "filename": "wcup_u7.rom",
+      "type": "sound"
+    }
+  },
+  "wcs_l2": {
+    "wcup_u6.rom": {
+      "filename": "wcup_u6.rom",
+      "type": "sound"
+    },
+    "wcup_lx2.rom": {
+      "filename": "wcup_lx2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wcup_u4.rom": {
+      "filename": "wcup_u4.rom",
+      "type": "sound"
+    },
+    "wcup_u8.rom": {
+      "filename": "wcup_u8.rom",
+      "type": "sound"
+    },
+    "wcup_u3.rom": {
+      "filename": "wcup_u3.rom",
+      "type": "sound"
+    },
+    "wcup_u2.rom": {
+      "filename": "wcup_u2.rom",
+      "type": "sound"
+    },
+    "wcup_u5.rom": {
+      "filename": "wcup_u5.rom",
+      "type": "sound"
+    },
+    "wcup_u7.rom": {
+      "filename": "wcup_u7.rom",
+      "type": "sound"
+    }
+  },
+  "wcs_la2": {
+    "wcup_u6.rom": {
+      "filename": "wcup_u6.rom",
+      "type": "sound"
+    },
+    "wcup_u4.rom": {
+      "filename": "wcup_u4.rom",
+      "type": "sound"
+    },
+    "wcup_u8.rom": {
+      "filename": "wcup_u8.rom",
+      "type": "sound"
+    },
+    "wcup_u3.rom": {
+      "filename": "wcup_u3.rom",
+      "type": "sound"
+    },
+    "wcup_u2.rom": {
+      "filename": "wcup_u2.rom",
+      "type": "sound"
+    },
+    "wcup_u5.rom": {
+      "filename": "wcup_u5.rom",
+      "type": "sound"
+    },
+    "wcup_la2.rom": {
+      "filename": "wcup_la2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wcup_u7.rom": {
+      "filename": "wcup_u7.rom",
+      "type": "sound"
+    }
+  },
+  "wcs_p2": {
+    "wcup_u6.rom": {
+      "filename": "wcup_u6.rom",
+      "type": "sound"
+    },
+    "wcup_u4.rom": {
+      "filename": "wcup_u4.rom",
+      "type": "sound"
+    },
+    "wcup_u8.rom": {
+      "filename": "wcup_u8.rom",
+      "type": "sound"
+    },
+    "wcup_u3.rom": {
+      "filename": "wcup_u3.rom",
+      "type": "sound"
+    },
+    "u6-pa2.rom": {
+      "filename": "u6-pa2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wcup_u2.rom": {
+      "filename": "wcup_u2.rom",
+      "type": "sound"
+    },
+    "wcup_u5.rom": {
+      "filename": "wcup_u5.rom",
+      "type": "sound"
+    },
+    "wcup_u7.rom": {
+      "filename": "wcup_u7.rom",
+      "type": "sound"
+    }
+  },
+  "wcs_p3": {
+    "wcup_u6.rom": {
+      "filename": "wcup_u6.rom",
+      "type": "sound"
+    },
+    "wcup_u4.rom": {
+      "filename": "wcup_u4.rom",
+      "type": "sound"
+    },
+    "wcup_px3.rom": {
+      "filename": "wcup_px3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wcup_u8.rom": {
+      "filename": "wcup_u8.rom",
+      "type": "sound"
+    },
+    "wcup_u3.rom": {
+      "filename": "wcup_u3.rom",
+      "type": "sound"
+    },
+    "wcup_u2.rom": {
+      "filename": "wcup_u2.rom",
+      "type": "sound"
+    },
+    "wcup_u5.rom": {
+      "filename": "wcup_u5.rom",
+      "type": "sound"
+    },
+    "wcup_u7.rom": {
+      "filename": "wcup_u7.rom",
+      "type": "sound"
+    }
+  },
+  "lotr_sp": {
+    "lotrdspl.900": {
+      "filename": "lotrdspl.900",
+      "type": "dmd"
+    },
+    "lotrcpul.900": {
+      "filename": "lotrcpul.900",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrlu36.100": {
+      "filename": "lotrlu36.100",
+      "type": "sound"
+    },
+    "lotrlu37.100": {
+      "filename": "lotrlu37.100",
+      "type": "sound"
+    },
+    "lotrlu7.100": {
+      "filename": "lotrlu7.100",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrlu17.100": {
+      "filename": "lotrlu17.100",
+      "type": "sound"
+    },
+    "lotrlu21.100": {
+      "filename": "lotrlu21.100",
+      "type": "sound"
+    }
+  },
+  "lotr_sp9": {
+    "lotrdspl.900": {
+      "filename": "lotrdspl.900",
+      "type": "dmd"
+    },
+    "lotrcpul.900": {
+      "filename": "lotrcpul.900",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrlu36.100": {
+      "filename": "lotrlu36.100",
+      "type": "sound"
+    },
+    "lotrlu37.100": {
+      "filename": "lotrlu37.100",
+      "type": "sound"
+    },
+    "lotrlu7.100": {
+      "filename": "lotrlu7.100",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrlu17.100": {
+      "filename": "lotrlu17.100",
+      "type": "sound"
+    },
+    "lotrlu21.100": {
+      "filename": "lotrlu21.100",
+      "type": "sound"
+    }
+  },
+  "lightnfp": {
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "fpltg_u6.716": {
+      "filename": "fpltg_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpltg_u5.716": {
+      "filename": "fpltg_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "lightnin": {
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "blkou_hf": {
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "sound2.716": {
+      "filename": "sound2.716",
+      "type": "sound"
+    }
+  },
+  "blkou_l1": {
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "sound2.716": {
+      "filename": "sound2.716",
+      "type": "sound"
+    }
+  },
+  "blkou_t1": {
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "green2a.716": {
+      "filename": "green2a.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "sound2.716": {
+      "filename": "sound2.716",
+      "type": "sound"
+    }
+  },
+  "monopred": {
+    "monopdsp.400": {
+      "filename": "monopdsp.400",
+      "type": "dmd"
+    },
+    "monopred.u7": {
+      "filename": "monopred.u7",
+      "type": "sound"
+    },
+    "monopcpu.401": {
+      "filename": "monopcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "monopred.u17": {
+      "filename": "monopred.u17",
+      "type": "sound"
+    }
+  },
+  "columbia": {
+    "columb-e.bin": {
+      "filename": "columb-e.bin",
+      "type": "main",
+      "romType": "ltd"
+    }
+  },
+  "pecmen": {
+    "pecmen_h.bin": {
+      "filename": "pecmen_h.bin",
+      "type": "main",
+      "romType": "ltd"
+    },
+    "pecmen_l.bin": {
+      "filename": "pecmen_l.bin",
+      "type": "main",
+      "romType": "ltd"
+    }
+  },
+  "jngld_l1": {
+    "ic14-l1.716": {
+      "filename": "ic14-l1.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "speech5.532": {
+      "filename": "speech5.532",
+      "type": "sound"
+    },
+    "speech7.532": {
+      "filename": "speech7.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic26-l1.716": {
+      "filename": "ic26-l1.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech6.532": {
+      "filename": "speech6.532",
+      "type": "sound"
+    }
+  },
+  "godzilla": {
+    "gdzcpu.205": {
+      "filename": "gdzcpu.205",
+      "type": "main",
+      "romType": "se"
+    },
+    "gdzu37.100": {
+      "filename": "gdzu37.100",
+      "type": "sound"
+    },
+    "gdzu17.100": {
+      "filename": "gdzu17.100",
+      "type": "sound"
+    },
+    "gdzu7.100": {
+      "filename": "gdzu7.100",
+      "type": "sound"
+    },
+    "gzdspa.200": {
+      "filename": "gzdspa.200",
+      "type": "dmd"
+    },
+    "gdzu21.100": {
+      "filename": "gdzu21.100",
+      "type": "sound"
+    },
+    "gdzu36.100": {
+      "filename": "gdzu36.100",
+      "type": "sound"
+    }
+  },
+  "jy_03": {
+    "jy_cpu.0_3": {
+      "filename": "jy_cpu.0_3",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jy_s3.0_2": {
+      "filename": "jy_s3.0_2",
+      "type": "sound"
+    },
+    "jy_s5.0_2": {
+      "filename": "jy_s5.0_2",
+      "type": "sound"
+    },
+    "jy_s2.0_2": {
+      "filename": "jy_s2.0_2",
+      "type": "sound"
+    },
+    "jy_s4.0_2": {
+      "filename": "jy_s4.0_2",
+      "type": "sound"
+    }
+  },
+  "tftc_400": {
+    "tftcdspa.400": {
+      "filename": "TFTCDSPA.400",
+      "type": "dmd"
+    },
+    "sndu17.dat": {
+      "filename": "sndu17.dat",
+      "type": "sound"
+    },
+    "tftccpua.400": {
+      "filename": "TFTCCPUA.400",
+      "type": "main",
+      "romType": "de"
+    },
+    "sndu7.dat": {
+      "filename": "sndu7.dat",
+      "type": "sound"
+    },
+    "sndu21.dat": {
+      "filename": "sndu21.dat",
+      "type": "sound"
+    }
+  },
+  "rip300": {
+    "ripdispa.300": {
+      "filename": "ripdispa.300",
+      "type": "dmd"
+    },
+    "ripsnd.u37": {
+      "filename": "ripsnd.u37",
+      "type": "sound"
+    },
+    "ripsnd.u21": {
+      "filename": "ripsnd.u21",
+      "type": "sound"
+    },
+    "ripsnd.u7": {
+      "filename": "ripsnd.u7",
+      "type": "sound"
+    },
+    "ripcpu.300": {
+      "filename": "ripcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsnd.u36": {
+      "filename": "ripsnd.u36",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsnd.u17": {
+      "filename": "ripsnd.u17",
+      "type": "sound"
+    }
+  },
+  "rip301": {
+    "ripdispa.300": {
+      "filename": "ripdispa.300",
+      "type": "dmd"
+    },
+    "ripsnd.u37": {
+      "filename": "ripsnd.u37",
+      "type": "sound"
+    },
+    "ripsnd.u21": {
+      "filename": "ripsnd.u21",
+      "type": "sound"
+    },
+    "ripsnd.u7": {
+      "filename": "ripsnd.u7",
+      "type": "sound"
+    },
+    "ripcpu.301": {
+      "filename": "ripcpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsnd.u36": {
+      "filename": "ripsnd.u36",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsnd.u17": {
+      "filename": "ripsnd.u17",
+      "type": "sound"
+    }
+  },
+  "rip302": {
+    "ripdispa.300": {
+      "filename": "ripdispa.300",
+      "type": "dmd"
+    },
+    "ripsnd.u37": {
+      "filename": "ripsnd.u37",
+      "type": "sound"
+    },
+    "ripsnd.u21": {
+      "filename": "ripsnd.u21",
+      "type": "sound"
+    },
+    "ripsnd.u7": {
+      "filename": "ripsnd.u7",
+      "type": "sound"
+    },
+    "ripsnd.u36": {
+      "filename": "ripsnd.u36",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsnd.u17": {
+      "filename": "ripsnd.u17",
+      "type": "sound"
+    },
+    "ripcpu.302": {
+      "filename": "ripcpu.302",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "rip310": {
+    "ripdispa.300": {
+      "filename": "ripdispa.300",
+      "type": "dmd"
+    },
+    "ripsnd.u37": {
+      "filename": "ripsnd.u37",
+      "type": "sound"
+    },
+    "ripsnd.u21": {
+      "filename": "ripsnd.u21",
+      "type": "sound"
+    },
+    "ripsnd.u7": {
+      "filename": "ripsnd.u7",
+      "type": "sound"
+    },
+    "ripcpu.310": {
+      "filename": "ripcpu.310",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsnd.u36": {
+      "filename": "ripsnd.u36",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsnd.u17": {
+      "filename": "ripsnd.u17",
+      "type": "sound"
+    }
+  },
+  "ripleys": {
+    "ripdispa.300": {
+      "filename": "ripdispa.300",
+      "type": "dmd"
+    },
+    "ripsnd.u37": {
+      "filename": "ripsnd.u37",
+      "type": "sound"
+    },
+    "ripsnd.u21": {
+      "filename": "ripsnd.u21",
+      "type": "sound"
+    },
+    "ripsnd.u7": {
+      "filename": "ripsnd.u7",
+      "type": "sound"
+    },
+    "ripcpu.320": {
+      "filename": "ripcpu.320",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsnd.u36": {
+      "filename": "ripsnd.u36",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsnd.u17": {
+      "filename": "ripsnd.u17",
+      "type": "sound"
+    }
+  },
+  "bmf_sp": {
+    "bfdrom3l.401": {
+      "filename": "bfdrom3l.401",
+      "type": "dmd"
+    },
+    "batnova.401": {
+      "filename": "batnova.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom0l.401": {
+      "filename": "bfdrom0l.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "dragon": {
+    "419.cpu": {
+      "filename": "419.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "shaqatt2": {
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "gprom2.bin": {
+      "filename": "gprom2.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "shaqattq": {
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "dmd"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "godz_090": {
+    "gdzu21.090": {
+      "filename": "gdzu21.090",
+      "type": "sound"
+    },
+    "gdzu7.090": {
+      "filename": "gdzu7.090",
+      "type": "sound"
+    },
+    "gdzu37.090": {
+      "filename": "gdzu37.090",
+      "type": "sound"
+    },
+    "gdzu36.090": {
+      "filename": "gdzu36.090",
+      "type": "sound"
+    },
+    "gdzcpu.090": {
+      "filename": "gdzcpu.090",
+      "type": "main",
+      "romType": "se"
+    },
+    "gdzdspa.090": {
+      "filename": "gdzdspa.090",
+      "type": "dmd"
+    },
+    "gdzu17.090": {
+      "filename": "gdzu17.090",
+      "type": "sound"
+    }
+  },
+  "st_142h": {
+    "stle1-42.bin": {
+      "filename": "STLE1-42.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "nba_500": {
+    "nba_v5-0_a.bin": {
+      "filename": "nba_v5-0_a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "blckhole": {
+    "668-4.cpu": {
+      "filename": "668-4.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "668-s1.snd": {
+      "filename": "668-s1.snd",
+      "type": "sound"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "668-s2.snd": {
+      "filename": "668-s2.snd",
+      "type": "sound"
+    }
+  },
+  "blkhole7": {
+    "668-4.cpu": {
+      "filename": "668-4.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "668-s1.snd": {
+      "filename": "668-s1.snd",
+      "type": "sound"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "668-s2.snd": {
+      "filename": "668-s2.snd",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "xfiles": {
+    "xfsndu7.512": {
+      "filename": "xfsndu7.512",
+      "type": "sound"
+    },
+    "xfildspa.300": {
+      "filename": "xfildspa.300",
+      "type": "dmd"
+    },
+    "xfsndu17.c40": {
+      "filename": "xfsndu17.c40",
+      "type": "sound"
+    },
+    "xfsndu21.c40": {
+      "filename": "xfsndu21.c40",
+      "type": "sound"
+    },
+    "xfcpu.303": {
+      "filename": "xfcpu.303",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "xfiles2": {
+    "xfsndu7.512": {
+      "filename": "xfsndu7.512",
+      "type": "sound"
+    },
+    "xfsndu17.c40": {
+      "filename": "xfsndu17.c40",
+      "type": "sound"
+    },
+    "xfcpu.204": {
+      "filename": "xfcpu.204",
+      "type": "main",
+      "romType": "se"
+    },
+    "xfsndu21.c40": {
+      "filename": "xfsndu21.c40",
+      "type": "sound"
+    },
+    "xfildspa.201": {
+      "filename": "xfildspa.201",
+      "type": "dmd"
+    }
+  },
+  "xfiles20": {
+    "xfsndu7.512": {
+      "filename": "xfsndu7.512",
+      "type": "sound"
+    },
+    "xfildspa.200": {
+      "filename": "xfildspa.200",
+      "type": "dmd"
+    },
+    "xfsndu17.c40": {
+      "filename": "xfsndu17.c40",
+      "type": "sound"
+    },
+    "xfsndu21.c40": {
+      "filename": "xfsndu21.c40",
+      "type": "sound"
+    },
+    "xfcpu.200": {
+      "filename": "xfcpu.200",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "bk_f4": {
+    "speech7f.532": {
+      "filename": "speech7f.532",
+      "type": "sound"
+    },
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech5f.532": {
+      "filename": "speech5f.532",
+      "type": "sound"
+    },
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "speech4f.532": {
+      "filename": "speech4f.532",
+      "type": "sound"
+    },
+    "speech6f.532": {
+      "filename": "speech6f.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "circus": {
+    "654-2.cpu": {
+      "filename": "654-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "654-1.cpu": {
+      "filename": "654-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "654.snd": {
+      "filename": "654.snd",
+      "type": "sound"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "circus7": {
+    "654-2.cpu": {
+      "filename": "654-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "654-1.cpu": {
+      "filename": "654-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "654.snd": {
+      "filename": "654.snd",
+      "type": "sound"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "eatpm_l2": {
+    "u27-la2.rom": {
+      "filename": "u27-la2.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u20.l1": {
+      "filename": "elvi_u20.l1",
+      "type": "sound"
+    },
+    "elvi_u21.l1": {
+      "filename": "elvi_u21.l1",
+      "type": "sound"
+    },
+    "elvi_u19.l1": {
+      "filename": "elvi_u19.l1",
+      "type": "sound"
+    },
+    "elvi_u4.l1": {
+      "filename": "elvi_u4.l1",
+      "type": "sound"
+    },
+    "u26-la2.rom": {
+      "filename": "u26-la2.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u22.l1": {
+      "filename": "elvi_u22.l1",
+      "type": "sound"
+    }
+  },
+  "elv302l": {
+    "elvisl.u36": {
+      "filename": "elvisl.u36",
+      "type": "sound"
+    },
+    "elvscpul.302": {
+      "filename": "elvscpul.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisl.u17": {
+      "filename": "elvisl.u17",
+      "type": "sound"
+    },
+    "elvisl.u21": {
+      "filename": "elvisl.u21",
+      "type": "sound"
+    },
+    "elvisl.u37": {
+      "filename": "elvisl.u37",
+      "type": "sound"
+    },
+    "elvisl.u7": {
+      "filename": "Elvisl.u7",
+      "type": "sound"
+    },
+    "elvsdspl.302": {
+      "filename": "ELVSDSPL.302",
+      "type": "dmd"
+    }
+  },
+  "elv303l": {
+    "elvisl.u36": {
+      "filename": "elvisl.u36",
+      "type": "sound"
+    },
+    "elvisl.u17": {
+      "filename": "elvisl.u17",
+      "type": "sound"
+    },
+    "elvisl.u21": {
+      "filename": "elvisl.u21",
+      "type": "sound"
+    },
+    "elvscpul.303": {
+      "filename": "ELVSCPUL.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisl.u37": {
+      "filename": "elvisl.u37",
+      "type": "sound"
+    },
+    "elvisl.u7": {
+      "filename": "Elvisl.u7",
+      "type": "sound"
+    },
+    "elvsdspl.302": {
+      "filename": "ELVSDSPL.302",
+      "type": "dmd"
+    }
+  },
+  "elv400l": {
+    "elvisl.u36": {
+      "filename": "elvisl.u36",
+      "type": "sound"
+    },
+    "elvisl.u17": {
+      "filename": "elvisl.u17",
+      "type": "sound"
+    },
+    "elvisl.u21": {
+      "filename": "elvisl.u21",
+      "type": "sound"
+    },
+    "elvscpul.400": {
+      "filename": "elvscpul.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvsdspl.401": {
+      "filename": "elvsdspl.401",
+      "type": "dmd"
+    },
+    "elvisl.u37": {
+      "filename": "elvisl.u37",
+      "type": "sound"
+    },
+    "elvisl.u7": {
+      "filename": "Elvisl.u7",
+      "type": "sound"
+    }
+  },
+  "elvisl": {
+    "elvisl.u36": {
+      "filename": "elvisl.u36",
+      "type": "sound"
+    },
+    "elvisl.u17": {
+      "filename": "elvisl.u17",
+      "type": "sound"
+    },
+    "elvisl.u21": {
+      "filename": "elvisl.u21",
+      "type": "sound"
+    },
+    "elvscpul.400": {
+      "filename": "elvscpul.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvsdspl.401": {
+      "filename": "elvsdspl.401",
+      "type": "dmd"
+    },
+    "elvisl.u37": {
+      "filename": "elvisl.u37",
+      "type": "sound"
+    },
+    "elvisl.u7": {
+      "filename": "elvisl.u7",
+      "type": "sound"
+    }
+  },
+  "br_p17": {
+    "u18-sp1.rom": {
+      "filename": "u18-sp1.rom",
+      "type": "sound"
+    },
+    "br_u15.l1": {
+      "filename": "br_u15.l1",
+      "type": "sound"
+    },
+    "br_u14.l1": {
+      "filename": "br_u14.l1",
+      "type": "sound"
+    },
+    "u6-p17.rom": {
+      "filename": "u6-p17.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "cerberus": {
+    "cerb8.cpu": {
+      "filename": "CERB8.CPU",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "cerb9.cpu": {
+      "filename": "CERB9.CPU",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "cerb10.cpu": {
+      "filename": "CERB10.CPU",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "cerb.snd": {
+      "filename": "CERB.SND",
+      "type": "sound"
+    }
+  },
+  "biggame": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "eballch2": {
+    "u3_cpu.128": {
+      "filename": "u3_cpu.128",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "eballchp": {
+    "u3_cpu.128": {
+      "filename": "u3_cpu.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "u3_snd.532": {
+      "filename": "u3_snd.532",
+      "type": "sound"
+    },
+    "u4_snd.532": {
+      "filename": "u4_snd.532",
+      "type": "sound"
+    },
+    "u5_snd.532": {
+      "filename": "u5_snd.532",
+      "type": "sound"
+    }
+  },
+  "rab_103": {
+    "rabdspsp.103": {
+      "filename": "rabdspsp.103",
+      "type": "dmd"
+    },
+    "rab.u21": {
+      "filename": "rab.u21",
+      "type": "sound"
+    },
+    "rab.u17": {
+      "filename": "rab.u17",
+      "type": "sound"
+    },
+    "rab.u7": {
+      "filename": "rab.u7",
+      "type": "sound"
+    },
+    "rabcpu.103": {
+      "filename": "rabcpu.103",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "harl_a10": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "harcpu.103": {
+      "filename": "harcpu.103",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "hddispa.100": {
+      "filename": "hddispa.100",
+      "type": "dmd"
+    }
+  },
+  "harl_a13": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "harcpu.103": {
+      "filename": "harcpu.103",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "hddispa.104": {
+      "filename": "hddispa.104",
+      "type": "dmd"
+    }
+  },
+  "harl_f13": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "harcpu.103": {
+      "filename": "harcpu.103",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hddispf.104": {
+      "filename": "hddispf.104",
+      "type": "dmd"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_g13": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "harcpu.103": {
+      "filename": "harcpu.103",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "hddispg.104": {
+      "filename": "hddispg.104",
+      "type": "dmd"
+    }
+  },
+  "harl_i13": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "harcpu.103": {
+      "filename": "harcpu.103",
+      "type": "main",
+      "romType": "se"
+    },
+    "hddispi.104": {
+      "filename": "hddispi.104",
+      "type": "dmd"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_l13": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "harcpu.103": {
+      "filename": "harcpu.103",
+      "type": "main",
+      "romType": "se"
+    },
+    "hddisps.104": {
+      "filename": "hddisps.104",
+      "type": "dmd"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_u13": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "harcpuk.103": {
+      "filename": "harcpuk.103",
+      "type": "main",
+      "romType": "se"
+    },
+    "hddispa.104": {
+      "filename": "hddispa.104",
+      "type": "dmd"
+    }
+  },
+  "harl_a18": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hddispa.105": {
+      "filename": "hddispa.105",
+      "type": "dmd"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "harcpu.108": {
+      "filename": "harcpu.108",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_a30": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hddispa.300": {
+      "filename": "hddispa.300",
+      "type": "dmd"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "harcpu.300": {
+      "filename": "harcpu.300",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "harl_a40": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "harcpu.400": {
+      "filename": "HARCPU.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "hddispa.400": {
+      "filename": "HDDISPA.400",
+      "type": "dmd"
+    }
+  },
+  "harl_f18": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hddispf.105": {
+      "filename": "hddispf.105",
+      "type": "dmd"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "harcpu.108": {
+      "filename": "harcpu.108",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_f30": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hddispf.300": {
+      "filename": "hddispf.300",
+      "type": "dmd"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "harcpu.300": {
+      "filename": "harcpu.300",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "harl_f40": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "harcpu.400": {
+      "filename": "HARCPU.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "hddispf.400": {
+      "filename": "HDDISPF.400",
+      "type": "dmd"
+    }
+  },
+  "harl_g18": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "harcpu.108": {
+      "filename": "harcpu.108",
+      "type": "main",
+      "romType": "se"
+    },
+    "hddispg.105": {
+      "filename": "hddispg.105",
+      "type": "dmd"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_g30": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hddispg.300": {
+      "filename": "hddispg.300",
+      "type": "dmd"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "harcpu.300": {
+      "filename": "harcpu.300",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "harl_g40": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hddispg.400": {
+      "filename": "HDDISPG.400",
+      "type": "dmd"
+    },
+    "harcpu.400": {
+      "filename": "HARCPU.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_i18": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hddispi.105": {
+      "filename": "hddispi.105",
+      "type": "dmd"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "harcpu.108": {
+      "filename": "harcpu.108",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_i30": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hddispi.300": {
+      "filename": "hddispi.300",
+      "type": "dmd"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "harcpu.300": {
+      "filename": "harcpu.300",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "harl_i40": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "harcpu.400": {
+      "filename": "HARCPU.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "hddispi.400": {
+      "filename": "HDDISPI.400",
+      "type": "dmd"
+    }
+  },
+  "harl_l18": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hddisps.105": {
+      "filename": "hddisps.105",
+      "type": "dmd"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "harcpu.108": {
+      "filename": "harcpu.108",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "harl_l30": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "hddispl.300": {
+      "filename": "hddispl.300",
+      "type": "dmd"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    },
+    "harcpu.300": {
+      "filename": "harcpu.300",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "harl_l40": {
+    "hdvc1.u17": {
+      "filename": "hdvc1.u17",
+      "type": "sound"
+    },
+    "hdvc3.u36": {
+      "filename": "hdvc3.u36",
+      "type": "sound"
+    },
+    "harcpu.400": {
+      "filename": "HARCPU.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "hdvc2.u21": {
+      "filename": "hdvc2.u21",
+      "type": "sound"
+    },
+    "hddispl.400": {
+      "filename": "HDDISPL.400",
+      "type": "dmd"
+    },
+    "hdvc4.u37": {
+      "filename": "hdvc4.u37",
+      "type": "sound"
+    },
+    "hdsnd.u7": {
+      "filename": "hdsnd.u7",
+      "type": "sound"
+    }
+  },
+  "lotr6": {
+    "lotrcpu.600": {
+      "filename": "lotrcpu.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrdspa.600": {
+      "filename": "lotrdspa.600",
+      "type": "dmd"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "lotr_fr6": {
+    "lotrcpu.600": {
+      "filename": "lotrcpu.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrdspf.600": {
+      "filename": "lotrdspf.600",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "lotr_gr6": {
+    "lotrcpu.600": {
+      "filename": "lotrcpu.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspg.600": {
+      "filename": "lotrdspg.600",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "lotr_it6": {
+    "lotrcpu.600": {
+      "filename": "lotrcpu.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspi.600": {
+      "filename": "lotrdspi.600",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "potc_110ai": {
+    "potc0110ai.bin": {
+      "filename": "potc0110ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lah_110": {
+    "lahsnd.u7": {
+      "filename": "lahsnd.u7",
+      "type": "sound"
+    },
+    "lahsnd.u21": {
+      "filename": "lahsnd.u21",
+      "type": "sound"
+    },
+    "lahdispa.106": {
+      "filename": "lahdispa.106",
+      "type": "dmd"
+    },
+    "lahsnd.u17": {
+      "filename": "lahsnd.u17",
+      "type": "sound"
+    },
+    "lahcpua.110": {
+      "filename": "lahcpua.110",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "lah_112": {
+    "lahsnd.u7": {
+      "filename": "lahsnd.u7",
+      "type": "sound"
+    },
+    "lahsnd.u21": {
+      "filename": "lahsnd.u21",
+      "type": "sound"
+    },
+    "lahdispa.106": {
+      "filename": "lahdispa.106",
+      "type": "dmd"
+    },
+    "lahsnd.u17": {
+      "filename": "lahsnd.u17",
+      "type": "sound"
+    },
+    "lahcpua.112": {
+      "filename": "lahcpua.112",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "lah_l104": {
+    "lahsnd.u7": {
+      "filename": "lahsnd.u7",
+      "type": "sound"
+    },
+    "lahdispl.102": {
+      "filename": "lahdispl.102",
+      "type": "dmd"
+    },
+    "lahsnd.u21": {
+      "filename": "lahsnd.u21",
+      "type": "sound"
+    },
+    "lahcpua.104": {
+      "filename": "lahcpua.104",
+      "type": "main",
+      "romType": "de"
+    },
+    "lahsnd.u17": {
+      "filename": "lahsnd.u17",
+      "type": "sound"
+    }
+  },
+  "lah_l108": {
+    "lahsnd.u7": {
+      "filename": "lahsnd.u7",
+      "type": "sound"
+    },
+    "lahsnd.u21": {
+      "filename": "lahsnd.u21",
+      "type": "sound"
+    },
+    "lahdispl.104": {
+      "filename": "lahdispl.104",
+      "type": "dmd"
+    },
+    "lahcpua.108": {
+      "filename": "lahcpua.108",
+      "type": "main",
+      "romType": "de"
+    },
+    "lahsnd.u17": {
+      "filename": "lahsnd.u17",
+      "type": "sound"
+    }
+  },
+  "lwar_a81": {
+    "lwar_e7.snd": {
+      "filename": "lwar_e7.snd",
+      "type": "sound"
+    },
+    "lwar_e6.snd": {
+      "filename": "lwar_e6.snd",
+      "type": "sound"
+    },
+    "lwar_e9.snd": {
+      "filename": "lwar_e9.snd",
+      "type": "sound"
+    },
+    "c100_g8.256": {
+      "filename": "c100_g8.256",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "lwar_a83": {
+    "lwar_e7.snd": {
+      "filename": "lwar_e7.snd",
+      "type": "sound"
+    },
+    "lwar_e6.snd": {
+      "filename": "lwar_e6.snd",
+      "type": "sound"
+    },
+    "lwar_e9.snd": {
+      "filename": "lwar_e9.snd",
+      "type": "sound"
+    },
+    "lwar8-3.c5": {
+      "filename": "lwar8-3.c5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "lwar_e90": {
+    "lwar_e7.snd": {
+      "filename": "lwar_e7.snd",
+      "type": "sound"
+    },
+    "lwar_e6.snd": {
+      "filename": "lwar_e6.snd",
+      "type": "sound"
+    },
+    "lwar_e9.snd": {
+      "filename": "lwar_e9.snd",
+      "type": "sound"
+    },
+    "lwar9-0.e5": {
+      "filename": "lwar9-0.e5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "tafg_h3": {
+    "ag_u18_s.l1": {
+      "filename": "ag_u18_s.l1",
+      "type": "sound"
+    },
+    "cpu-u6h3.rom": {
+      "filename": "cpu-u6h3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ag_u15_s.l1": {
+      "filename": "ag_u15_s.l1",
+      "type": "sound"
+    }
+  },
+  "tafg_la2": {
+    "ag_u18_s.l1": {
+      "filename": "ag_u18_s.l1",
+      "type": "sound"
+    },
+    "u6-la2.rom": {
+      "filename": "u6-la2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ag_u15_s.l1": {
+      "filename": "ag_u15_s.l1",
+      "type": "sound"
+    }
+  },
+  "tafg_la3": {
+    "ag_u18_s.l1": {
+      "filename": "ag_u18_s.l1",
+      "type": "sound"
+    },
+    "ag_u15_s.l1": {
+      "filename": "ag_u15_s.l1",
+      "type": "sound"
+    },
+    "u6-la3.rom": {
+      "filename": "u6-la3.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "tafg_lx3": {
+    "ag_u18_s.l1": {
+      "filename": "ag_u18_s.l1",
+      "type": "sound"
+    },
+    "afgldlx3.rom": {
+      "filename": "afgldlx3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ag_u15_s.l1": {
+      "filename": "ag_u15_s.l1",
+      "type": "sound"
+    }
+  },
+  "elektra": {
+    "857-01_3.532": {
+      "filename": "857-01_3.532",
+      "type": "sound"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "857-04_2.732": {
+      "filename": "857-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "857-03_5.716": {
+      "filename": "857-03_5.716",
+      "type": "sound"
+    },
+    "857-02_4.532": {
+      "filename": "857-02_4.532",
+      "type": "sound"
+    }
+  },
+  "elektraa": {
+    "857-01_3.532": {
+      "filename": "857-01_3.532",
+      "type": "sound"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "857-04_2.732": {
+      "filename": "857-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "857-03_5.716": {
+      "filename": "857-03_5.716",
+      "type": "sound"
+    },
+    "857-02_4.532": {
+      "filename": "857-02_4.532",
+      "type": "sound"
+    }
+  },
+  "ffv101": {
+    "u3l_v101.bin": {
+      "filename": "u3l_v101.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u1h_v100.bin": {
+      "filename": "u1h_v100.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u1l_v100.bin": {
+      "filename": "u1l_v100.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u31_v100.bin": {
+      "filename": "u31_v100.bin",
+      "type": "sound"
+    },
+    "u4h_v100.bin": {
+      "filename": "u4h_v100.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u4l_v100.bin": {
+      "filename": "u4l_v100.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_v100.bin": {
+      "filename": "u28_v100.bin",
+      "type": "sound"
+    },
+    "u29_v100.bin": {
+      "filename": "u29_v100.bin",
+      "type": "sound"
+    },
+    "u2h_v100.bin": {
+      "filename": "u2h_v100.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u30_v100.bin": {
+      "filename": "u30_v100.bin",
+      "type": "sound"
+    },
+    "u3h_v101.bin": {
+      "filename": "u3h_v101.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u2l_v100.bin": {
+      "filename": "u2l_v100.bin",
+      "type": "main",
+      "romType": "capcom"
+    }
+  },
+  "kissd": {
+    "strekd.u6": {
+      "filename": "strekd.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "kiss2732.u2": {
+      "filename": "kiss2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "paragond": {
+    "strekd.u6": {
+      "filename": "strekd.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    },
+    "para2732.u2": {
+      "filename": "para2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "playboyd": {
+    "strekd.u6": {
+      "filename": "strekd.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "play2732.u2": {
+      "filename": "play2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "startred": {
+    "strekd.u6": {
+      "filename": "strekd.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "star2732.u2": {
+      "filename": "star2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "smmand": {
+    "strekd.u6": {
+      "filename": "strekd.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "6mi$2732.u2": {
+      "filename": "6mi$2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "sstd": {
+    "strekd.u6": {
+      "filename": "strekd.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "surp2732.u2": {
+      "filename": "surp2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "voltand": {
+    "strekd.u6": {
+      "filename": "strekd.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "volt2732.u2": {
+      "filename": "volt2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "nbaf_11": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "fb-s2.1_0": {
+      "filename": "fb-s2.1_0",
+      "type": "sound"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "g11-11.rom": {
+      "filename": "g11-11.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    }
+  },
+  "nbaf_115": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "fb-s2.1_0": {
+      "filename": "fb-s2.1_0",
+      "type": "sound"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "g11-115": {
+      "filename": "g11-115",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    }
+  },
+  "nbaf_11a": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "g11-11.rom": {
+      "filename": "g11-11.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    },
+    "fb-s2.2_0": {
+      "filename": "fb-s2.2_0",
+      "type": "sound"
+    }
+  },
+  "nbaf_11s": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "fb-s2.0_4": {
+      "filename": "fb-s2.0_4",
+      "type": "sound"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "g11-11.rom": {
+      "filename": "g11-11.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    }
+  },
+  "nbaf_21": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "fb-s2.1_0": {
+      "filename": "fb-s2.1_0",
+      "type": "sound"
+    },
+    "g11-21.rom": {
+      "filename": "g11-21.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    }
+  },
+  "nbaf_22": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "g11-22.rom": {
+      "filename": "g11-22.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s2.1_0": {
+      "filename": "fb-s2.1_0",
+      "type": "sound"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    }
+  },
+  "nbaf_23": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "fb-s2.1_0": {
+      "filename": "fb-s2.1_0",
+      "type": "sound"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "g11-23.rom": {
+      "filename": "g11-23.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    }
+  },
+  "nbaf_31": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "fb-s2.3_0": {
+      "filename": "fb-s2.3_0",
+      "type": "sound"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "fb_g11.3_1": {
+      "filename": "fb_g11.3_1",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    }
+  },
+  "nbaf_31a": {
+    "fb-s3.1_0": {
+      "filename": "fb-s3.1_0",
+      "type": "sound"
+    },
+    "fb-s2.1_0": {
+      "filename": "fb-s2.1_0",
+      "type": "sound"
+    },
+    "fb-s4.1_0": {
+      "filename": "fb-s4.1_0",
+      "type": "sound"
+    },
+    "fb_g11.3_1": {
+      "filename": "fb_g11.3_1",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fb-s5.1_0": {
+      "filename": "fb-s5.1_0",
+      "type": "sound"
+    },
+    "fb-s6.1_0": {
+      "filename": "fb-s6.1_0",
+      "type": "sound"
+    }
+  },
+  "rescu911": {
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "pfevr_p3": {
+    "cpu_u19.732": {
+      "filename": "cpu_u19.732",
+      "type": "main",
+      "romType": "s9"
+    },
+    "cpu_u20.764": {
+      "filename": "cpu_u20.764",
+      "type": "main",
+      "romType": "s9"
+    },
+    "cpu_u49.128": {
+      "filename": "cpu_u49.128",
+      "type": "sound"
+    }
+  },
+  "rock": {
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    }
+  },
+  "jb_10b": {
+    "jbsnd_u4.rom": {
+      "filename": "jbsnd_u4.rom",
+      "type": "sound"
+    },
+    "jbsnd_u5.rom": {
+      "filename": "jbsnd_u5.rom",
+      "type": "sound"
+    },
+    "jbsnd_u3.rom": {
+      "filename": "jbsnd_u3.rom",
+      "type": "sound"
+    },
+    "jbsnd_u6.rom": {
+      "filename": "jbsnd_u6.rom",
+      "type": "sound"
+    },
+    "jbsnd_u2.rom": {
+      "filename": "jbsnd_u2.rom",
+      "type": "sound"
+    },
+    "jack1_0b.rom": {
+      "filename": "jack1_0b.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "jb_10r": {
+    "jbsnd_u4.rom": {
+      "filename": "jbsnd_u4.rom",
+      "type": "sound"
+    },
+    "jbsnd_u5.rom": {
+      "filename": "jbsnd_u5.rom",
+      "type": "sound"
+    },
+    "jack1_0r.rom": {
+      "filename": "jack1_0r.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jbsnd_u3.rom": {
+      "filename": "jbsnd_u3.rom",
+      "type": "sound"
+    },
+    "jbsnd_u6.rom": {
+      "filename": "jbsnd_u6.rom",
+      "type": "sound"
+    },
+    "jbsnd_u2.rom": {
+      "filename": "jbsnd_u2.rom",
+      "type": "sound"
+    }
+  },
+  "bmx": {
+    "888-03_2.732": {
+      "filename": "888-03_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "888-02_4.532": {
+      "filename": "888-02_4.532",
+      "type": "sound"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "bmxa": {
+    "888-03_2.732": {
+      "filename": "888-03_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "888-02_4.532": {
+      "filename": "888-02_4.532",
+      "type": "sound"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "nas301l": {
+    "nascsp.u7": {
+      "filename": "nascsp.u7",
+      "type": "sound"
+    },
+    "nassndl.u17": {
+      "filename": "nassndl.u17",
+      "type": "sound"
+    },
+    "nassndl.u37": {
+      "filename": "nassndl.u37",
+      "type": "sound"
+    },
+    "nascpul.301": {
+      "filename": "nascpul.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "nassndl.u36": {
+      "filename": "nassndl.u36",
+      "type": "sound"
+    },
+    "nasdspl.301": {
+      "filename": "nasdspl.301",
+      "type": "dmd"
+    },
+    "nassndl.u21": {
+      "filename": "nassndl.u21",
+      "type": "sound"
+    }
+  },
+  "nas340l": {
+    "nascsp.u7": {
+      "filename": "nascsp.u7",
+      "type": "sound"
+    },
+    "nassndl.u17": {
+      "filename": "nassndl.u17",
+      "type": "sound"
+    },
+    "nassndl.u37": {
+      "filename": "nassndl.u37",
+      "type": "sound"
+    },
+    "nasdspl.303": {
+      "filename": "nasdspl.303",
+      "type": "dmd"
+    },
+    "nassndl.u36": {
+      "filename": "nassndl.u36",
+      "type": "sound"
+    },
+    "nascpul.340": {
+      "filename": "nascpul.340",
+      "type": "main",
+      "romType": "se"
+    },
+    "nassndl.u21": {
+      "filename": "nassndl.u21",
+      "type": "sound"
+    }
+  },
+  "nas350l": {
+    "nascsp.u7": {
+      "filename": "nascsp.u7",
+      "type": "sound"
+    },
+    "nassndl.u17": {
+      "filename": "nassndl.u17",
+      "type": "sound"
+    },
+    "nassndl.u37": {
+      "filename": "nassndl.u37",
+      "type": "sound"
+    },
+    "nasdspl.303": {
+      "filename": "nasdspl.303",
+      "type": "dmd"
+    },
+    "nassndl.u36": {
+      "filename": "nassndl.u36",
+      "type": "sound"
+    },
+    "nascpul.350": {
+      "filename": "nascpul.350",
+      "type": "main",
+      "romType": "se"
+    },
+    "nassndl.u21": {
+      "filename": "nassndl.u21",
+      "type": "sound"
+    }
+  },
+  "nas352l": {
+    "nascsp.u7": {
+      "filename": "nascsp.u7",
+      "type": "sound"
+    },
+    "nassndl.u17": {
+      "filename": "nassndl.u17",
+      "type": "sound"
+    },
+    "nassndl.u37": {
+      "filename": "nassndl.u37",
+      "type": "sound"
+    },
+    "nasdspl.303": {
+      "filename": "nasdspl.303",
+      "type": "dmd"
+    },
+    "nassndl.u36": {
+      "filename": "nassndl.u36",
+      "type": "sound"
+    },
+    "nascpul.352": {
+      "filename": "nascpul.352",
+      "type": "main",
+      "romType": "se"
+    },
+    "nassndl.u21": {
+      "filename": "nassndl.u21",
+      "type": "sound"
+    }
+  },
+  "nas400l": {
+    "nascsp.u7": {
+      "filename": "nascsp.u7",
+      "type": "sound"
+    },
+    "nassndl.u17": {
+      "filename": "nassndl.u17",
+      "type": "sound"
+    },
+    "nascpul.400": {
+      "filename": "nascpul.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "nassndl.u37": {
+      "filename": "nassndl.u37",
+      "type": "sound"
+    },
+    "nassndl.u36": {
+      "filename": "nassndl.u36",
+      "type": "sound"
+    },
+    "nasdspl.400": {
+      "filename": "nasdspl.400",
+      "type": "dmd"
+    },
+    "nassndl.u21": {
+      "filename": "nassndl.u21",
+      "type": "sound"
+    }
+  },
+  "nascarl": {
+    "nascsp.u7": {
+      "filename": "nascsp.u7",
+      "type": "sound"
+    },
+    "nassndl.u17": {
+      "filename": "nassndl.u17",
+      "type": "sound"
+    },
+    "nascpul.450": {
+      "filename": "nascpul.450",
+      "type": "main",
+      "romType": "se"
+    },
+    "nassndl.u37": {
+      "filename": "nassndl.u37",
+      "type": "sound"
+    },
+    "nassndl.u36": {
+      "filename": "nassndl.u36",
+      "type": "sound"
+    },
+    "nasdspl.400": {
+      "filename": "nasdspl.400",
+      "type": "dmd"
+    },
+    "nassndl.u21": {
+      "filename": "nassndl.u21",
+      "type": "sound"
+    }
+  },
+  "aar_101": {
+    "as512cpu.bin": {
+      "filename": "as512cpu.bin",
+      "type": "main",
+      "romType": "de"
+    },
+    "asdspu14.bin": {
+      "filename": "asdspu14.bin",
+      "type": "dmd"
+    },
+    "asdspu12.bin": {
+      "filename": "asdspu12.bin",
+      "type": "dmd"
+    },
+    "assndu21.bin": {
+      "filename": "assndu21.bin",
+      "type": "sound"
+    },
+    "assndu17.bin": {
+      "filename": "assndu17.bin",
+      "type": "sound"
+    },
+    "assndu7.bin": {
+      "filename": "assndu7.bin",
+      "type": "sound"
+    }
+  },
+  "potc_400af": {
+    "potc0400af.bin": {
+      "filename": "potc0400af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "dm_dt099": {
+    "dm.2": {
+      "filename": "dm.2",
+      "type": "sound"
+    },
+    "dm.6": {
+      "filename": "dm.6",
+      "type": "sound"
+    },
+    "dm.3": {
+      "filename": "dm.3",
+      "type": "sound"
+    },
+    "dm.9": {
+      "filename": "dm.9",
+      "type": "sound"
+    },
+    "dm.8": {
+      "filename": "dm.8",
+      "type": "sound"
+    },
+    "dm_dt099.rom": {
+      "filename": "dm_dt099.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm.7": {
+      "filename": "dm.7",
+      "type": "sound"
+    },
+    "dm.5": {
+      "filename": "dm.5",
+      "type": "sound"
+    },
+    "dm.4": {
+      "filename": "dm.4",
+      "type": "sound"
+    }
+  },
+  "dm_dt101": {
+    "dm.2": {
+      "filename": "dm.2",
+      "type": "sound"
+    },
+    "dm.6": {
+      "filename": "dm.6",
+      "type": "sound"
+    },
+    "dm.3": {
+      "filename": "dm.3",
+      "type": "sound"
+    },
+    "dm.9": {
+      "filename": "dm.9",
+      "type": "sound"
+    },
+    "dm.8": {
+      "filename": "dm.8",
+      "type": "sound"
+    },
+    "dm.7": {
+      "filename": "dm.7",
+      "type": "sound"
+    },
+    "dm.5": {
+      "filename": "dm.5",
+      "type": "sound"
+    },
+    "dm_dt101.rom": {
+      "filename": "dm_dt101.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm.4": {
+      "filename": "dm.4",
+      "type": "sound"
+    }
+  },
+  "dm_h5": {
+    "dm.2": {
+      "filename": "dm.2",
+      "type": "sound"
+    },
+    "dm.6": {
+      "filename": "dm.6",
+      "type": "sound"
+    },
+    "dm.3": {
+      "filename": "dm.3",
+      "type": "sound"
+    },
+    "dm.9": {
+      "filename": "dm.9",
+      "type": "sound"
+    },
+    "dm.8": {
+      "filename": "dm.8",
+      "type": "sound"
+    },
+    "dm.7": {
+      "filename": "dm.7",
+      "type": "sound"
+    },
+    "dm.5": {
+      "filename": "dm.5",
+      "type": "sound"
+    },
+    "dman_h5.rom": {
+      "filename": "dman_h5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm.4": {
+      "filename": "dm.4",
+      "type": "sound"
+    }
+  },
+  "dm_h5b": {
+    "dm.2": {
+      "filename": "dm.2",
+      "type": "sound"
+    },
+    "dman_h5b.rom": {
+      "filename": "dman_h5b.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm.6": {
+      "filename": "dm.6",
+      "type": "sound"
+    },
+    "dm.3": {
+      "filename": "dm.3",
+      "type": "sound"
+    },
+    "dm.9": {
+      "filename": "dm.9",
+      "type": "sound"
+    },
+    "dm.8": {
+      "filename": "dm.8",
+      "type": "sound"
+    },
+    "dm.7": {
+      "filename": "dm.7",
+      "type": "sound"
+    },
+    "dm.5": {
+      "filename": "dm.5",
+      "type": "sound"
+    },
+    "dm.4": {
+      "filename": "dm.4",
+      "type": "sound"
+    }
+  },
+  "dm_h6": {
+    "dm.2": {
+      "filename": "dm.2",
+      "type": "sound"
+    },
+    "dm.6": {
+      "filename": "dm.6",
+      "type": "sound"
+    },
+    "dman_h6.rom": {
+      "filename": "dman_h6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm.3": {
+      "filename": "dm.3",
+      "type": "sound"
+    },
+    "dm.9": {
+      "filename": "dm.9",
+      "type": "sound"
+    },
+    "dm.8": {
+      "filename": "dm.8",
+      "type": "sound"
+    },
+    "dm.7": {
+      "filename": "dm.7",
+      "type": "sound"
+    },
+    "dm.5": {
+      "filename": "dm.5",
+      "type": "sound"
+    },
+    "dm.4": {
+      "filename": "dm.4",
+      "type": "sound"
+    }
+  },
+  "hotdoggn": {
+    "809-06_2.716": {
+      "filename": "809-06_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "809-05_1.716": {
+      "filename": "809-05_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "809-07_4.716": {
+      "filename": "809-07_4.716",
+      "type": "sound"
+    },
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "elv302f": {
+    "elvisf.u36": {
+      "filename": "elvisf.u36",
+      "type": "sound"
+    },
+    "elvsdspf.302": {
+      "filename": "ELVSDSPF.302",
+      "type": "dmd"
+    },
+    "elvisf.u21": {
+      "filename": "elvisf.u21",
+      "type": "sound"
+    },
+    "elvisf.u7": {
+      "filename": "Elvisf.u7",
+      "type": "sound"
+    },
+    "elvscpuf.302": {
+      "filename": "elvscpuf.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisf.u17": {
+      "filename": "elvisf.u17",
+      "type": "sound"
+    },
+    "elvisf.u37": {
+      "filename": "elvisf.u37",
+      "type": "sound"
+    }
+  },
+  "elv303f": {
+    "elvisf.u36": {
+      "filename": "elvisf.u36",
+      "type": "sound"
+    },
+    "elvsdspf.302": {
+      "filename": "ELVSDSPF.302",
+      "type": "dmd"
+    },
+    "elvisf.u21": {
+      "filename": "elvisf.u21",
+      "type": "sound"
+    },
+    "elvisf.u7": {
+      "filename": "Elvisf.u7",
+      "type": "sound"
+    },
+    "elvisf.u17": {
+      "filename": "elvisf.u17",
+      "type": "sound"
+    },
+    "elvisf.u37": {
+      "filename": "elvisf.u37",
+      "type": "sound"
+    },
+    "elvscpuf.303": {
+      "filename": "ELVSCPUF.303",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "elv400f": {
+    "elvisf.u36": {
+      "filename": "elvisf.u36",
+      "type": "sound"
+    },
+    "elvsdspf.401": {
+      "filename": "elvsdspf.401",
+      "type": "dmd"
+    },
+    "elvisf.u21": {
+      "filename": "elvisf.u21",
+      "type": "sound"
+    },
+    "elvisf.u7": {
+      "filename": "Elvisf.u7",
+      "type": "sound"
+    },
+    "elvscpuf.400": {
+      "filename": "elvscpuf.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisf.u17": {
+      "filename": "elvisf.u17",
+      "type": "sound"
+    },
+    "elvisf.u37": {
+      "filename": "elvisf.u37",
+      "type": "sound"
+    }
+  },
+  "elvisf": {
+    "elvisf.u36": {
+      "filename": "elvisf.u36",
+      "type": "sound"
+    },
+    "elvsdspf.401": {
+      "filename": "elvsdspf.401",
+      "type": "dmd"
+    },
+    "elvisf.u21": {
+      "filename": "elvisf.u21",
+      "type": "sound"
+    },
+    "elvisf.u7": {
+      "filename": "elvisf.u7",
+      "type": "sound"
+    },
+    "elvscpuf.400": {
+      "filename": "elvscpuf.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisf.u17": {
+      "filename": "elvisf.u17",
+      "type": "sound"
+    },
+    "elvisf.u37": {
+      "filename": "elvisf.u37",
+      "type": "sound"
+    }
+  },
+  "meteor": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "bcats_l2": {
+    "cats_u21.l1": {
+      "filename": "cats_u21.l1",
+      "type": "sound"
+    },
+    "cats_u4.l1": {
+      "filename": "cats_u4.l1",
+      "type": "sound"
+    },
+    "bcgu26.la2": {
+      "filename": "bcgu26.la2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cats_u22.l1": {
+      "filename": "cats_u22.l1",
+      "type": "sound"
+    },
+    "bcgu27.la2": {
+      "filename": "bcgu27.la2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cats_u20.l1": {
+      "filename": "cats_u20.l1",
+      "type": "sound"
+    },
+    "cats_u19.l1": {
+      "filename": "cats_u19.l1",
+      "type": "sound"
+    }
+  },
+  "bcats_l5": {
+    "cats_u21.l1": {
+      "filename": "cats_u21.l1",
+      "type": "sound"
+    },
+    "cats_u4.l1": {
+      "filename": "cats_u4.l1",
+      "type": "sound"
+    },
+    "cats_u26.l5": {
+      "filename": "cats_u26.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cats_u22.l1": {
+      "filename": "cats_u22.l1",
+      "type": "sound"
+    },
+    "cats_u20.l1": {
+      "filename": "cats_u20.l1",
+      "type": "sound"
+    },
+    "cats_u27.l5": {
+      "filename": "cats_u27.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cats_u19.l1": {
+      "filename": "cats_u19.l1",
+      "type": "sound"
+    }
+  },
+  "pz_f4": {
+    "pzonef_4.rom": {
+      "filename": "pzonef_4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "pz_u15.l1": {
+      "filename": "pz_u15.l1",
+      "type": "sound"
+    },
+    "pz_u14.l1": {
+      "filename": "pz_u14.l1",
+      "type": "sound"
+    },
+    "pz_u18.l1": {
+      "filename": "pz_u18.l1",
+      "type": "sound"
+    }
+  },
+  "spcpnthr": {
+    "sp_game.bin": {
+      "filename": "SP_Game.BIN",
+      "type": "main"
+    },
+    "sp_sound.bin": {
+      "filename": "SP_Sound.BIN",
+      "type": "main"
+    }
+  },
+  "sman_170al": {
+    "spd_1-7_es.bin": {
+      "filename": "spd_1-7_es.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wrldtou2": {
+    "romdef1.c20": {
+      "filename": "romdef1.c20",
+      "type": "dmd"
+    },
+    "cpu02b.512": {
+      "filename": "cpu02b.512",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "samp_3.c21": {
+      "filename": "samp_3.c21",
+      "type": "sound"
+    },
+    "romdef2.c20": {
+      "filename": "romdef2.c20",
+      "type": "dmd"
+    },
+    "samp_0.c21": {
+      "filename": "samp_0.c21",
+      "type": "sound"
+    },
+    "samp_2.c21": {
+      "filename": "samp_2.c21",
+      "type": "sound"
+    },
+    "dot02b.512": {
+      "filename": "dot02b.512",
+      "type": "dmd"
+    },
+    "samp_1.c21": {
+      "filename": "samp_1.c21",
+      "type": "sound"
+    },
+    "soundc.512": {
+      "filename": "soundc.512",
+      "type": "sound"
+    }
+  },
+  "wrldtou3": {
+    "romdef1.c20": {
+      "filename": "romdef1.c20",
+      "type": "dmd"
+    },
+    "samp_3.c21": {
+      "filename": "samp_3.c21",
+      "type": "sound"
+    },
+    "romdef2.c20": {
+      "filename": "romdef2.c20",
+      "type": "dmd"
+    },
+    "samp_0.c21": {
+      "filename": "samp_0.c21",
+      "type": "sound"
+    },
+    "samp_2.c21": {
+      "filename": "samp_2.c21",
+      "type": "sound"
+    },
+    "cpu03.512": {
+      "filename": "cpu03.512",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "samp_1.c21": {
+      "filename": "samp_1.c21",
+      "type": "sound"
+    },
+    "soundc.512": {
+      "filename": "soundc.512",
+      "type": "sound"
+    },
+    "dot03.512": {
+      "filename": "dot03.512",
+      "type": "dmd"
+    }
+  },
+  "wrldtour": {
+    "romdef1.c20": {
+      "filename": "romdef1.c20",
+      "type": "dmd"
+    },
+    "samp_3.c21": {
+      "filename": "samp_3.c21",
+      "type": "sound"
+    },
+    "romdef2.c20": {
+      "filename": "romdef2.c20",
+      "type": "dmd"
+    },
+    "samp_0.c21": {
+      "filename": "samp_0.c21",
+      "type": "sound"
+    },
+    "samp_2.c21": {
+      "filename": "samp_2.c21",
+      "type": "sound"
+    },
+    "samp_1.c21": {
+      "filename": "samp_1.c21",
+      "type": "sound"
+    },
+    "soundc.512": {
+      "filename": "soundc.512",
+      "type": "sound"
+    },
+    "dot27c.512": {
+      "filename": "dot27c.512",
+      "type": "dmd"
+    },
+    "cpu27c.512": {
+      "filename": "cpu27c.512",
+      "type": "main",
+      "romType": "alvin"
+    }
+  },
+  "jolypark": {
+    "jpsndc1.rom": {
+      "filename": "jpsndc1.rom",
+      "type": "sound"
+    },
+    "jpcpu0.rom": {
+      "filename": "jpcpu0.rom",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "jpdmd1.rom": {
+      "filename": "jpdmd1.rom",
+      "type": "dmd"
+    },
+    "jpsndm4.rom": {
+      "filename": "jpsndm4.rom",
+      "type": "sound"
+    },
+    "jpsndm5.rom": {
+      "filename": "jpsndm5.rom",
+      "type": "sound"
+    },
+    "jpsndm3.rom": {
+      "filename": "jpsndm3.rom",
+      "type": "sound"
+    },
+    "jpsndc0.rom": {
+      "filename": "jpsndc0.rom",
+      "type": "sound"
+    },
+    "jpdmd0.rom": {
+      "filename": "jpdmd0.rom",
+      "type": "dmd"
+    },
+    "jpcpu1.rom": {
+      "filename": "jpcpu1.rom",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "jpsndm2.rom": {
+      "filename": "jpsndm2.rom",
+      "type": "sound"
+    },
+    "jpsndm1.rom": {
+      "filename": "jpsndm1.rom",
+      "type": "sound"
+    }
+  },
+  "hook_401p": {
+    "hook-voi.u21": {
+      "filename": "hook-voi.u21",
+      "type": "sound"
+    },
+    "hooksnd.u7": {
+      "filename": "hooksnd.u7",
+      "type": "sound"
+    },
+    "hokcpua.401": {
+      "filename": "hokcpua.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "hook-voi.u17": {
+      "filename": "hook-voi.u17",
+      "type": "sound"
+    }
+  },
+  "bighouse": {
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    }
+  },
+  "centaurb": {
+    "cent2un.u2": {
+      "filename": "cent2un.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "848-01_3.532": {
+      "filename": "848-01_3.532",
+      "type": "sound"
+    },
+    "848-05_5.716": {
+      "filename": "848-05_5.716",
+      "type": "sound"
+    },
+    "cent2un.u6": {
+      "filename": "cent2un.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "848-02_4.532": {
+      "filename": "848-02_4.532",
+      "type": "sound"
+    }
+  },
+  "corsario": {
+    "c-corsar.bin": {
+      "filename": "c-corsar.bin",
+      "type": "sound"
+    },
+    "d-corsar.bin": {
+      "filename": "d-corsar.bin",
+      "type": "sound"
+    },
+    "b-corsar.bin": {
+      "filename": "b-corsar.bin",
+      "type": "sound"
+    },
+    "0-corsar.bin": {
+      "filename": "0-corsar.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "e-corsar.bin": {
+      "filename": "e-corsar.bin",
+      "type": "sound"
+    },
+    "a-corsar.bin": {
+      "filename": "a-corsar.bin",
+      "type": "sound"
+    }
+  },
+  "hlywoodh": {
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    }
+  },
+  "clown": {
+    "clown_e.snd": {
+      "filename": "clown_e.snd",
+      "type": "sound"
+    },
+    "clown_1.lgc": {
+      "filename": "clown_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "clown_2.lgc": {
+      "filename": "clown_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "clown_f.snd": {
+      "filename": "clown_f.snd",
+      "type": "sound"
+    }
+  },
+  "clownfp": {
+    "clown_e.snd": {
+      "filename": "clown_e.snd",
+      "type": "sound"
+    },
+    "clownfp.ic2": {
+      "filename": "clownfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "clownfp.ic1": {
+      "filename": "clownfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "clown_f.snd": {
+      "filename": "clown_f.snd",
+      "type": "sound"
+    }
+  },
+  "rvrbt_l3": {
+    "gamb_u19.l1": {
+      "filename": "gamb_u19.l1",
+      "type": "sound"
+    },
+    "gamb_u27.l3": {
+      "filename": "gamb_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gamb_u20.l1": {
+      "filename": "gamb_u20.l1",
+      "type": "sound"
+    },
+    "gamb_u26.l3": {
+      "filename": "gamb_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gamb_u4.l2": {
+      "filename": "gamb_u4.l2",
+      "type": "sound"
+    }
+  },
+  "rvrbt_p7": {
+    "gamb_u19.l1": {
+      "filename": "gamb_u19.l1",
+      "type": "sound"
+    },
+    "gamb_u26.pa7": {
+      "filename": "gamb_u26.pa7",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gamb_u27.pa7": {
+      "filename": "gamb_u27.pa7",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gamb_u20.l1": {
+      "filename": "gamb_u20.l1",
+      "type": "sound"
+    },
+    "gamb_u4.l2": {
+      "filename": "gamb_u4.l2",
+      "type": "sound"
+    }
+  },
+  "jupk_501": {
+    "jpdspa.501": {
+      "filename": "jpdspa.501",
+      "type": "dmd"
+    },
+    "jpu17.dat": {
+      "filename": "jpu17.dat",
+      "type": "sound"
+    },
+    "jpu21.dat": {
+      "filename": "jpu21.dat",
+      "type": "sound"
+    },
+    "jpcpua.501": {
+      "filename": "jpcpua.501",
+      "type": "main",
+      "romType": "de"
+    },
+    "jpu7.dat": {
+      "filename": "jpu7.dat",
+      "type": "sound"
+    }
+  },
+  "strapids": {
+    "rapids_2.lgc": {
+      "filename": "rapids_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rapids_5.lgc": {
+      "filename": "rapids_5.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rapids_1.lgc": {
+      "filename": "rapids_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rapids_4.lgc": {
+      "filename": "rapids_4.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rapids_3.lgc": {
+      "filename": "rapids_3.lgc",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "dvlrdifp": {
+    "dride_it.1g": {
+      "filename": "dride_it.1g",
+      "type": "sound"
+    },
+    "driders.ic2": {
+      "filename": "driders.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "dride_it.1e": {
+      "filename": "dride_it.1e",
+      "type": "sound"
+    },
+    "dride_it.1d": {
+      "filename": "dride_it.1d",
+      "type": "sound"
+    },
+    "driders.ic1": {
+      "filename": "driders.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "dvlridei": {
+    "dride_it.1g": {
+      "filename": "dride_it.1g",
+      "type": "sound"
+    },
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "cpu.ic1": {
+      "filename": "cpu.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "dride_it.1e": {
+      "filename": "dride_it.1e",
+      "type": "sound"
+    },
+    "dride_it.1d": {
+      "filename": "dride_it.1d",
+      "type": "sound"
+    }
+  },
+  "bbnny_l2": {
+    "bugs_u4.l2": {
+      "filename": "bugs_u4.l2",
+      "type": "sound"
+    },
+    "bugs_u20.l1": {
+      "filename": "bugs_u20.l1",
+      "type": "sound"
+    },
+    "bugs_u27.l2": {
+      "filename": "bugs_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bugs_u19.l1": {
+      "filename": "bugs_u19.l1",
+      "type": "sound"
+    },
+    "bugs_u26.l2": {
+      "filename": "bugs_u26.l2",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "bbnny_lu": {
+    "bugs_u4.l2": {
+      "filename": "bugs_u4.l2",
+      "type": "sound"
+    },
+    "bugs_u20.l1": {
+      "filename": "bugs_u20.l1",
+      "type": "sound"
+    },
+    "bugs_u19.l1": {
+      "filename": "bugs_u19.l1",
+      "type": "sound"
+    },
+    "u27-lu2.rom": {
+      "filename": "u27-lu2.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bugs_u26.l2": {
+      "filename": "bugs_u26.l2",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "pool_l5": {
+    "pool_u4.l2": {
+      "filename": "pool_u4.l2",
+      "type": "sound"
+    },
+    "pool_u19.l2": {
+      "filename": "pool_u19.l2",
+      "type": "sound"
+    },
+    "pool_u27.l5": {
+      "filename": "pool_u27.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pool_u26.l5": {
+      "filename": "pool_u26.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pool_u20.l2": {
+      "filename": "pool_u20.l2",
+      "type": "sound"
+    }
+  },
+  "pool_l6": {
+    "pool_u4.l2": {
+      "filename": "pool_u4.l2",
+      "type": "sound"
+    },
+    "pool_u19.l2": {
+      "filename": "pool_u19.l2",
+      "type": "sound"
+    },
+    "pool_u27.la6": {
+      "filename": "POOL_U27.LA6",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pool_u20.l2": {
+      "filename": "pool_u20.l2",
+      "type": "sound"
+    },
+    "pool_u26.la6": {
+      "filename": "POOL_U26.LA6",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "pool_l7": {
+    "pool_u4.l2": {
+      "filename": "pool_u4.l2",
+      "type": "sound"
+    },
+    "pool_u19.l2": {
+      "filename": "pool_u19.l2",
+      "type": "sound"
+    },
+    "pool_u27.l7": {
+      "filename": "pool_u27.l7",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pool_u20.l2": {
+      "filename": "pool_u20.l2",
+      "type": "sound"
+    },
+    "pool_u26.l7": {
+      "filename": "pool_u26.l7",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "pool_le2": {
+    "pool_u4.l2": {
+      "filename": "pool_u4.l2",
+      "type": "sound"
+    },
+    "pool_u19.l2": {
+      "filename": "pool_u19.l2",
+      "type": "sound"
+    },
+    "pool_u26.le2": {
+      "filename": "POOL_U26.LE2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pool_u27.le2": {
+      "filename": "POOL_U27.LE2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pool_u20.l2": {
+      "filename": "pool_u20.l2",
+      "type": "sound"
+    }
+  },
+  "pool_p7": {
+    "pool_u4.l2": {
+      "filename": "pool_u4.l2",
+      "type": "sound"
+    },
+    "pool_u19.l2": {
+      "filename": "pool_u19.l2",
+      "type": "sound"
+    },
+    "pool_u26.pa7": {
+      "filename": "POOL_U26.PA7",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pool_u20.l2": {
+      "filename": "pool_u20.l2",
+      "type": "sound"
+    },
+    "pool_u27.pa7": {
+      "filename": "POOL_U27.PA7",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "farfallg": {
+    "farf_de.1g": {
+      "filename": "farf_de.1g",
+      "type": "sound"
+    },
+    "farf_de.1d": {
+      "filename": "farf_de.1d",
+      "type": "sound"
+    },
+    "cpurom2.bin": {
+      "filename": "cpurom2.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rom2.snd": {
+      "filename": "rom2.snd",
+      "type": "sound"
+    },
+    "cpurom1.bin": {
+      "filename": "cpurom1.bin",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "farfgfp": {
+    "farf_de.1g": {
+      "filename": "farf_de.1g",
+      "type": "sound"
+    },
+    "farffp.ic1": {
+      "filename": "farffp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "farf_de.1d": {
+      "filename": "farf_de.1d",
+      "type": "sound"
+    },
+    "farffp.ic2": {
+      "filename": "farffp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rom2.snd": {
+      "filename": "rom2.snd",
+      "type": "sound"
+    }
+  },
+  "redbaron": {
+    "redbaron.r2": {
+      "filename": "redbaron.r2",
+      "type": "main"
+    },
+    "rbsnd2.732": {
+      "filename": "rbsnd2.732",
+      "type": "main"
+    },
+    "redbaron.r3": {
+      "filename": "redbaron.r3",
+      "type": "main"
+    },
+    "rbsnd1.732": {
+      "filename": "rbsnd1.732",
+      "type": "main"
+    },
+    "rbsnd3.732": {
+      "filename": "rbsnd3.732",
+      "type": "main"
+    },
+    "redbaron.r1": {
+      "filename": "redbaron.r1",
+      "type": "main"
+    },
+    "rbsnd4.732": {
+      "filename": "rbsnd4.732",
+      "type": "main"
+    }
+  },
+  "quicksfp": {
+    "fpqs_u6.716": {
+      "filename": "fpqs_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "atleta": {
+    "atletaa.snd": {
+      "filename": "ATLETAA.SND",
+      "type": "sound"
+    },
+    "atleta1.cpu": {
+      "filename": "ATLETA1.CPU",
+      "type": "main",
+      "romType": "inder"
+    },
+    "atletae.snd": {
+      "filename": "ATLETAE.SND",
+      "type": "sound"
+    },
+    "atletac.snd": {
+      "filename": "ATLETAC.SND",
+      "type": "sound"
+    },
+    "atleta0.cpu": {
+      "filename": "ATLETA0.CPU",
+      "type": "main",
+      "romType": "inder"
+    },
+    "atletad.snd": {
+      "filename": "ATLETAD.SND",
+      "type": "sound"
+    },
+    "atletab.snd": {
+      "filename": "ATLETAB.SND",
+      "type": "sound"
+    }
+  },
+  "genesis": {
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "bonebstr": {
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "drom2.snd": {
+      "filename": "drom2.snd",
+      "type": "sound"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    }
+  },
+  "bsb105": {
+    "bsu1l_b1.05": {
+      "filename": "bsu1l_b1.05",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "bsu28_b1.2": {
+      "filename": "bsu28_b1.2",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "bsu1h_b1.05": {
+      "filename": "bsu1h_b1.05",
+      "type": "main",
+      "romType": "capcom"
+    }
+  },
+  "sman_160": {
+    "spd_1-6_e.bin": {
+      "filename": "spd_1-6_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fire_l2": {
+    "fire_u26.l2": {
+      "filename": "fire_u26.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "fire_u4.l1": {
+      "filename": "fire_u4.l1",
+      "type": "sound"
+    },
+    "fire_u22.l2": {
+      "filename": "fire_u22.l2",
+      "type": "sound"
+    },
+    "fire_u21.l2": {
+      "filename": "fire_u21.l2",
+      "type": "sound"
+    },
+    "fire_u27.l2": {
+      "filename": "fire_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "ij_l3": {
+    "ijone_l3.rom": {
+      "filename": "ijone_l3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ijsnd_l3.u4": {
+      "filename": "ijsnd_l3.u4",
+      "type": "sound"
+    },
+    "ijsnd_l3.u7": {
+      "filename": "ijsnd_l3.u7",
+      "type": "sound"
+    },
+    "ijsnd_l3.u3": {
+      "filename": "ijsnd_l3.u3",
+      "type": "sound"
+    },
+    "ijsnd_l3.u8": {
+      "filename": "ijsnd_l3.u8",
+      "type": "sound"
+    },
+    "ijsnd_l1.u2": {
+      "filename": "ijsnd_l1.u2",
+      "type": "sound"
+    },
+    "ijsnd_l3.u6": {
+      "filename": "ijsnd_l3.u6",
+      "type": "sound"
+    },
+    "ijsnd_l3.u5": {
+      "filename": "ijsnd_l3.u5",
+      "type": "sound"
+    }
+  },
+  "seawitfp": {
+    "fpsw_u1.716": {
+      "filename": "fpsw_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpsw_u5.716": {
+      "filename": "fpsw_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "trailer": {
+    "trsndu3.rom": {
+      "filename": "TRSNDU3.ROM",
+      "type": "sound"
+    },
+    "trsndu4.rom": {
+      "filename": "TRSNDU4.ROM",
+      "type": "sound"
+    },
+    "trcpu.rom": {
+      "filename": "trcpu.rom",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "solar_l2": {
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "sprk_090": {
+    "spku17.090": {
+      "filename": "spku17.090",
+      "type": "sound"
+    },
+    "spku37.090": {
+      "filename": "spku37.090",
+      "type": "sound"
+    },
+    "spku7.090": {
+      "filename": "spku7.090",
+      "type": "sound"
+    },
+    "spdspa.101": {
+      "filename": "spdspa.101",
+      "type": "dmd"
+    },
+    "spku36.090": {
+      "filename": "spku36.090",
+      "type": "sound"
+    },
+    "spkcpu.090": {
+      "filename": "spkcpu.090",
+      "type": "main",
+      "romType": "se"
+    },
+    "spku21.090": {
+      "filename": "spku21.090",
+      "type": "sound"
+    }
+  },
+  "sprk_096": {
+    "spku17.090": {
+      "filename": "spku17.090",
+      "type": "sound"
+    },
+    "spku37.090": {
+      "filename": "spku37.090",
+      "type": "sound"
+    },
+    "spku7.090": {
+      "filename": "spku7.090",
+      "type": "sound"
+    },
+    "spdspa.101": {
+      "filename": "spdspa.101",
+      "type": "dmd"
+    },
+    "spkcpu.096": {
+      "filename": "spkcpu.096",
+      "type": "main",
+      "romType": "se"
+    },
+    "spku36.090": {
+      "filename": "spku36.090",
+      "type": "sound"
+    },
+    "spku21.090": {
+      "filename": "spku21.090",
+      "type": "sound"
+    }
+  },
+  "ij_h1": {
+    "ijsnd_l3.u4": {
+      "filename": "ijsnd_l3.u4",
+      "type": "sound"
+    },
+    "ijsnd_l3.u7": {
+      "filename": "ijsnd_l3.u7",
+      "type": "sound"
+    },
+    "ijsnd_l3.u3": {
+      "filename": "ijsnd_l3.u3",
+      "type": "sound"
+    },
+    "ijsnd_l3.u8": {
+      "filename": "ijsnd_l3.u8",
+      "type": "sound"
+    },
+    "ijone_h1.rom": {
+      "filename": "ijone_h1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ijsnd_l3.u6": {
+      "filename": "ijsnd_l3.u6",
+      "type": "sound"
+    },
+    "ijsnd_l3.u5": {
+      "filename": "ijsnd_l3.u5",
+      "type": "sound"
+    },
+    "ijsnd_l3.u2": {
+      "filename": "ijsnd_l3.u2",
+      "type": "sound"
+    }
+  },
+  "ij_l4": {
+    "ijsnd_l3.u4": {
+      "filename": "ijsnd_l3.u4",
+      "type": "sound"
+    },
+    "ijsnd_l3.u7": {
+      "filename": "ijsnd_l3.u7",
+      "type": "sound"
+    },
+    "ijsnd_l3.u3": {
+      "filename": "ijsnd_l3.u3",
+      "type": "sound"
+    },
+    "ijsnd_l3.u8": {
+      "filename": "ijsnd_l3.u8",
+      "type": "sound"
+    },
+    "ijsnd_l2.u2": {
+      "filename": "ijsnd_l2.u2",
+      "type": "sound"
+    },
+    "ij_l4.u6": {
+      "filename": "ij_l4.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ijsnd_l3.u6": {
+      "filename": "ijsnd_l3.u6",
+      "type": "sound"
+    },
+    "ijsnd_l3.u5": {
+      "filename": "ijsnd_l3.u5",
+      "type": "sound"
+    }
+  },
+  "ij_l5": {
+    "ijsnd_l3.u4": {
+      "filename": "ijsnd_l3.u4",
+      "type": "sound"
+    },
+    "ijsnd_l3.u7": {
+      "filename": "ijsnd_l3.u7",
+      "type": "sound"
+    },
+    "ijsnd_l3.u3": {
+      "filename": "ijsnd_l3.u3",
+      "type": "sound"
+    },
+    "ijsnd_l3.u8": {
+      "filename": "ijsnd_l3.u8",
+      "type": "sound"
+    },
+    "ijsnd_l2.u2": {
+      "filename": "ijsnd_l2.u2",
+      "type": "sound"
+    },
+    "ijsnd_l3.u6": {
+      "filename": "ijsnd_l3.u6",
+      "type": "sound"
+    },
+    "ijone_l5.rom": {
+      "filename": "ijone_l5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ijsnd_l3.u5": {
+      "filename": "ijsnd_l3.u5",
+      "type": "sound"
+    }
+  },
+  "ij_l6": {
+    "ijsnd_l3.u4": {
+      "filename": "ijsnd_l3.u4",
+      "type": "sound"
+    },
+    "ijsnd_l3.u7": {
+      "filename": "ijsnd_l3.u7",
+      "type": "sound"
+    },
+    "ijsnd_l3.u3": {
+      "filename": "ijsnd_l3.u3",
+      "type": "sound"
+    },
+    "ijsnd_l3.u8": {
+      "filename": "ijsnd_l3.u8",
+      "type": "sound"
+    },
+    "ijone_l6.rom": {
+      "filename": "ijone_l6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ijsnd_l3.u6": {
+      "filename": "ijsnd_l3.u6",
+      "type": "sound"
+    },
+    "ijsnd_l3.u5": {
+      "filename": "ijsnd_l3.u5",
+      "type": "sound"
+    },
+    "ijsnd_l3.u2": {
+      "filename": "ijsnd_l3.u2",
+      "type": "sound"
+    }
+  },
+  "ij_l7": {
+    "ijsnd_l3.u4": {
+      "filename": "ijsnd_l3.u4",
+      "type": "sound"
+    },
+    "ijsnd_l3.u7": {
+      "filename": "ijsnd_l3.u7",
+      "type": "sound"
+    },
+    "ijsnd_l3.u3": {
+      "filename": "ijsnd_l3.u3",
+      "type": "sound"
+    },
+    "ijsnd_l3.u8": {
+      "filename": "ijsnd_l3.u8",
+      "type": "sound"
+    },
+    "ijone_l7.rom": {
+      "filename": "ijone_l7.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ijsnd_l3.u6": {
+      "filename": "ijsnd_l3.u6",
+      "type": "sound"
+    },
+    "ijsnd_l3.u5": {
+      "filename": "ijsnd_l3.u5",
+      "type": "sound"
+    },
+    "ijsnd_l3.u2": {
+      "filename": "ijsnd_l3.u2",
+      "type": "sound"
+    }
+  },
+  "ij_lg7": {
+    "ijsnd_l3.u4": {
+      "filename": "ijsnd_l3.u4",
+      "type": "sound"
+    },
+    "ijsnd_l3.u7": {
+      "filename": "ijsnd_l3.u7",
+      "type": "sound"
+    },
+    "ijsnd_l3.u3": {
+      "filename": "ijsnd_l3.u3",
+      "type": "sound"
+    },
+    "ijsnd_l3.u8": {
+      "filename": "ijsnd_l3.u8",
+      "type": "sound"
+    },
+    "ijsnd_l3.u6": {
+      "filename": "ijsnd_l3.u6",
+      "type": "sound"
+    },
+    "u6-lg7.rom": {
+      "filename": "u6-lg7.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ijsnd_l3.u5": {
+      "filename": "ijsnd_l3.u5",
+      "type": "sound"
+    },
+    "ijsnd_l3.u2": {
+      "filename": "ijsnd_l3.u2",
+      "type": "sound"
+    }
+  },
+  "ij_p2": {
+    "ijsnd_l3.u4": {
+      "filename": "ijsnd_l3.u4",
+      "type": "sound"
+    },
+    "ijone_p2.rom": {
+      "filename": "ijone_p2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ijsnd_l3.u7": {
+      "filename": "ijsnd_l3.u7",
+      "type": "sound"
+    },
+    "ijsnd_l3.u3": {
+      "filename": "ijsnd_l3.u3",
+      "type": "sound"
+    },
+    "ijsnd_l3.u8": {
+      "filename": "ijsnd_l3.u8",
+      "type": "sound"
+    },
+    "ijsnd_l1.u2": {
+      "filename": "ijsnd_l1.u2",
+      "type": "sound"
+    },
+    "ijsnd_l3.u6": {
+      "filename": "ijsnd_l3.u6",
+      "type": "sound"
+    },
+    "ijsnd_l3.u5": {
+      "filename": "ijsnd_l3.u5",
+      "type": "sound"
+    }
+  },
+  "aavenger": {
+    "airborne.e00": {
+      "filename": "airborne.e00",
+      "type": "main",
+      "romType": "atari"
+    },
+    "airborne.e0": {
+      "filename": "airborne.e0",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "radcl_g1": {
+    "rad_u20.l1": {
+      "filename": "rad_u20.l1",
+      "type": "sound"
+    },
+    "u27-lg1.rom": {
+      "filename": "u27-lg1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rad_u4.l1": {
+      "filename": "rad_u4.l1",
+      "type": "sound"
+    },
+    "rad_u19.l1": {
+      "filename": "rad_u19.l1",
+      "type": "sound"
+    },
+    "rad_u26.l1": {
+      "filename": "rad_u26.l1",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "radcl_l1": {
+    "rad_u20.l1": {
+      "filename": "rad_u20.l1",
+      "type": "sound"
+    },
+    "rad_u4.l1": {
+      "filename": "rad_u4.l1",
+      "type": "sound"
+    },
+    "rad_u27.l1": {
+      "filename": "rad_u27.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rad_u19.l1": {
+      "filename": "rad_u19.l1",
+      "type": "sound"
+    },
+    "rad_u26.l1": {
+      "filename": "rad_u26.l1",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "rct400": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.400": {
+      "filename": "rctcpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdisp-a.400": {
+      "filename": "rctdisp-a.400",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct400f": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.400": {
+      "filename": "rctcpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "rctdisp-f.400": {
+      "filename": "rctdisp-f.400",
+      "type": "dmd"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct400g": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.400": {
+      "filename": "rctcpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdisp-g.400": {
+      "filename": "rctdisp-g.400",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct400i": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.400": {
+      "filename": "rctcpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdisp-i.400": {
+      "filename": "rctdisp-i.400",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct400l": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.400": {
+      "filename": "rctcpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdisp-s.400": {
+      "filename": "rctdisp-s.400",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct600": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.600": {
+      "filename": "rctcpu.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdispa.600": {
+      "filename": "rctdispa.600",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct600f": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.600": {
+      "filename": "rctcpu.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "rctdispf.600": {
+      "filename": "rctdispf.600",
+      "type": "dmd"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct600i": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.600": {
+      "filename": "rctcpu.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdispi.600": {
+      "filename": "rctdispi.600",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct600l": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.600": {
+      "filename": "rctcpu.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdisps.600": {
+      "filename": "rctdisps.600",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct701": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdispa.700": {
+      "filename": "rctdispa.700",
+      "type": "dmd"
+    },
+    "rctcpu.701": {
+      "filename": "rctcpu.701",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct701f": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctdispf.700": {
+      "filename": "rctdispf.700",
+      "type": "dmd"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctcpu.701": {
+      "filename": "rctcpu.701",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct701g": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rctdispg.700": {
+      "filename": "rctdispg.700",
+      "type": "dmd"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctcpu.701": {
+      "filename": "rctcpu.701",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct701i": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rctdispi.700": {
+      "filename": "rctdispi.700",
+      "type": "dmd"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctcpu.701": {
+      "filename": "rctcpu.701",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rct701l": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdisps.700": {
+      "filename": "rctdisps.700",
+      "type": "dmd"
+    },
+    "rctcpu.701": {
+      "filename": "rctcpu.701",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rctycn": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rctdispa.701": {
+      "filename": "rctdispa.701",
+      "type": "dmd"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.702": {
+      "filename": "rctcpu.702",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rctycnf": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctdispf.701": {
+      "filename": "rctdispf.701",
+      "type": "dmd"
+    },
+    "rctcpu.702": {
+      "filename": "rctcpu.702",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rctycng": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.702": {
+      "filename": "rctcpu.702",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdispg.701": {
+      "filename": "rctdispg.701",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rctycni": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.702": {
+      "filename": "rctcpu.702",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rctdispi.701": {
+      "filename": "rctdispi.701",
+      "type": "dmd"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "rctycnl": {
+    "rcsndu36.100": {
+      "filename": "rcsndu36.100",
+      "type": "sound"
+    },
+    "rctdisps.701": {
+      "filename": "rctdisps.701",
+      "type": "dmd"
+    },
+    "rcsndu17.100": {
+      "filename": "rcsndu17.100",
+      "type": "sound"
+    },
+    "rctcpu.702": {
+      "filename": "rctcpu.702",
+      "type": "main",
+      "romType": "se"
+    },
+    "rcsndu21.100": {
+      "filename": "rcsndu21.100",
+      "type": "sound"
+    },
+    "rcsndu7.100": {
+      "filename": "rcsndu7.100",
+      "type": "sound"
+    }
+  },
+  "lotr_i41": {
+    "lotrdspi.404": {
+      "filename": "lotrdspi.404",
+      "type": "dmd"
+    },
+    "lotrcpu.410": {
+      "filename": "lotrcpu.410",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "krull": {
+    "676-s2.snd": {
+      "filename": "676-s2.snd",
+      "type": "sound"
+    },
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "676-3.cpu": {
+      "filename": "676-3.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "676-s1.snd": {
+      "filename": "676-s1.snd",
+      "type": "sound"
+    }
+  },
+  "hypbl_l2": {
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14-l2.532": {
+      "filename": "ic14-l2.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20-l2.532": {
+      "filename": "ic20-l2.532",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "hypbl_l4": {
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.532": {
+      "filename": "ic14.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.532": {
+      "filename": "ic20.532",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "hypbl_l5": {
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    },
+    "ic20_fix.532": {
+      "filename": "ic20_fix.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.532": {
+      "filename": "ic14.532",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "hypbl_l6": {
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.532": {
+      "filename": "ic14.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20_l6.532": {
+      "filename": "ic20_l6.532",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "cybrnaua": {
+    "cybe2732.u2": {
+      "filename": "cybe2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "cybu3.snd": {
+      "filename": "cybu3.snd",
+      "type": "sound"
+    }
+  },
+  "cybrnaut": {
+    "cybe2732.u2": {
+      "filename": "cybe2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "cybu3.snd": {
+      "filename": "cybu3.snd",
+      "type": "sound"
+    },
+    "720-5332.u6": {
+      "filename": "720-5332.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "teedoff": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "macattck": {
+    "vid_ic16.rom": {
+      "filename": "vid_ic16.rom",
+      "type": "dmd"
+    },
+    "vid_ic15.rom": {
+      "filename": "vid_ic15.rom",
+      "type": "dmd"
+    },
+    "vid_ic91.rom": {
+      "filename": "vid_ic91.rom",
+      "type": "dmd"
+    },
+    "vid_ic61.rom": {
+      "filename": "vid_ic61.rom",
+      "type": "dmd"
+    },
+    "vid_ic18.rom": {
+      "filename": "vid_ic18.rom",
+      "type": "dmd"
+    },
+    "vid_ic17.rom": {
+      "filename": "vid_ic17.rom",
+      "type": "dmd"
+    },
+    "vid_ic14.rom": {
+      "filename": "vid_ic14.rom",
+      "type": "dmd"
+    }
+  },
+  "gpr301l": {
+    "gpsndl.u7": {
+      "filename": "gpsndl.u7",
+      "type": "sound"
+    },
+    "gpsndl.u17": {
+      "filename": "gpsndl.u17",
+      "type": "sound"
+    },
+    "gpdspl.301": {
+      "filename": "gpdspl.301",
+      "type": "dmd"
+    },
+    "gpsndl.u36": {
+      "filename": "gpsndl.u36",
+      "type": "sound"
+    },
+    "gpcpul.301": {
+      "filename": "gpcpul.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndl.u37": {
+      "filename": "gpsndl.u37",
+      "type": "sound"
+    },
+    "gpsndl.u21": {
+      "filename": "gpsndl.u21",
+      "type": "sound"
+    }
+  },
+  "gpr340l": {
+    "gpsndl.u7": {
+      "filename": "gpsndl.u7",
+      "type": "sound"
+    },
+    "gpsndl.u17": {
+      "filename": "gpsndl.u17",
+      "type": "sound"
+    },
+    "gpcpul.340": {
+      "filename": "gpcpul.340",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpdspl.303": {
+      "filename": "gpdspl.303",
+      "type": "dmd"
+    },
+    "gpsndl.u36": {
+      "filename": "gpsndl.u36",
+      "type": "sound"
+    },
+    "gpsndl.u37": {
+      "filename": "gpsndl.u37",
+      "type": "sound"
+    },
+    "gpsndl.u21": {
+      "filename": "gpsndl.u21",
+      "type": "sound"
+    }
+  },
+  "gpr350l": {
+    "gpsndl.u7": {
+      "filename": "gpsndl.u7",
+      "type": "sound"
+    },
+    "gpsndl.u17": {
+      "filename": "gpsndl.u17",
+      "type": "sound"
+    },
+    "gpcpul.350": {
+      "filename": "gpcpul.350",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpdspl.303": {
+      "filename": "gpdspl.303",
+      "type": "dmd"
+    },
+    "gpsndl.u36": {
+      "filename": "gpsndl.u36",
+      "type": "sound"
+    },
+    "gpsndl.u37": {
+      "filename": "gpsndl.u37",
+      "type": "sound"
+    },
+    "gpsndl.u21": {
+      "filename": "gpsndl.u21",
+      "type": "sound"
+    }
+  },
+  "gpr352l": {
+    "gpsndl.u7": {
+      "filename": "gpsndl.u7",
+      "type": "sound"
+    },
+    "gpsndl.u17": {
+      "filename": "gpsndl.u17",
+      "type": "sound"
+    },
+    "gpdspl.303": {
+      "filename": "gpdspl.303",
+      "type": "dmd"
+    },
+    "gpsndl.u36": {
+      "filename": "gpsndl.u36",
+      "type": "sound"
+    },
+    "gpcpul.352": {
+      "filename": "gpcpul.352",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndl.u37": {
+      "filename": "gpsndl.u37",
+      "type": "sound"
+    },
+    "gpsndl.u21": {
+      "filename": "gpsndl.u21",
+      "type": "sound"
+    }
+  },
+  "gpr400l": {
+    "gpsndl.u7": {
+      "filename": "gpsndl.u7",
+      "type": "sound"
+    },
+    "gpsndl.u17": {
+      "filename": "gpsndl.u17",
+      "type": "sound"
+    },
+    "gpdspl.400": {
+      "filename": "gpdspl.400",
+      "type": "dmd"
+    },
+    "gpsndl.u36": {
+      "filename": "gpsndl.u36",
+      "type": "sound"
+    },
+    "gpcpul.400": {
+      "filename": "gpcpul.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndl.u37": {
+      "filename": "gpsndl.u37",
+      "type": "sound"
+    },
+    "gpsndl.u21": {
+      "filename": "gpsndl.u21",
+      "type": "sound"
+    }
+  },
+  "gprixl": {
+    "gpsndl.u7": {
+      "filename": "gpsndl.u7",
+      "type": "sound"
+    },
+    "gpsndl.u17": {
+      "filename": "gpsndl.u17",
+      "type": "sound"
+    },
+    "gpdspl.400": {
+      "filename": "gpdspl.400",
+      "type": "dmd"
+    },
+    "gpcpul.450": {
+      "filename": "gpcpul.450",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndl.u36": {
+      "filename": "gpsndl.u36",
+      "type": "sound"
+    },
+    "gpsndl.u37": {
+      "filename": "gpsndl.u37",
+      "type": "sound"
+    },
+    "gpsndl.u21": {
+      "filename": "gpsndl.u21",
+      "type": "sound"
+    }
+  },
+  "monoi251": {
+    "moncpu.251": {
+      "filename": "moncpu.251",
+      "type": "main",
+      "romType": "se"
+    },
+    "mondsp-i.206": {
+      "filename": "mondsp-i.206",
+      "type": "dmd"
+    },
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "monop251": {
+    "moncpu.251": {
+      "filename": "moncpu.251",
+      "type": "main",
+      "romType": "se"
+    },
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "mondsp-a.206": {
+      "filename": "mondsp-a.206",
+      "type": "dmd"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "term3f": {
+    "t3dispf.400": {
+      "filename": "t3dispf.400",
+      "type": "dmd"
+    },
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3cpu.400": {
+      "filename": "t3cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "whirl_g3": {
+    "whir_u26.l3": {
+      "filename": "whir_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "whir_u4.l1": {
+      "filename": "whir_u4.l1",
+      "type": "sound"
+    },
+    "whir_u20.l1": {
+      "filename": "whir_u20.l1",
+      "type": "sound"
+    },
+    "whir_u27.lg3": {
+      "filename": "WHIR_U27.LG3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "whir_u19.l1": {
+      "filename": "whir_u19.l1",
+      "type": "sound"
+    },
+    "whir_u21.l1": {
+      "filename": "whir_u21.l1",
+      "type": "sound"
+    },
+    "whir_u22.l1": {
+      "filename": "whir_u22.l1",
+      "type": "sound"
+    }
+  },
+  "whirl_l2": {
+    "whir_u26.l3": {
+      "filename": "whir_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "whir_u4.l1": {
+      "filename": "whir_u4.l1",
+      "type": "sound"
+    },
+    "whir_u20.l1": {
+      "filename": "whir_u20.l1",
+      "type": "sound"
+    },
+    "whir_u19.l1": {
+      "filename": "whir_u19.l1",
+      "type": "sound"
+    },
+    "wwdgu27.l2": {
+      "filename": "wwdgu27.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "whir_u21.l1": {
+      "filename": "whir_u21.l1",
+      "type": "sound"
+    },
+    "whir_u22.l1": {
+      "filename": "whir_u22.l1",
+      "type": "sound"
+    }
+  },
+  "whirl_l3": {
+    "whir_u26.l3": {
+      "filename": "whir_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "whir_u4.l1": {
+      "filename": "whir_u4.l1",
+      "type": "sound"
+    },
+    "whir_u27.l3": {
+      "filename": "whir_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "whir_u20.l1": {
+      "filename": "whir_u20.l1",
+      "type": "sound"
+    },
+    "whir_u19.l1": {
+      "filename": "whir_u19.l1",
+      "type": "sound"
+    },
+    "whir_u21.l1": {
+      "filename": "whir_u21.l1",
+      "type": "sound"
+    },
+    "whir_u22.l1": {
+      "filename": "whir_u22.l1",
+      "type": "sound"
+    }
+  },
+  "fs_lx5": {
+    "flin_lx5.rom": {
+      "filename": "flin_lx5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fs_u9_s.l1": {
+      "filename": "fs_u9_s.l1",
+      "type": "sound"
+    },
+    "fs_u6_s.l1": {
+      "filename": "fs_u6_s.l1",
+      "type": "sound"
+    },
+    "fs_u5_s.l1": {
+      "filename": "fs_u5_s.l1",
+      "type": "sound"
+    },
+    "fs_u4_s.l1": {
+      "filename": "fs_u4_s.l1",
+      "type": "sound"
+    },
+    "fs_u8_s.l1": {
+      "filename": "fs_u8_s.l1",
+      "type": "sound"
+    },
+    "fs_u2_s.l1": {
+      "filename": "fs_u2_s.l1",
+      "type": "sound"
+    },
+    "fs_u3_s.l1": {
+      "filename": "fs_u3_s.l1",
+      "type": "sound"
+    },
+    "fs_u7_s.l1": {
+      "filename": "fs_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "fs_sp2": {
+    "flin_lx5.rom": {
+      "filename": "flin_lx5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fs_u9_s.l1": {
+      "filename": "fs_u9_s.l1",
+      "type": "sound"
+    },
+    "fs_u6_s.l1": {
+      "filename": "fs_u6_s.l1",
+      "type": "sound"
+    },
+    "fs_u5_s.l1": {
+      "filename": "fs_u5_s.l1",
+      "type": "sound"
+    },
+    "su2-sp2.rom": {
+      "filename": "su2-sp2.rom",
+      "type": "sound"
+    },
+    "fs_u4_s.l1": {
+      "filename": "fs_u4_s.l1",
+      "type": "sound"
+    },
+    "fs_u8_s.l1": {
+      "filename": "fs_u8_s.l1",
+      "type": "sound"
+    },
+    "fs_u3_s.l1": {
+      "filename": "fs_u3_s.l1",
+      "type": "sound"
+    },
+    "fs_u7_s.l1": {
+      "filename": "fs_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "i500_10r": {
+    "su3": {
+      "filename": "su3",
+      "type": "sound"
+    },
+    "su4": {
+      "filename": "su4",
+      "type": "sound"
+    },
+    "su7": {
+      "filename": "su7",
+      "type": "sound"
+    },
+    "su6": {
+      "filename": "su6",
+      "type": "sound"
+    },
+    "su2": {
+      "filename": "su2",
+      "type": "sound"
+    },
+    "indy1_0r.rom": {
+      "filename": "indy1_0r.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "su5": {
+      "filename": "su5",
+      "type": "sound"
+    }
+  },
+  "i500_11b": {
+    "su3": {
+      "filename": "su3",
+      "type": "sound"
+    },
+    "su4": {
+      "filename": "su4",
+      "type": "sound"
+    },
+    "indy1_1b.rom": {
+      "filename": "indy1_1b.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "su7": {
+      "filename": "su7",
+      "type": "sound"
+    },
+    "su6": {
+      "filename": "su6",
+      "type": "sound"
+    },
+    "su2": {
+      "filename": "su2",
+      "type": "sound"
+    },
+    "su5": {
+      "filename": "su5",
+      "type": "sound"
+    }
+  },
+  "i500_11r": {
+    "su3": {
+      "filename": "su3",
+      "type": "sound"
+    },
+    "su4": {
+      "filename": "su4",
+      "type": "sound"
+    },
+    "su7": {
+      "filename": "su7",
+      "type": "sound"
+    },
+    "su6": {
+      "filename": "su6",
+      "type": "sound"
+    },
+    "su2": {
+      "filename": "su2",
+      "type": "sound"
+    },
+    "indy1_1r.rom": {
+      "filename": "indy1_1r.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "su5": {
+      "filename": "su5",
+      "type": "sound"
+    }
+  },
+  "cntinntl": {
+    "bingo.u44": {
+      "filename": "bingo.u44",
+      "type": "main"
+    },
+    "bingo.u37": {
+      "filename": "bingo.u37",
+      "type": "main"
+    },
+    "bingo.u40": {
+      "filename": "bingo.u40",
+      "type": "main"
+    },
+    "bingo.u48": {
+      "filename": "bingo.u48",
+      "type": "main"
+    }
+  },
+  "shock": {
+    "shock2.bin": {
+      "filename": "shock2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "shock_s1.bin": {
+      "filename": "shock_s1.bin",
+      "type": "sound"
+    },
+    "shock4.bin": {
+      "filename": "shock4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "shock1.bin": {
+      "filename": "shock1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "shock3.bin": {
+      "filename": "shock3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "shock_s2.bin": {
+      "filename": "shock_s2.bin",
+      "type": "sound"
+    }
+  },
+  "xsandos": {
+    "x&os2732.u2": {
+      "filename": "x&os2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "720_u3.snd": {
+      "filename": "720_u3.snd",
+      "type": "sound"
+    },
+    "720-5332.u6": {
+      "filename": "720-5332.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "xsandosa": {
+    "x&os2732.u2": {
+      "filename": "x&os2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "720_u3.snd": {
+      "filename": "720_u3.snd",
+      "type": "sound"
+    }
+  },
+  "rota_101": {
+    "v101-b.bin": {
+      "filename": "v101-b.bin",
+      "type": "main"
+    },
+    "v101-c.bin": {
+      "filename": "v101-c.bin",
+      "type": "main"
+    },
+    "v101-a.bin": {
+      "filename": "v101-a.bin",
+      "type": "main"
+    }
+  },
+  "wpt_109g": {
+    "wpt0109g.bin": {
+      "filename": "wpt0109g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sopr204": {
+    "sopsnd1.u37": {
+      "filename": "sopsnd1.u37",
+      "type": "sound"
+    },
+    "sopsnda.u17": {
+      "filename": "sopsnda.u17",
+      "type": "sound"
+    },
+    "sopsnd1.u21": {
+      "filename": "sopsnd1.u21",
+      "type": "sound"
+    },
+    "sopsnda.u7": {
+      "filename": "Sopsnda.u7",
+      "type": "sound"
+    },
+    "sopcpua.204": {
+      "filename": "sopcpua.204",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsnd1.u36": {
+      "filename": "sopsnd1.u36",
+      "type": "sound"
+    },
+    "sopdspa.200": {
+      "filename": "sopdspa.200",
+      "type": "dmd"
+    }
+  },
+  "soprano3": {
+    "sopsnda.u37": {
+      "filename": "sopsnda.u37",
+      "type": "sound"
+    },
+    "sopsnda.u17": {
+      "filename": "sopsnda.u17",
+      "type": "sound"
+    },
+    "sopsnda.u21": {
+      "filename": "sopsnda.u21",
+      "type": "sound"
+    },
+    "sopdspa.300": {
+      "filename": "Sopdspa.300",
+      "type": "dmd"
+    },
+    "sopsnda.u7": {
+      "filename": "Sopsnda.u7",
+      "type": "sound"
+    },
+    "sopcpua.300": {
+      "filename": "SOPCPUA.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsnda.u36": {
+      "filename": "sopsnda.u36",
+      "type": "sound"
+    }
+  },
+  "taf_l6": {
+    "taf_l6.u6": {
+      "filename": "taf_l6.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tafu18l1.rom": {
+      "filename": "tafu18l1.rom",
+      "type": "sound"
+    }
+  },
+  "striker": {
+    "675.cpu": {
+      "filename": "675.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "675-s1.snd": {
+      "filename": "675-s1.snd",
+      "type": "sound"
+    },
+    "675-s2.snd": {
+      "filename": "675-s2.snd",
+      "type": "sound"
+    }
+  },
+  "ninebalb": {
+    "nineball.256": {
+      "filename": "nineball.256",
+      "type": "main"
+    }
+  },
+  "tmacgfp": {
+    "tmach_de.1g": {
+      "filename": "tmach_de.1g",
+      "type": "sound"
+    },
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    },
+    "timemfp.ic2": {
+      "filename": "timemfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "timemfp.ic1": {
+      "filename": "timemfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "tmach_de.1d": {
+      "filename": "tmach_de.1d",
+      "type": "sound"
+    }
+  },
+  "tmacgzac": {
+    "tmach_de.1g": {
+      "filename": "tmach_de.1g",
+      "type": "sound"
+    },
+    "timemach.ic2": {
+      "filename": "timemach.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    },
+    "tmach_de.1d": {
+      "filename": "tmach_de.1d",
+      "type": "sound"
+    },
+    "timemach.ic1": {
+      "filename": "timemach.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "trek_110": {
+    "trekcpu.110": {
+      "filename": "trekcpu.110",
+      "type": "main",
+      "romType": "de"
+    },
+    "trek.u17": {
+      "filename": "trek.u17",
+      "type": "sound"
+    },
+    "trek.u21": {
+      "filename": "trek.u21",
+      "type": "sound"
+    },
+    "trekdsp.106": {
+      "filename": "trekdsp.106",
+      "type": "dmd"
+    },
+    "trek.u7": {
+      "filename": "trek.u7",
+      "type": "sound"
+    }
+  },
+  "trek_11a": {
+    "trekcpu.110": {
+      "filename": "trekcpu.110",
+      "type": "main",
+      "romType": "de"
+    },
+    "trek.u17": {
+      "filename": "trek.u17",
+      "type": "sound"
+    },
+    "trekadsp.bin": {
+      "filename": "trekadsp.bin",
+      "type": "dmd"
+    },
+    "trek.u21": {
+      "filename": "trek.u21",
+      "type": "sound"
+    },
+    "trek.u7": {
+      "filename": "trek.u7",
+      "type": "sound"
+    }
+  },
+  "msdisco": {
+    "1.bin": {
+      "filename": "1.bin",
+      "type": "main"
+    }
+  },
+  "cftbl_l3": {
+    "u18-sp1.rom": {
+      "filename": "u18-sp1.rom",
+      "type": "sound"
+    },
+    "cftbl_l3.u6": {
+      "filename": "cftbl_l3.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "bl_u15.l1": {
+      "filename": "bl_u15.l1",
+      "type": "sound"
+    },
+    "bl_u14.l1": {
+      "filename": "bl_u14.l1",
+      "type": "sound"
+    }
+  },
+  "cftbl_p3": {
+    "u18-sp1.rom": {
+      "filename": "u18-sp1.rom",
+      "type": "sound"
+    },
+    "bl_u15.l1": {
+      "filename": "bl_u15.l1",
+      "type": "sound"
+    },
+    "bl_u14.l1": {
+      "filename": "bl_u14.l1",
+      "type": "sound"
+    },
+    "cftbl_p3.u6": {
+      "filename": "cftbl_p3.u6",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "bikerac2": {
+    "bkcpu05.bin": {
+      "filename": "bkcpu05.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "07.bin": {
+      "filename": "07.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bkdsp01.bin": {
+      "filename": "bkdsp01.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bkcpu06.bin": {
+      "filename": "bkcpu06.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "04.bin": {
+      "filename": "04.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bksnd03.bin": {
+      "filename": "bksnd03.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bksnd02.bin": {
+      "filename": "bksnd02.bin",
+      "type": "main",
+      "romType": "sleic"
+    }
+  },
+  "bikerace": {
+    "bkcpu05.bin": {
+      "filename": "bkcpu05.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bkdsp01.bin": {
+      "filename": "bkdsp01.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bkcpu06.bin": {
+      "filename": "bkcpu06.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bkio07.bin": {
+      "filename": "bkio07.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bksnd03.bin": {
+      "filename": "bksnd03.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bkcpu04.bin": {
+      "filename": "bkcpu04.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "bksnd02.bin": {
+      "filename": "bksnd02.bin",
+      "type": "main",
+      "romType": "sleic"
+    }
+  },
+  "simp204": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.204": {
+      "filename": "spp-cpu.204",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdispa.201": {
+      "filename": "sppdispa.201",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp204f": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.204": {
+      "filename": "spp-cpu.204",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdispf.201": {
+      "filename": "sppdispf.201",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp204i": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.204": {
+      "filename": "spp-cpu.204",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdispi.201": {
+      "filename": "sppdispi.201",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp204l": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.204": {
+      "filename": "spp-cpu.204",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdispl.201": {
+      "filename": "sppdispl.201",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp300": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "sppdspa.300": {
+      "filename": "sppdspa.300",
+      "type": "dmd"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "spp-cpu.300": {
+      "filename": "spp-cpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp300f": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspf.300": {
+      "filename": "sppdspf.300",
+      "type": "dmd"
+    },
+    "spp-cpu.300": {
+      "filename": "spp-cpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp300i": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "sppdspi.300": {
+      "filename": "sppdspi.300",
+      "type": "dmd"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "spp-cpu.300": {
+      "filename": "spp-cpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp300l": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspl.300": {
+      "filename": "sppdspl.300",
+      "type": "dmd"
+    },
+    "spp-cpu.300": {
+      "filename": "spp-cpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp400": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspa.400": {
+      "filename": "sppdspa.400",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp400f": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspf.400": {
+      "filename": "sppdspf.400",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp400g": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "sppdspg.400": {
+      "filename": "sppdspg.400",
+      "type": "dmd"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp400i": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspi.400": {
+      "filename": "sppdspi.400",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simp400l": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspl.400": {
+      "filename": "sppdspl.400",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simpprtf": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspf.400": {
+      "filename": "sppdspf.400",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simpprtg": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simpprti": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspi.400": {
+      "filename": "sppdspi.400",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simpprtl": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp-cpu.400": {
+      "filename": "spp-cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdspl.400": {
+      "filename": "sppdspl.400",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "simpprty": {
+    "spp100.u37": {
+      "filename": "spp100.u37",
+      "type": "sound"
+    },
+    "spp100.u21": {
+      "filename": "spp100.u21",
+      "type": "sound"
+    },
+    "spp-cpu.500": {
+      "filename": "spp-cpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "spp101.u7": {
+      "filename": "spp101.u7",
+      "type": "sound"
+    },
+    "spp100.u17": {
+      "filename": "spp100.u17",
+      "type": "sound"
+    },
+    "sppdispa.500": {
+      "filename": "sppdispa.500",
+      "type": "dmd"
+    },
+    "spp100.u36": {
+      "filename": "spp100.u36",
+      "type": "sound"
+    }
+  },
+  "fh_905h": {
+    "fh_u15.l2": {
+      "filename": "fh_u15.l2",
+      "type": "sound"
+    },
+    "fh_u14.l2": {
+      "filename": "fh_u14.l2",
+      "type": "sound"
+    },
+    "fh_905h.rom": {
+      "filename": "fh_905h.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fh_u18.sl3": {
+      "filename": "fh_u18.sl3",
+      "type": "sound"
+    }
+  },
+  "fh_906h": {
+    "fh_u15.l2": {
+      "filename": "fh_u15.l2",
+      "type": "sound"
+    },
+    "fh_906h.rom": {
+      "filename": "fh_906h.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fh_u14.l2": {
+      "filename": "fh_u14.l2",
+      "type": "sound"
+    },
+    "fh_u18.sl3": {
+      "filename": "fh_u18.sl3",
+      "type": "sound"
+    }
+  },
+  "fh_f91": {
+    "fh_u15.l2": {
+      "filename": "FH_U15.L2",
+      "type": "sound"
+    },
+    "fh_u14.l2": {
+      "filename": "FH_U14.L2",
+      "type": "sound"
+    },
+    "fh_u18.sl3": {
+      "filename": "fh_u18.sl3",
+      "type": "sound"
+    },
+    "ffh0_91.rom": {
+      "filename": "ffh0_91.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "fh_l2": {
+    "fh_u15.l2": {
+      "filename": "fh_u15.l2",
+      "type": "sound"
+    },
+    "fh_u18.sl2": {
+      "filename": "fh_u18.sl2",
+      "type": "sound"
+    },
+    "fh_u14.l2": {
+      "filename": "fh_u14.l2",
+      "type": "sound"
+    },
+    "u6-l2.rom": {
+      "filename": "u6-l2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "fh_l3": {
+    "fh_u15.l2": {
+      "filename": "fh_u15.l2",
+      "type": "sound"
+    },
+    "fh_u14.l2": {
+      "filename": "fh_u14.l2",
+      "type": "sound"
+    },
+    "u6-l3.rom": {
+      "filename": "u6-l3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fh_u18.l2m": {
+      "filename": "fh_u18.l2m",
+      "type": "sound"
+    }
+  },
+  "fh_l4": {
+    "fh_u15.l2": {
+      "filename": "fh_u15.l2",
+      "type": "sound"
+    },
+    "fh_u14.l2": {
+      "filename": "fh_u14.l2",
+      "type": "sound"
+    },
+    "fh_u18.l2m": {
+      "filename": "fh_u18.l2m",
+      "type": "sound"
+    },
+    "u6-l4.rom": {
+      "filename": "u6-l4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "fh_l5": {
+    "fh_u15.l2": {
+      "filename": "fh_u15.l2",
+      "type": "sound"
+    },
+    "fh_u14.l2": {
+      "filename": "fh_u14.l2",
+      "type": "sound"
+    },
+    "fh_u18.l2m": {
+      "filename": "fh_u18.l2m",
+      "type": "sound"
+    },
+    "u6-l5.rom": {
+      "filename": "u6-l5.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "fh_l9": {
+    "fh_u15.l2": {
+      "filename": "fh_u15.l2",
+      "type": "sound"
+    },
+    "fh_u14.l2": {
+      "filename": "fh_u14.l2",
+      "type": "sound"
+    },
+    "fh_u18.l2m": {
+      "filename": "fh_u18.l2m",
+      "type": "sound"
+    },
+    "funh_l9.rom": {
+      "filename": "funh_l9.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "fh_l9b": {
+    "fh_u15.l2": {
+      "filename": "fh_u15.l2",
+      "type": "sound"
+    },
+    "fh_u14.l2": {
+      "filename": "fh_u14.l2",
+      "type": "sound"
+    },
+    "fh_u18.l2m": {
+      "filename": "fh_u18.l2m",
+      "type": "sound"
+    },
+    "fh_l9ger.rom": {
+      "filename": "fh_l9ger.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "spaceinv": {
+    "792-10_1.716": {
+      "filename": "792-10_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "792-07_4.716": {
+      "filename": "792-07_4.716",
+      "type": "sound"
+    },
+    "792-13_2.716": {
+      "filename": "792-13_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-37_6.716": {
+      "filename": "720-37_6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "sshuttl1": {
+    "sshtl_s3.bin": {
+      "filename": "sshtl_s3.bin",
+      "type": "sound"
+    },
+    "sshtl4a.bin": {
+      "filename": "sshtl4a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "sshtl_s2.bin": {
+      "filename": "sshtl_s2.bin",
+      "type": "sound"
+    },
+    "sshtl_s1.bin": {
+      "filename": "sshtl_s1.bin",
+      "type": "sound"
+    },
+    "sshtl1.bin": {
+      "filename": "sshtl1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "sshtl3a.bin": {
+      "filename": "sshtl3a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "sshtl2.bin": {
+      "filename": "sshtl2.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "sshuttle": {
+    "sshtl_s3.bin": {
+      "filename": "sshtl_s3.bin",
+      "type": "sound"
+    },
+    "sshtl3.bin": {
+      "filename": "sshtl3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "sshtl4.bin": {
+      "filename": "sshtl4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "sshtl_s2.bin": {
+      "filename": "sshtl_s2.bin",
+      "type": "sound"
+    },
+    "sshtl_s1.bin": {
+      "filename": "sshtl_s1.bin",
+      "type": "sound"
+    },
+    "sshtl1.bin": {
+      "filename": "sshtl1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "sshtl2.bin": {
+      "filename": "sshtl2.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "fg_1200ag": {
+    "fg120ai.bin": {
+      "filename": "fg120ai.bin",
+      "type": "main",
+      "romType": "sam"
+    },
+    "fg120af.bin": {
+      "filename": "fg120af.bin",
+      "type": "main",
+      "romType": "sam"
+    },
+    "fg120al.bin": {
+      "filename": "fg120al.bin",
+      "type": "main",
+      "romType": "sam"
+    },
+    "fg120ag.bin": {
+      "filename": "FG120ag.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_1200ai": {
+    "fg120ai.bin": {
+      "filename": "fg120ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "kpv106": {
+    "u31_b18.bin": {
+      "filename": "u31_b18.bin",
+      "type": "sound"
+    },
+    "u29_b11.bin": {
+      "filename": "u29_b11.bin",
+      "type": "sound"
+    },
+    "u2hu2l.bin": {
+      "filename": "u2hu2l.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_b11.bin": {
+      "filename": "u28_b11.bin",
+      "type": "sound"
+    },
+    "u1hu1l.bin": {
+      "filename": "u1hu1l.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u30_b11.bin": {
+      "filename": "u30_b11.bin",
+      "type": "sound"
+    }
+  },
+  "bdk_200": {
+    "bat_v2-0_e.bin": {
+      "filename": "bat_v2-0_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bay_e400": {
+    "baycpua2.400": {
+      "filename": "baycpua2.400",
+      "type": "main",
+      "romType": "de"
+    },
+    "bw-u36.bin": {
+      "filename": "bw-u36.bin",
+      "type": "sound"
+    },
+    "bayrom3a.400": {
+      "filename": "bayrom3a.400",
+      "type": "dmd"
+    },
+    "bayrom0a.400": {
+      "filename": "bayrom0a.400",
+      "type": "dmd"
+    },
+    "bw-u21.bin": {
+      "filename": "bw-u21.bin",
+      "type": "sound"
+    },
+    "bw-u17.bin": {
+      "filename": "bw-u17.bin",
+      "type": "sound"
+    },
+    "bw-u7.bin": {
+      "filename": "bw-u7.bin",
+      "type": "sound"
+    }
+  },
+  "milln_l3": {
+    "mill_u26.l3": {
+      "filename": "mill_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "mill_u21.l1": {
+      "filename": "mill_u21.l1",
+      "type": "sound"
+    },
+    "mill_u22.l1": {
+      "filename": "mill_u22.l1",
+      "type": "sound"
+    },
+    "mill_u27.l3": {
+      "filename": "mill_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "mill_u4.l1": {
+      "filename": "mill_u4.l1",
+      "type": "sound"
+    },
+    "mill_u19.l1": {
+      "filename": "mill_u19.l1",
+      "type": "sound"
+    }
+  },
+  "aust201": {
+    "apsndu21.100": {
+      "filename": "apsndu21.100",
+      "type": "sound"
+    },
+    "apcpu.201": {
+      "filename": "apcpu.201",
+      "type": "main",
+      "romType": "se"
+    },
+    "apsndu17.100": {
+      "filename": "apsndu17.100",
+      "type": "sound"
+    },
+    "apsndu7.100": {
+      "filename": "apsndu7.100",
+      "type": "sound"
+    },
+    "apsndu37.100": {
+      "filename": "apsndu37.100",
+      "type": "sound"
+    },
+    "apdisp-a.200": {
+      "filename": "apdisp-a.200",
+      "type": "dmd"
+    },
+    "apsndu36.100": {
+      "filename": "apsndu36.100",
+      "type": "sound"
+    }
+  },
+  "aust300": {
+    "apsndu21.100": {
+      "filename": "apsndu21.100",
+      "type": "sound"
+    },
+    "apcpu.300": {
+      "filename": "apcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "apsndu17.100": {
+      "filename": "apsndu17.100",
+      "type": "sound"
+    },
+    "apsndu7.100": {
+      "filename": "apsndu7.100",
+      "type": "sound"
+    },
+    "apsndu37.100": {
+      "filename": "apsndu37.100",
+      "type": "sound"
+    },
+    "apdsp-a.300": {
+      "filename": "apdsp-a.300",
+      "type": "dmd"
+    },
+    "apsndu36.100": {
+      "filename": "apsndu36.100",
+      "type": "sound"
+    }
+  },
+  "aust301": {
+    "apsndu21.100": {
+      "filename": "apsndu21.100",
+      "type": "sound"
+    },
+    "apcpu.301": {
+      "filename": "APCPU.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "apsndu17.100": {
+      "filename": "apsndu17.100",
+      "type": "sound"
+    },
+    "apsndu7.100": {
+      "filename": "apsndu7.100",
+      "type": "sound"
+    },
+    "apsndu37.100": {
+      "filename": "apsndu37.100",
+      "type": "sound"
+    },
+    "apdsp-a.300": {
+      "filename": "apdsp-a.300",
+      "type": "dmd"
+    },
+    "apsndu36.100": {
+      "filename": "apsndu36.100",
+      "type": "sound"
+    }
+  },
+  "austin": {
+    "apsndu21.100": {
+      "filename": "apsndu21.100",
+      "type": "sound"
+    },
+    "apcpu.302": {
+      "filename": "apcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "apsndu17.100": {
+      "filename": "apsndu17.100",
+      "type": "sound"
+    },
+    "apsndu7.100": {
+      "filename": "apsndu7.100",
+      "type": "sound"
+    },
+    "apsndu37.100": {
+      "filename": "apsndu37.100",
+      "type": "sound"
+    },
+    "apdsp-a.300": {
+      "filename": "apdsp-a.300",
+      "type": "dmd"
+    },
+    "apsndu36.100": {
+      "filename": "apsndu36.100",
+      "type": "sound"
+    }
+  },
+  "austinf": {
+    "apsndu21.100": {
+      "filename": "apsndu21.100",
+      "type": "sound"
+    },
+    "apcpu.302": {
+      "filename": "apcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "apsndu17.100": {
+      "filename": "apsndu17.100",
+      "type": "sound"
+    },
+    "apsndu7.100": {
+      "filename": "apsndu7.100",
+      "type": "sound"
+    },
+    "apsndu37.100": {
+      "filename": "apsndu37.100",
+      "type": "sound"
+    },
+    "apsndu36.100": {
+      "filename": "apsndu36.100",
+      "type": "sound"
+    }
+  },
+  "austing": {
+    "apsndu21.100": {
+      "filename": "apsndu21.100",
+      "type": "sound"
+    },
+    "apcpu.302": {
+      "filename": "apcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "apsndu17.100": {
+      "filename": "apsndu17.100",
+      "type": "sound"
+    },
+    "apsndu7.100": {
+      "filename": "apsndu7.100",
+      "type": "sound"
+    },
+    "apsndu37.100": {
+      "filename": "apsndu37.100",
+      "type": "sound"
+    },
+    "apsndu36.100": {
+      "filename": "apsndu36.100",
+      "type": "sound"
+    }
+  },
+  "austini": {
+    "apsndu21.100": {
+      "filename": "apsndu21.100",
+      "type": "sound"
+    },
+    "apcpu.302": {
+      "filename": "apcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "apsndu17.100": {
+      "filename": "apsndu17.100",
+      "type": "sound"
+    },
+    "apsndu7.100": {
+      "filename": "apsndu7.100",
+      "type": "sound"
+    },
+    "apsndu37.100": {
+      "filename": "apsndu37.100",
+      "type": "sound"
+    },
+    "apsndu36.100": {
+      "filename": "apsndu36.100",
+      "type": "sound"
+    }
+  },
+  "gpr301": {
+    "gpcpua.301": {
+      "filename": "gpcpua.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsnda.u17": {
+      "filename": "gpsnda.u17",
+      "type": "sound"
+    },
+    "gpsnda.u36": {
+      "filename": "gpsnda.u36",
+      "type": "sound"
+    },
+    "gpsnda.u21": {
+      "filename": "gpsnda.u21",
+      "type": "sound"
+    },
+    "gpdspa.301": {
+      "filename": "gpdspa.301",
+      "type": "dmd"
+    },
+    "gpsnda.u37": {
+      "filename": "gpsnda.u37",
+      "type": "sound"
+    },
+    "gpsnda.u7": {
+      "filename": "gpsnda.u7",
+      "type": "sound"
+    }
+  },
+  "wd_03r": {
+    "u4-s031.rom": {
+      "filename": "u4-s031.rom",
+      "type": "sound"
+    },
+    "u5-s031.rom": {
+      "filename": "u5-s031.rom",
+      "type": "sound"
+    },
+    "u3-s031.rom": {
+      "filename": "u3-s031.rom",
+      "type": "sound"
+    },
+    "u6_03r.rom": {
+      "filename": "u6_03r.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "u2-s031.rom": {
+      "filename": "u2-s031.rom",
+      "type": "sound"
+    },
+    "u6-s031.rom": {
+      "filename": "u6-s031.rom",
+      "type": "sound"
+    },
+    "u7-s031.rom": {
+      "filename": "u7-s031.rom",
+      "type": "sound"
+    }
+  },
+  "wd_048r": {
+    "u4-s031.rom": {
+      "filename": "u4-s031.rom",
+      "type": "sound"
+    },
+    "u5-s031.rom": {
+      "filename": "u5-s031.rom",
+      "type": "sound"
+    },
+    "u3-s031.rom": {
+      "filename": "u3-s031.rom",
+      "type": "sound"
+    },
+    "wd_048r.rom": {
+      "filename": "wd_048r.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "u2-s031.rom": {
+      "filename": "u2-s031.rom",
+      "type": "sound"
+    },
+    "u6-s031.rom": {
+      "filename": "u6-s031.rom",
+      "type": "sound"
+    },
+    "u7-s031.rom": {
+      "filename": "u7-s031.rom",
+      "type": "sound"
+    }
+  },
+  "deadweap": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "avg_170h": {
+    "avgle170.bin": {
+      "filename": "AVGLE170.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ratrc_l1": {
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.532": {
+      "filename": "ic20.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.532": {
+      "filename": "ic14.532",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "olympus": {
+    "c4.256": {
+      "filename": "C4.256",
+      "type": "sound"
+    },
+    "olympus.dat": {
+      "filename": "olympus.dat",
+      "type": "main",
+      "romType": "jp"
+    },
+    "c7.256": {
+      "filename": "C7.256",
+      "type": "sound"
+    },
+    "c3.256": {
+      "filename": "C3.256",
+      "type": "sound"
+    },
+    "cs.128": {
+      "filename": "CS.128",
+      "type": "sound"
+    },
+    "c5.256": {
+      "filename": "C5.256",
+      "type": "sound"
+    },
+    "c1.256": {
+      "filename": "C1.256",
+      "type": "sound"
+    },
+    "c6.256": {
+      "filename": "C6.256",
+      "type": "sound"
+    }
+  },
+  "ckpt_a17": {
+    "chkpntc5.107": {
+      "filename": "chkpntc5.107",
+      "type": "main",
+      "romType": "de"
+    },
+    "chkpntds.512": {
+      "filename": "chkpntds.512",
+      "type": "dmd"
+    },
+    "chkpntf5.rom": {
+      "filename": "chkpntf5.rom",
+      "type": "sound"
+    },
+    "chkpntf6.rom": {
+      "filename": "chkpntf6.rom",
+      "type": "sound"
+    },
+    "chkpntb5.107": {
+      "filename": "chkpntb5.107",
+      "type": "main",
+      "romType": "de"
+    },
+    "chkpntf7.rom": {
+      "filename": "chkpntf7.rom",
+      "type": "sound"
+    }
+  },
+  "gmine_l2": {
+    "u22.256": {
+      "filename": "u22.256",
+      "type": "sound"
+    },
+    "u21.256": {
+      "filename": "u21.256",
+      "type": "sound"
+    },
+    "u27.128": {
+      "filename": "u27.128",
+      "type": "sound"
+    }
+  },
+  "frankst": {
+    "frsnd.u7": {
+      "filename": "frsnd.u7",
+      "type": "sound"
+    },
+    "frsnd.u17": {
+      "filename": "frsnd.u17",
+      "type": "sound"
+    },
+    "frsnd.u21": {
+      "filename": "frsnd.u21",
+      "type": "sound"
+    },
+    "frdspr3a.103": {
+      "filename": "frdspr3a.103",
+      "type": "dmd"
+    },
+    "frsnd.u36": {
+      "filename": "frsnd.u36",
+      "type": "sound"
+    },
+    "frdspr0a.103": {
+      "filename": "frdspr0a.103",
+      "type": "dmd"
+    },
+    "franka.103": {
+      "filename": "franka.103",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "frankstg": {
+    "frsnd.u7": {
+      "filename": "frsnd.u7",
+      "type": "sound"
+    },
+    "frsnd.u17": {
+      "filename": "frsnd.u17",
+      "type": "sound"
+    },
+    "frsnd.u21": {
+      "filename": "frsnd.u21",
+      "type": "sound"
+    },
+    "frdspr0g.101": {
+      "filename": "frdspr0g.101",
+      "type": "dmd"
+    },
+    "frsnd.u36": {
+      "filename": "frsnd.u36",
+      "type": "sound"
+    },
+    "franka.103": {
+      "filename": "franka.103",
+      "type": "main",
+      "romType": "de"
+    },
+    "frdspr3g.101": {
+      "filename": "frdspr3g.101",
+      "type": "dmd"
+    }
+  },
+  "mystcasa": {
+    "mcastle.sr0": {
+      "filename": "mcastle.sr0",
+      "type": "sound"
+    },
+    "mcastle.sr1": {
+      "filename": "mcastle.sr1",
+      "type": "sound"
+    },
+    "cpu_103.bin": {
+      "filename": "cpu_103.bin",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "mcastle.sr3": {
+      "filename": "mcastle.sr3",
+      "type": "sound"
+    },
+    "u4.bin": {
+      "filename": "u4.bin",
+      "type": "dmd"
+    },
+    "mcastle.103": {
+      "filename": "mcastle.103",
+      "type": "sound"
+    },
+    "mcastle.sr2": {
+      "filename": "mcastle.sr2",
+      "type": "sound"
+    },
+    "u5.bin": {
+      "filename": "u5.bin",
+      "type": "dmd"
+    },
+    "u6.bin": {
+      "filename": "u6.bin",
+      "type": "dmd"
+    }
+  },
+  "mystcast": {
+    "mcastle.sr0": {
+      "filename": "mcastle.sr0",
+      "type": "sound"
+    },
+    "mcastle.sr1": {
+      "filename": "mcastle.sr1",
+      "type": "sound"
+    },
+    "mcastle.du4": {
+      "filename": "mcastle.du4",
+      "type": "dmd"
+    },
+    "mcastle.sr3": {
+      "filename": "mcastle.sr3",
+      "type": "sound"
+    },
+    "mcastle.102": {
+      "filename": "mcastle.102",
+      "type": "sound"
+    },
+    "mcastle.du5": {
+      "filename": "mcastle.du5",
+      "type": "dmd"
+    },
+    "mcastle.cpu": {
+      "filename": "mcastle.cpu",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "mcastle.sr2": {
+      "filename": "mcastle.sr2",
+      "type": "sound"
+    }
+  },
+  "cobra": {
+    "snd_u9.256": {
+      "filename": "SND_U9.256",
+      "type": "main"
+    },
+    "snd_u10.256": {
+      "filename": "SND_U10.256",
+      "type": "main"
+    },
+    "cpu_u7.256": {
+      "filename": "CPU_U7.256",
+      "type": "main"
+    },
+    "snd_u8.256": {
+      "filename": "SND_U8.256",
+      "type": "main"
+    },
+    "snd_u11.256": {
+      "filename": "SND_U11.256",
+      "type": "main"
+    }
+  },
+  "galaxy": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "bk2k_l4": {
+    "bk2k_u21.l1": {
+      "filename": "bk2k_u21.l1",
+      "type": "sound"
+    },
+    "bk2k_u26.l4": {
+      "filename": "bk2k_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u4.l2": {
+      "filename": "bk2k_u4.l2",
+      "type": "sound"
+    },
+    "bk2k_u19.l1": {
+      "filename": "bk2k_u19.l1",
+      "type": "sound"
+    },
+    "bk2k_u27.l4": {
+      "filename": "bk2k_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u22.l1": {
+      "filename": "bk2k_u22.l1",
+      "type": "sound"
+    }
+  },
+  "bk2k_la2": {
+    "bk2k_u21.l1": {
+      "filename": "bk2k_u21.l1",
+      "type": "sound"
+    },
+    "bk2k_u4.l2": {
+      "filename": "bk2k_u4.l2",
+      "type": "sound"
+    },
+    "bk2k_u26.la2": {
+      "filename": "bk2k_u26.la2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u27.la2": {
+      "filename": "bk2k_u27.la2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u19.l1": {
+      "filename": "bk2k_u19.l1",
+      "type": "sound"
+    },
+    "bk2k_u22.l1": {
+      "filename": "bk2k_u22.l1",
+      "type": "sound"
+    }
+  },
+  "bk2k_lg1": {
+    "bk2k_u21.l1": {
+      "filename": "bk2k_u21.l1",
+      "type": "sound"
+    },
+    "bk2k_u4.l2": {
+      "filename": "bk2k_u4.l2",
+      "type": "sound"
+    },
+    "bk2kgu27.lg1": {
+      "filename": "bk2kgu27.lg1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u19.l1": {
+      "filename": "bk2k_u19.l1",
+      "type": "sound"
+    },
+    "bk2k_u22.l1": {
+      "filename": "bk2k_u22.l1",
+      "type": "sound"
+    },
+    "bk2kgu26.lg1": {
+      "filename": "bk2kgu26.lg1",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "bk2k_lg3": {
+    "bk2k_u21.l1": {
+      "filename": "bk2k_u21.l1",
+      "type": "sound"
+    },
+    "bk2k_u4.l2": {
+      "filename": "bk2k_u4.l2",
+      "type": "sound"
+    },
+    "u27-lg3.rom": {
+      "filename": "u27-lg3.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u19.l1": {
+      "filename": "bk2k_u19.l1",
+      "type": "sound"
+    },
+    "u26-lg3.rom": {
+      "filename": "u26-lg3.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u22.l1": {
+      "filename": "bk2k_u22.l1",
+      "type": "sound"
+    }
+  },
+  "bk2k_pa7": {
+    "bk2k_u21.l1": {
+      "filename": "bk2k_u21.l1",
+      "type": "sound"
+    },
+    "bk2k_u4.l2": {
+      "filename": "bk2k_u4.l2",
+      "type": "sound"
+    },
+    "bk2k_u19.l1": {
+      "filename": "bk2k_u19.l1",
+      "type": "sound"
+    },
+    "bk2k_u27.pa7": {
+      "filename": "bk2k_u27.pa7",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u22.l1": {
+      "filename": "bk2k_u22.l1",
+      "type": "sound"
+    },
+    "bk2k_u26.pa7": {
+      "filename": "bk2k_u26.pa7",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "bk2k_pu1": {
+    "bk2k_u21.l1": {
+      "filename": "bk2k_u21.l1",
+      "type": "sound"
+    },
+    "bk2k_u4.l2": {
+      "filename": "bk2k_u4.l2",
+      "type": "sound"
+    },
+    "u27-pu1.rom": {
+      "filename": "u27-pu1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "u26-pu1.rom": {
+      "filename": "u26-pu1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "bk2k_u19.l1": {
+      "filename": "bk2k_u19.l1",
+      "type": "sound"
+    },
+    "bk2k_u22.l1": {
+      "filename": "bk2k_u22.l1",
+      "type": "sound"
+    }
+  },
+  "esha_pa1": {
+    "u26-pa1.rom": {
+      "filename": "u26-pa1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u22.l1": {
+      "filename": "eshk_u22.l1",
+      "type": "sound"
+    },
+    "u4-p1.rom": {
+      "filename": "u4-p1.rom",
+      "type": "sound"
+    },
+    "u27-pa1.rom": {
+      "filename": "u27-pa1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u19.l1": {
+      "filename": "eshk_u19.l1",
+      "type": "sound"
+    },
+    "eshk_u21.l1": {
+      "filename": "eshk_u21.l1",
+      "type": "sound"
+    }
+  },
+  "rollston": {
+    "796-18_2.716": {
+      "filename": "796-18_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "796-17_1.716": {
+      "filename": "796-17_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "796-19_4.716": {
+      "filename": "796-19_4.716",
+      "type": "sound"
+    }
+  },
+  "obaoba1": {
+    "ob_s2a.bin": {
+      "filename": "ob_s2a.bin",
+      "type": "sound"
+    },
+    "ob3a.bin": {
+      "filename": "ob3a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ob2a.bin": {
+      "filename": "ob2a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ob1a.bin": {
+      "filename": "ob1a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ob_s1a.bin": {
+      "filename": "ob_s1a.bin",
+      "type": "sound"
+    }
+  },
+  "sopr107g": {
+    "sopsndg.u36": {
+      "filename": "sopsndg.u36",
+      "type": "sound"
+    },
+    "sopsndg.u37": {
+      "filename": "sopsndg.u37",
+      "type": "sound"
+    },
+    "sopdspg.100": {
+      "filename": "sopdspg.100",
+      "type": "dmd"
+    },
+    "sopsndg.u7": {
+      "filename": "sopsndg.u7",
+      "type": "sound"
+    },
+    "sopsndg1.u21": {
+      "filename": "Sopsndg1.u21",
+      "type": "sound"
+    },
+    "sopsndg.u17": {
+      "filename": "sopsndg.u17",
+      "type": "sound"
+    },
+    "sopcpug.107": {
+      "filename": "sopcpug.107",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "sopr300g": {
+    "sopsndg.u36": {
+      "filename": "sopsndg.u36",
+      "type": "sound"
+    },
+    "sopsndg.u37": {
+      "filename": "sopsndg.u37",
+      "type": "sound"
+    },
+    "sopsndg.u21": {
+      "filename": "sopsndg.u21",
+      "type": "sound"
+    },
+    "sopdspg.300": {
+      "filename": "sopdspg.300",
+      "type": "dmd"
+    },
+    "sopcpug.300": {
+      "filename": "sopcpug.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndg.u7": {
+      "filename": "sopsndg.u7",
+      "type": "sound"
+    },
+    "sopsndg.u17": {
+      "filename": "sopsndg.u17",
+      "type": "sound"
+    }
+  },
+  "sopr400g": {
+    "sopsndg.u36": {
+      "filename": "sopsndg.u36",
+      "type": "sound"
+    },
+    "sopsndg.u37": {
+      "filename": "sopsndg.u37",
+      "type": "sound"
+    },
+    "sopdspg.400": {
+      "filename": "sopdspg.400",
+      "type": "dmd"
+    },
+    "sopcpug.400": {
+      "filename": "sopcpug.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndg.u21": {
+      "filename": "sopsndg.u21",
+      "type": "sound"
+    },
+    "sopsndg.u7": {
+      "filename": "sopsndg.u7",
+      "type": "sound"
+    },
+    "sopsndg.u17": {
+      "filename": "sopsndg.u17",
+      "type": "sound"
+    }
+  },
+  "sopranog": {
+    "sopsndg.u36": {
+      "filename": "sopsndg.u36",
+      "type": "sound"
+    },
+    "sopsndg.u37": {
+      "filename": "sopsndg.u37",
+      "type": "sound"
+    },
+    "sopdspg.300": {
+      "filename": "sopdspg.300",
+      "type": "dmd"
+    },
+    "sopcpug.300": {
+      "filename": "sopcpug.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndg.u7": {
+      "filename": "sopsndg.u7",
+      "type": "sound"
+    },
+    "sopsndg.u21": {
+      "filename": "sopsndg.u21",
+      "type": "sound"
+    },
+    "sopsndg.u17": {
+      "filename": "sopsndg.u17",
+      "type": "sound"
+    }
+  },
+  "paragon": {
+    "748-17_1.716": {
+      "filename": "748-17_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "748-15_2.716": {
+      "filename": "748-15_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-30_6.716": {
+      "filename": "720-30_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    }
+  },
+  "bguns_l7": {
+    "guns_u22.l1": {
+      "filename": "guns_u22.l1",
+      "type": "sound"
+    },
+    "guns_u21.l1": {
+      "filename": "guns_u21.l1",
+      "type": "sound"
+    },
+    "guns_u26.l8": {
+      "filename": "guns_u26.l8",
+      "type": "main",
+      "romType": "s11"
+    },
+    "guns_u27.l7": {
+      "filename": "guns_u27.l7",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gund_u4.l1": {
+      "filename": "gund_u4.l1",
+      "type": "sound"
+    },
+    "guns_u19.l1": {
+      "filename": "guns_u19.l1",
+      "type": "sound"
+    }
+  },
+  "bguns_l8": {
+    "guns_u22.l1": {
+      "filename": "guns_u22.l1",
+      "type": "sound"
+    },
+    "guns_u21.l1": {
+      "filename": "guns_u21.l1",
+      "type": "sound"
+    },
+    "guns_u26.l8": {
+      "filename": "guns_u26.l8",
+      "type": "main",
+      "romType": "s11"
+    },
+    "guns_u27.l8": {
+      "filename": "guns_u27.l8",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gund_u4.l1": {
+      "filename": "gund_u4.l1",
+      "type": "sound"
+    },
+    "guns_u19.l1": {
+      "filename": "guns_u19.l1",
+      "type": "sound"
+    }
+  },
+  "bguns_la": {
+    "guns_u22.l1": {
+      "filename": "guns_u22.l1",
+      "type": "sound"
+    },
+    "guns_u21.l1": {
+      "filename": "guns_u21.l1",
+      "type": "sound"
+    },
+    "u26-l-a.rom": {
+      "filename": "u26-l-a.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gund_u4.l1": {
+      "filename": "gund_u4.l1",
+      "type": "sound"
+    },
+    "guns_u19.l1": {
+      "filename": "guns_u19.l1",
+      "type": "sound"
+    },
+    "u27-l-a.rom": {
+      "filename": "u27-l-a.rom",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "bguns_p1": {
+    "guns_u22.l1": {
+      "filename": "guns_u22.l1",
+      "type": "sound"
+    },
+    "u26-p-1.rom": {
+      "filename": "u26-p-1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "u27-p-1.rom": {
+      "filename": "u27-p-1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "guns_u21.l1": {
+      "filename": "guns_u21.l1",
+      "type": "sound"
+    },
+    "gund_u4.l1": {
+      "filename": "gund_u4.l1",
+      "type": "sound"
+    },
+    "guns_u19.l1": {
+      "filename": "guns_u19.l1",
+      "type": "sound"
+    }
+  },
+  "mtl_112": {
+    "mtl_112.bin": {
+      "filename": "mtl_112.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "smbmush": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "raimfire": {
+    "686-s.snd": {
+      "filename": "686-s.snd",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "686.cpu": {
+      "filename": "686.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "dvlrideg": {
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "g_snd_3.bin": {
+      "filename": "g_snd_3.bin",
+      "type": "sound"
+    },
+    "g_snd_2.bin": {
+      "filename": "g_snd_2.bin",
+      "type": "sound"
+    },
+    "cpu.ic1": {
+      "filename": "cpu.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "g_snd_1.bin": {
+      "filename": "g_snd_1.bin",
+      "type": "sound"
+    }
+  },
+  "dvlrider": {
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "gb01snd2.1e": {
+      "filename": "gb01snd2.1e",
+      "type": "sound"
+    },
+    "gb01snd3.1g": {
+      "filename": "gb01snd3.1g",
+      "type": "sound"
+    },
+    "cpu.ic1": {
+      "filename": "cpu.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "gb01snd1.1d": {
+      "filename": "gb01snd1.1d",
+      "type": "sound"
+    }
+  },
+  "potc_111as": {
+    "potc0111as.bin": {
+      "filename": "potc0111as.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "hirolcas": {
+    "hrcdispa.300": {
+      "filename": "hrcdispa.300",
+      "type": "dmd"
+    },
+    "hrccpu.300": {
+      "filename": "hrccpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "hrsndu36.100": {
+      "filename": "hrsndu36.100",
+      "type": "sound"
+    },
+    "hrsndu17.100": {
+      "filename": "hrsndu17.100",
+      "type": "sound"
+    },
+    "hrsndu7.100": {
+      "filename": "hrsndu7.100",
+      "type": "sound"
+    },
+    "hrsndu21.100": {
+      "filename": "hrsndu21.100",
+      "type": "sound"
+    },
+    "hrsndu37.100": {
+      "filename": "hrsndu37.100",
+      "type": "sound"
+    }
+  },
+  "thund_p3": {
+    "ic14_908.532": {
+      "filename": "ic14_908.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech5.532": {
+      "filename": "speech5.532",
+      "type": "sound"
+    },
+    "ic20_908.532": {
+      "filename": "ic20_908.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech4.532": {
+      "filename": "speech4.532",
+      "type": "sound"
+    },
+    "speech7.532": {
+      "filename": "speech7.532",
+      "type": "sound"
+    },
+    "speech6.532": {
+      "filename": "speech6.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    }
+  },
+  "jd_l1": {
+    "jd_l1.u6": {
+      "filename": "jd_l1.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jdsnd_u3.bin": {
+      "filename": "jdsnd_u3.bin",
+      "type": "sound"
+    },
+    "jdsnd_u8.bin": {
+      "filename": "jdsnd_u8.bin",
+      "type": "sound"
+    },
+    "jdsnd_u9.bin": {
+      "filename": "jdsnd_u9.bin",
+      "type": "sound"
+    },
+    "jdsnd_u4.bin": {
+      "filename": "jdsnd_u4.bin",
+      "type": "sound"
+    },
+    "jdsnd_u7.bin": {
+      "filename": "jdsnd_u7.bin",
+      "type": "sound"
+    },
+    "jdsnd_u5.bin": {
+      "filename": "jdsnd_u5.bin",
+      "type": "sound"
+    },
+    "jdsnd_u2.bin": {
+      "filename": "jdsnd_u2.bin",
+      "type": "sound"
+    },
+    "jdsnd_u6.bin": {
+      "filename": "jdsnd_u6.bin",
+      "type": "sound"
+    }
+  },
+  "potc_115gf": {
+    "potc0115gf.bin": {
+      "filename": "potc0115gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bdk_290": {
+    "bdk290.bin": {
+      "filename": "bdk290.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fjholden": {
+    "fj_ic3.snd": {
+      "filename": "fj_ic3.snd",
+      "type": "sound"
+    },
+    "fj_ic14.snd": {
+      "filename": "fj_ic14.snd",
+      "type": "sound"
+    },
+    "fj_ic2.mpu": {
+      "filename": "fj_ic2.mpu",
+      "type": "main",
+      "romType": "hnk"
+    },
+    "fj_ic3.mpu": {
+      "filename": "fj_ic3.mpu",
+      "type": "main",
+      "romType": "hnk"
+    }
+  },
+  "stargod": {
+    "stargod4.lgc": {
+      "filename": "stargod4.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "stargod5.lgc": {
+      "filename": "stargod5.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "zac_boot.lgc": {
+      "filename": "zac_boot.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "stargod2.lgc": {
+      "filename": "stargod2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "stargod3.lgc": {
+      "filename": "stargod3.lgc",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "stargoda": {
+    "stargod4.lgc": {
+      "filename": "stargod4.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "stargod5.lgc": {
+      "filename": "stargod5.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "zac_boot.lgc": {
+      "filename": "zac_boot.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "stargod2.lgc": {
+      "filename": "stargod2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "stargod3.lgc": {
+      "filename": "stargod3.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "stargod.snd": {
+      "filename": "stargod.snd",
+      "type": "sound"
+    }
+  },
+  "cosmic": {
+    "cosmic4.bin": {
+      "filename": "cosmic4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cosmc_s1.bin": {
+      "filename": "cosmc_s1.bin",
+      "type": "sound"
+    },
+    "cosmic1.bin": {
+      "filename": "cosmic1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cosmic2.bin": {
+      "filename": "cosmic2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cosmc_s2.bin": {
+      "filename": "cosmc_s2.bin",
+      "type": "sound"
+    },
+    "cosmic3.bin": {
+      "filename": "cosmic3.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "hvymetal": {
+    "u3.rom": {
+      "filename": "u3.rom",
+      "type": "main",
+      "romType": "by"
+    },
+    "u2.rom": {
+      "filename": "u2.rom",
+      "type": "main",
+      "romType": "by"
+    },
+    "u12.rom": {
+      "filename": "u12.rom",
+      "type": "sound"
+    },
+    "u11.rom": {
+      "filename": "u11.rom",
+      "type": "sound"
+    }
+  },
+  "jd_l4": {
+    "jdsnd_u3.bin": {
+      "filename": "jdsnd_u3.bin",
+      "type": "sound"
+    },
+    "jdsnd_u8.bin": {
+      "filename": "jdsnd_u8.bin",
+      "type": "sound"
+    },
+    "jdsnd_u9.bin": {
+      "filename": "jdsnd_u9.bin",
+      "type": "sound"
+    },
+    "jdsnd_u4.bin": {
+      "filename": "jdsnd_u4.bin",
+      "type": "sound"
+    },
+    "jdsnd_u7.bin": {
+      "filename": "jdsnd_u7.bin",
+      "type": "sound"
+    },
+    "jdsnd_u5.bin": {
+      "filename": "jdsnd_u5.bin",
+      "type": "sound"
+    },
+    "jd_l4.u6": {
+      "filename": "jd_l4.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jdsnd_u2.bin": {
+      "filename": "jdsnd_u2.bin",
+      "type": "sound"
+    },
+    "jdsnd_u6.bin": {
+      "filename": "jdsnd_u6.bin",
+      "type": "sound"
+    }
+  },
+  "jd_l5": {
+    "jdsnd_u3.bin": {
+      "filename": "jdsnd_u3.bin",
+      "type": "sound"
+    },
+    "jdsnd_u8.bin": {
+      "filename": "jdsnd_u8.bin",
+      "type": "sound"
+    },
+    "jd_l5.u6": {
+      "filename": "jd_l5.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jdsnd_u9.bin": {
+      "filename": "jdsnd_u9.bin",
+      "type": "sound"
+    },
+    "jdsnd_u4.bin": {
+      "filename": "jdsnd_u4.bin",
+      "type": "sound"
+    },
+    "jdsnd_u7.bin": {
+      "filename": "jdsnd_u7.bin",
+      "type": "sound"
+    },
+    "jdsnd_u5.bin": {
+      "filename": "jdsnd_u5.bin",
+      "type": "sound"
+    },
+    "jdsnd_u2.bin": {
+      "filename": "jdsnd_u2.bin",
+      "type": "sound"
+    },
+    "jdsnd_u6.bin": {
+      "filename": "jdsnd_u6.bin",
+      "type": "sound"
+    }
+  },
+  "jd_l6": {
+    "jdsnd_u3.bin": {
+      "filename": "jdsnd_u3.bin",
+      "type": "sound"
+    },
+    "jd_l6.u6": {
+      "filename": "jd_l6.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jdsnd_u8.bin": {
+      "filename": "jdsnd_u8.bin",
+      "type": "sound"
+    },
+    "jdsnd_u9.bin": {
+      "filename": "jdsnd_u9.bin",
+      "type": "sound"
+    },
+    "jdsnd_u4.bin": {
+      "filename": "jdsnd_u4.bin",
+      "type": "sound"
+    },
+    "jdsnd_u7.bin": {
+      "filename": "jdsnd_u7.bin",
+      "type": "sound"
+    },
+    "jdsnd_u5.bin": {
+      "filename": "jdsnd_u5.bin",
+      "type": "sound"
+    },
+    "jdsnd_u2.bin": {
+      "filename": "jdsnd_u2.bin",
+      "type": "sound"
+    },
+    "jdsnd_u6.bin": {
+      "filename": "jdsnd_u6.bin",
+      "type": "sound"
+    }
+  },
+  "jd_l7": {
+    "jdsnd_u3.bin": {
+      "filename": "jdsnd_u3.bin",
+      "type": "sound"
+    },
+    "jdsnd_u8.bin": {
+      "filename": "jdsnd_u8.bin",
+      "type": "sound"
+    },
+    "jdrd_l7.rom": {
+      "filename": "jdrd_l7.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jdsnd_u9.bin": {
+      "filename": "jdsnd_u9.bin",
+      "type": "sound"
+    },
+    "jdsnd_u4.bin": {
+      "filename": "jdsnd_u4.bin",
+      "type": "sound"
+    },
+    "jdsnd_u7.bin": {
+      "filename": "jdsnd_u7.bin",
+      "type": "sound"
+    },
+    "jdsnd_u5.bin": {
+      "filename": "jdsnd_u5.bin",
+      "type": "sound"
+    },
+    "jdsnd_u2.bin": {
+      "filename": "jdsnd_u2.bin",
+      "type": "sound"
+    },
+    "jdsnd_u6.bin": {
+      "filename": "jdsnd_u6.bin",
+      "type": "sound"
+    }
+  },
+  "diamond": {
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    }
+  },
+  "xenonf": {
+    "811-31_6.532": {
+      "filename": "811-31_6.532",
+      "type": "sound"
+    },
+    "811-40_1.716": {
+      "filename": "811-40_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-41_2.716": {
+      "filename": "811-41_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-23_2.532": {
+      "filename": "811-23_2.532",
+      "type": "sound"
+    },
+    "811-24_3.532": {
+      "filename": "811-24_3.532",
+      "type": "sound"
+    },
+    "811-36_4.532": {
+      "filename": "811-36_4.532",
+      "type": "sound"
+    },
+    "811-32_7.532": {
+      "filename": "811-32_7.532",
+      "type": "sound"
+    },
+    "811-22_1.532": {
+      "filename": "811-22_1.532",
+      "type": "sound"
+    },
+    "720-40_6.732": {
+      "filename": "720-40_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-30_5.532": {
+      "filename": "811-30_5.532",
+      "type": "sound"
+    },
+    "811-29_4.532": {
+      "filename": "811-29_4.532",
+      "type": "sound"
+    }
+  },
+  "xenonfa": {
+    "811-31_6.532": {
+      "filename": "811-31_6.532",
+      "type": "sound"
+    },
+    "811-23_2.532": {
+      "filename": "811-23_2.532",
+      "type": "sound"
+    },
+    "7406fn.u6": {
+      "filename": "7406fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-24_3.532": {
+      "filename": "811-24_3.532",
+      "type": "sound"
+    },
+    "811-36_4.532": {
+      "filename": "811-36_4.532",
+      "type": "sound"
+    },
+    "xeno2732.u2": {
+      "filename": "xeno2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-32_7.532": {
+      "filename": "811-32_7.532",
+      "type": "sound"
+    },
+    "811-22_1.532": {
+      "filename": "811-22_1.532",
+      "type": "sound"
+    },
+    "811-30_5.532": {
+      "filename": "811-30_5.532",
+      "type": "sound"
+    },
+    "811-29_4.532": {
+      "filename": "811-29_4.532",
+      "type": "sound"
+    }
+  },
+  "caveman": {
+    "v810-u1.bin": {
+      "filename": "v810-u1.bin",
+      "type": "dmd"
+    },
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "v810-u4.bin": {
+      "filename": "v810-u4.bin",
+      "type": "dmd"
+    },
+    "v810-u5.bin": {
+      "filename": "v810-u5.bin",
+      "type": "dmd"
+    },
+    "v810-u6.bin": {
+      "filename": "v810-u6.bin",
+      "type": "dmd"
+    },
+    "v810-u8.bin": {
+      "filename": "v810-u8.bin",
+      "type": "dmd"
+    },
+    "v810-u3.bin": {
+      "filename": "v810-u3.bin",
+      "type": "dmd"
+    },
+    "v810-u7.bin": {
+      "filename": "v810-u7.bin",
+      "type": "dmd"
+    },
+    "pv810-s1.snd": {
+      "filename": "pv810-s1.snd",
+      "type": "sound"
+    },
+    "v810-u2.bin": {
+      "filename": "v810-u2.bin",
+      "type": "dmd"
+    },
+    "pv810-s2.snd": {
+      "filename": "pv810-s2.snd",
+      "type": "sound"
+    },
+    "pv810-1.cpu": {
+      "filename": "pv810-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "pb_l2": {
+    "u27-l2.rom": {
+      "filename": "u27-l2.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pbot_u21.l1": {
+      "filename": "pbot_u21.l1",
+      "type": "sound"
+    },
+    "pbot_u19.l1": {
+      "filename": "pbot_u19.l1",
+      "type": "sound"
+    },
+    "pbot_u22.l1": {
+      "filename": "pbot_u22.l1",
+      "type": "sound"
+    },
+    "pbot_u4.l1": {
+      "filename": "pbot_u4.l1",
+      "type": "sound"
+    },
+    "u26-l2.rom": {
+      "filename": "u26-l2.rom",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "granny": {
+    "cs_u3.764": {
+      "filename": "cs_u3.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u6.532": {
+      "filename": "cpu_u6.532",
+      "type": "main",
+      "romType": "by"
+    },
+    "vid_u4.764": {
+      "filename": "vid_u4.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "vid_u9.764": {
+      "filename": "vid_u9.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "vid_u5.764": {
+      "filename": "vid_u5.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "vid_u6.764": {
+      "filename": "vid_u6.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "vid_u8.764": {
+      "filename": "vid_u8.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "vid_u7.764": {
+      "filename": "vid_u7.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u2.532": {
+      "filename": "cpu_u2.532",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "cavnegr1": {
+    "cn4a.bin": {
+      "filename": "cn4a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn1.bin": {
+      "filename": "cn1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn3a.bin": {
+      "filename": "cn3a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn2.bin": {
+      "filename": "cn2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn_s2.bin": {
+      "filename": "cn_s2.bin",
+      "type": "sound"
+    },
+    "cn_s1.bin": {
+      "filename": "cn_s1.bin",
+      "type": "sound"
+    }
+  },
+  "rip300f": {
+    "ripsndf.u36": {
+      "filename": "ripsndf.u36",
+      "type": "sound"
+    },
+    "ripsndf.u7": {
+      "filename": "ripsndf.u7",
+      "type": "sound"
+    },
+    "ripsndf.u37": {
+      "filename": "ripsndf.u37",
+      "type": "sound"
+    },
+    "ripsndf.u21": {
+      "filename": "ripsndf.u21",
+      "type": "sound"
+    },
+    "ripcpu.300": {
+      "filename": "ripcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsndf.u17": {
+      "filename": "ripsndf.u17",
+      "type": "sound"
+    },
+    "ripdispf.300": {
+      "filename": "ripdispf.300",
+      "type": "dmd"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    }
+  },
+  "rip301f": {
+    "ripsndf.u36": {
+      "filename": "ripsndf.u36",
+      "type": "sound"
+    },
+    "ripsndf.u7": {
+      "filename": "ripsndf.u7",
+      "type": "sound"
+    },
+    "ripsndf.u37": {
+      "filename": "ripsndf.u37",
+      "type": "sound"
+    },
+    "ripsndf.u21": {
+      "filename": "ripsndf.u21",
+      "type": "sound"
+    },
+    "ripsndf.u17": {
+      "filename": "ripsndf.u17",
+      "type": "sound"
+    },
+    "ripcpu.301": {
+      "filename": "ripcpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispf.301": {
+      "filename": "ripdispf.301",
+      "type": "dmd"
+    }
+  },
+  "rip302f": {
+    "ripsndf.u36": {
+      "filename": "ripsndf.u36",
+      "type": "sound"
+    },
+    "ripsndf.u7": {
+      "filename": "ripsndf.u7",
+      "type": "sound"
+    },
+    "ripsndf.u37": {
+      "filename": "ripsndf.u37",
+      "type": "sound"
+    },
+    "ripsndf.u21": {
+      "filename": "ripsndf.u21",
+      "type": "sound"
+    },
+    "ripsndf.u17": {
+      "filename": "ripsndf.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispf.301": {
+      "filename": "RIPDISPF.301",
+      "type": "dmd"
+    },
+    "ripcpu.302": {
+      "filename": "RIPCPU.302",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "rip310f": {
+    "ripsndf.u36": {
+      "filename": "ripsndf.u36",
+      "type": "sound"
+    },
+    "ripsndf.u7": {
+      "filename": "ripsndf.u7",
+      "type": "sound"
+    },
+    "ripsndf.u37": {
+      "filename": "ripsndf.u37",
+      "type": "sound"
+    },
+    "ripsndf.u21": {
+      "filename": "ripsndf.u21",
+      "type": "sound"
+    },
+    "ripcpu.310": {
+      "filename": "ripcpu.310",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsndf.u17": {
+      "filename": "ripsndf.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispf.301": {
+      "filename": "RIPDISPF.301",
+      "type": "dmd"
+    }
+  },
+  "ripleysf": {
+    "ripsndf.u36": {
+      "filename": "ripsndf.u36",
+      "type": "sound"
+    },
+    "ripsndf.u7": {
+      "filename": "ripsndf.u7",
+      "type": "sound"
+    },
+    "ripsndf.u37": {
+      "filename": "ripsndf.u37",
+      "type": "sound"
+    },
+    "ripsndf.u21": {
+      "filename": "ripsndf.u21",
+      "type": "sound"
+    },
+    "ripsndf.u17": {
+      "filename": "ripsndf.u17",
+      "type": "sound"
+    },
+    "ripcpu.320": {
+      "filename": "ripcpu.320",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispf.301": {
+      "filename": "ripdispf.301",
+      "type": "dmd"
+    }
+  },
+  "babypac": {
+    "891-u11.764": {
+      "filename": "891-u11.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u29.764": {
+      "filename": "891-u29.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u10.764": {
+      "filename": "891-u10.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u12.764": {
+      "filename": "891-u12.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u6.732": {
+      "filename": "891-u6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u2.732": {
+      "filename": "891-u2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u9.764": {
+      "filename": "891-u9.764",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "babypacn": {
+    "891-u11.764": {
+      "filename": "891-u11.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u29.764": {
+      "filename": "891-u29.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u10.764": {
+      "filename": "891-u10.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u12.764": {
+      "filename": "891-u12.764",
+      "type": "main",
+      "romType": "by"
+    },
+    "891-u6.732": {
+      "filename": "891-u6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "pacmann.u2": {
+      "filename": "pacmanN.U2",
+      "type": "main",
+      "romType": "by"
+    },
+    "babyvidn.u9": {
+      "filename": "babyvidN.u9",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "fs_lx2": {
+    "fs_u9_s.l1": {
+      "filename": "fs_u9_s.l1",
+      "type": "sound"
+    },
+    "fs_u6_s.l1": {
+      "filename": "fs_u6_s.l1",
+      "type": "sound"
+    },
+    "fs_u5_s.l1": {
+      "filename": "fs_u5_s.l1",
+      "type": "sound"
+    },
+    "fs_u4_s.l1": {
+      "filename": "fs_u4_s.l1",
+      "type": "sound"
+    },
+    "fs_u8_s.l1": {
+      "filename": "fs_u8_s.l1",
+      "type": "sound"
+    },
+    "fs_u2_s.l1": {
+      "filename": "fs_u2_s.l1",
+      "type": "sound"
+    },
+    "flin_lx2.rom": {
+      "filename": "flin_lx2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "fs_u3_s.l1": {
+      "filename": "fs_u3_s.l1",
+      "type": "sound"
+    },
+    "fs_u7_s.l1": {
+      "filename": "fs_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "fs_lx4": {
+    "fs_u9_s.l1": {
+      "filename": "fs_u9_s.l1",
+      "type": "sound"
+    },
+    "fs_u6_s.l1": {
+      "filename": "fs_u6_s.l1",
+      "type": "sound"
+    },
+    "fs_u5_s.l1": {
+      "filename": "fs_u5_s.l1",
+      "type": "sound"
+    },
+    "fs_u4_s.l1": {
+      "filename": "fs_u4_s.l1",
+      "type": "sound"
+    },
+    "fs_u8_s.l1": {
+      "filename": "fs_u8_s.l1",
+      "type": "sound"
+    },
+    "fs_u2_s.l1": {
+      "filename": "fs_u2_s.l1",
+      "type": "sound"
+    },
+    "fs_u3_s.l1": {
+      "filename": "fs_u3_s.l1",
+      "type": "sound"
+    },
+    "fs_u7_s.l1": {
+      "filename": "fs_u7_s.l1",
+      "type": "sound"
+    },
+    "flin_lx4.rom": {
+      "filename": "flin_lx4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "esclwrlg": {
+    "u2_ger.128": {
+      "filename": "u2_ger.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "u14.512": {
+      "filename": "u14.512",
+      "type": "sound"
+    },
+    "u12.512": {
+      "filename": "u12.512",
+      "type": "sound"
+    },
+    "u3_ger.128": {
+      "filename": "u3_ger.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "u11.512": {
+      "filename": "u11.512",
+      "type": "sound"
+    },
+    "u13.512": {
+      "filename": "u13.512",
+      "type": "sound"
+    }
+  },
+  "ts_lh6": {
+    "shad_h6.rom": {
+      "filename": "shad_h6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "ts_u2_s.l1": {
+      "filename": "ts_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "wd_10f": {
+    "wdu5_10.rom": {
+      "filename": "wdu5_10.rom",
+      "type": "sound"
+    },
+    "wdu2_10.rom": {
+      "filename": "wdu2_10.rom",
+      "type": "sound"
+    },
+    "wdu7_10.rom": {
+      "filename": "wdu7_10.rom",
+      "type": "sound"
+    },
+    "wdu4_10.rom": {
+      "filename": "wdu4_10.rom",
+      "type": "sound"
+    },
+    "u6_10f.rom": {
+      "filename": "u6_10f.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wdu3_10.rom": {
+      "filename": "wdu3_10.rom",
+      "type": "sound"
+    },
+    "wdu6_10.rom": {
+      "filename": "wdu6_10.rom",
+      "type": "sound"
+    }
+  },
+  "wd_10g": {
+    "wdu5_10.rom": {
+      "filename": "wdu5_10.rom",
+      "type": "sound"
+    },
+    "wdu2_20g.rom": {
+      "filename": "wdu2_20g.rom",
+      "type": "sound"
+    },
+    "wdu7_10.rom": {
+      "filename": "wdu7_10.rom",
+      "type": "sound"
+    },
+    "wdu4_10.rom": {
+      "filename": "wdu4_10.rom",
+      "type": "sound"
+    },
+    "wdu6_10.rom": {
+      "filename": "wdu6_10.rom",
+      "type": "sound"
+    },
+    "wdu3_20g.rom": {
+      "filename": "wdu3_20g.rom",
+      "type": "sound"
+    },
+    "u6_10g.rom": {
+      "filename": "u6_10g.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "wd_10r": {
+    "wdu5_10.rom": {
+      "filename": "wdu5_10.rom",
+      "type": "sound"
+    },
+    "wdu2_10.rom": {
+      "filename": "wdu2_10.rom",
+      "type": "sound"
+    },
+    "wdu7_10.rom": {
+      "filename": "wdu7_10.rom",
+      "type": "sound"
+    },
+    "wdu4_10.rom": {
+      "filename": "wdu4_10.rom",
+      "type": "sound"
+    },
+    "whod1_0.rom": {
+      "filename": "whod1_0.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wdu3_10.rom": {
+      "filename": "wdu3_10.rom",
+      "type": "sound"
+    },
+    "wdu6_10.rom": {
+      "filename": "wdu6_10.rom",
+      "type": "sound"
+    }
+  },
+  "wd_11": {
+    "wdu5_10.rom": {
+      "filename": "wdu5_10.rom",
+      "type": "sound"
+    },
+    "wdu2_10.rom": {
+      "filename": "wdu2_10.rom",
+      "type": "sound"
+    },
+    "wdu7_10.rom": {
+      "filename": "wdu7_10.rom",
+      "type": "sound"
+    },
+    "wdu4_10.rom": {
+      "filename": "wdu4_10.rom",
+      "type": "sound"
+    },
+    "whod1_1.rom": {
+      "filename": "whod1_1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wdu3_10.rom": {
+      "filename": "wdu3_10.rom",
+      "type": "sound"
+    },
+    "wdu6_10.rom": {
+      "filename": "wdu6_10.rom",
+      "type": "sound"
+    }
+  },
+  "wd_12": {
+    "wdu5_10.rom": {
+      "filename": "wdu5_10.rom",
+      "type": "sound"
+    },
+    "wdu2_10.rom": {
+      "filename": "wdu2_10.rom",
+      "type": "sound"
+    },
+    "wdu7_10.rom": {
+      "filename": "wdu7_10.rom",
+      "type": "sound"
+    },
+    "wdu4_10.rom": {
+      "filename": "wdu4_10.rom",
+      "type": "sound"
+    },
+    "wdu3_10.rom": {
+      "filename": "wdu3_10.rom",
+      "type": "sound"
+    },
+    "wdu6_10.rom": {
+      "filename": "wdu6_10.rom",
+      "type": "sound"
+    },
+    "whod1_2.rom": {
+      "filename": "whod1_2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "wd_12g": {
+    "wdu5_10.rom": {
+      "filename": "wdu5_10.rom",
+      "type": "sound"
+    },
+    "wdu2_20g.rom": {
+      "filename": "wdu2_20g.rom",
+      "type": "sound"
+    },
+    "wdu7_10.rom": {
+      "filename": "wdu7_10.rom",
+      "type": "sound"
+    },
+    "wdu4_10.rom": {
+      "filename": "wdu4_10.rom",
+      "type": "sound"
+    },
+    "wdu6_10.rom": {
+      "filename": "wdu6_10.rom",
+      "type": "sound"
+    },
+    "whod1_2.rom": {
+      "filename": "whod1_2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "wdu3_20g.rom": {
+      "filename": "wdu3_20g.rom",
+      "type": "sound"
+    }
+  },
+  "dakar": {
+    "vid_ic56.rom": {
+      "filename": "vid_ic56.rom",
+      "type": "dmd"
+    },
+    "cpu_ic14.rom": {
+      "filename": "cpu_ic14.rom",
+      "type": "main",
+      "romType": "mrgame"
+    },
+    "snd_ic06.rom": {
+      "filename": "snd_ic06.rom",
+      "type": "sound"
+    },
+    "vid_ic55.rom": {
+      "filename": "vid_ic55.rom",
+      "type": "dmd"
+    },
+    "snd_ic36.rom": {
+      "filename": "snd_ic36.rom",
+      "type": "sound"
+    },
+    "snd_ic07.rom": {
+      "filename": "snd_ic07.rom",
+      "type": "sound"
+    },
+    "snd_ic35.rom": {
+      "filename": "snd_ic35.rom",
+      "type": "sound"
+    },
+    "cpu_ic13.rom": {
+      "filename": "cpu_ic13.rom",
+      "type": "main",
+      "romType": "mrgame"
+    },
+    "vid_ic14.rom": {
+      "filename": "vid_ic14.rom",
+      "type": "dmd"
+    },
+    "vid_ic66.rom": {
+      "filename": "vid_ic66.rom",
+      "type": "dmd"
+    },
+    "snd_ic22.rom": {
+      "filename": "snd_ic22.rom",
+      "type": "sound"
+    }
+  },
+  "sopr300l": {
+    "sopsndl.u21": {
+      "filename": "sopsndl.u21",
+      "type": "sound"
+    },
+    "sopsndl.u7": {
+      "filename": "sopsndl.u7",
+      "type": "sound"
+    },
+    "sopsndl.u36": {
+      "filename": "sopsndl.u36",
+      "type": "sound"
+    },
+    "sopcpul.300": {
+      "filename": "sopcpul.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndl.u17": {
+      "filename": "sopsndl.u17",
+      "type": "sound"
+    },
+    "sopsndl.u37": {
+      "filename": "sopsndl.u37",
+      "type": "sound"
+    },
+    "sopdspl.300": {
+      "filename": "sopdspl.300",
+      "type": "dmd"
+    }
+  },
+  "sopr400l": {
+    "sopsndl.u21": {
+      "filename": "sopsndl.u21",
+      "type": "sound"
+    },
+    "sopsndl.u7": {
+      "filename": "sopsndl.u7",
+      "type": "sound"
+    },
+    "sopsndl.u36": {
+      "filename": "sopsndl.u36",
+      "type": "sound"
+    },
+    "sopsndl.u17": {
+      "filename": "sopsndl.u17",
+      "type": "sound"
+    },
+    "sopdspl.400": {
+      "filename": "sopdspl.400",
+      "type": "dmd"
+    },
+    "sopcpul.400": {
+      "filename": "sopcpul.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndl.u37": {
+      "filename": "sopsndl.u37",
+      "type": "sound"
+    }
+  },
+  "smb": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "dsprom2.bin": {
+      "filename": "dsprom2.bin",
+      "type": "dmd"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "smb1": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "dsprom2.bin": {
+      "filename": "dsprom2.bin",
+      "type": "dmd"
+    },
+    "gprom1.bin": {
+      "filename": "gprom1.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "smb2": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "dsprom2.bin": {
+      "filename": "dsprom2.bin",
+      "type": "dmd"
+    },
+    "gprom2.bin": {
+      "filename": "gprom2.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "smb3": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "dsprom2.bin": {
+      "filename": "dsprom2.bin",
+      "type": "dmd"
+    },
+    "gprom3.bin": {
+      "filename": "gprom3.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "jy_11": {
+    "jy_s4.rom": {
+      "filename": "jy_s4.rom",
+      "type": "sound"
+    },
+    "jy_s3.rom": {
+      "filename": "jy_s3.rom",
+      "type": "sound"
+    },
+    "jy_s2.rom": {
+      "filename": "jy_s2.rom",
+      "type": "sound"
+    },
+    "jy_g11.1_1": {
+      "filename": "jy_g11.1_1",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jy_s5.rom": {
+      "filename": "jy_s5.rom",
+      "type": "sound"
+    }
+  },
+  "jy_12": {
+    "jy_s4.rom": {
+      "filename": "jy_s4.rom",
+      "type": "sound"
+    },
+    "jy_s3.rom": {
+      "filename": "jy_s3.rom",
+      "type": "sound"
+    },
+    "jy_g11.1_2": {
+      "filename": "jy_g11.1_2",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jy_s2.rom": {
+      "filename": "jy_s2.rom",
+      "type": "sound"
+    },
+    "jy_s5.rom": {
+      "filename": "jy_s5.rom",
+      "type": "sound"
+    }
+  },
+  "bigbat": {
+    "u5.bin": {
+      "filename": "u5.bin",
+      "type": "sound"
+    },
+    "u2.bin": {
+      "filename": "u2.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "u4.bin": {
+      "filename": "u4.bin",
+      "type": "sound"
+    },
+    "u6.bin": {
+      "filename": "u6.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "u3.bin": {
+      "filename": "u3.bin",
+      "type": "sound"
+    }
+  },
+  "rflshdlx": {
+    "681-2.cpu": {
+      "filename": "681-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "681-s1.snd": {
+      "filename": "681-s1.snd",
+      "type": "sound"
+    },
+    "681-s2.snd": {
+      "filename": "681-s2.snd",
+      "type": "sound"
+    }
+  },
+  "grgar_l1": {
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "sound2.716": {
+      "filename": "sound2.716",
+      "type": "sound"
+    }
+  },
+  "grgar_t1": {
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "green2a.716": {
+      "filename": "green2a.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "sound2.716": {
+      "filename": "sound2.716",
+      "type": "sound"
+    }
+  },
+  "macjungn": {
+    "juego1.bin": {
+      "filename": "juego1.bin",
+      "type": "main"
+    },
+    "mac_snd.bin": {
+      "filename": "mac_snd.bin",
+      "type": "main"
+    }
+  },
+  "amazonh2": {
+    "684c-cpu.rom": {
+      "filename": "684c-cpu.rom",
+      "type": "main",
+      "romType": "gts"
+    },
+    "684c-snd.rom": {
+      "filename": "684c-snd.rom",
+      "type": "sound"
+    }
+  },
+  "tf_180": {
+    "tf_v1-80.bin": {
+      "filename": "TF_V1-80.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "esclwrld": {
+    "u14.512": {
+      "filename": "u14.512",
+      "type": "sound"
+    },
+    "u12.512": {
+      "filename": "u12.512",
+      "type": "sound"
+    },
+    "u11.512": {
+      "filename": "u11.512",
+      "type": "sound"
+    },
+    "u3.128": {
+      "filename": "u3.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "u13.512": {
+      "filename": "u13.512",
+      "type": "sound"
+    },
+    "u2.128": {
+      "filename": "u2.128",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wpt_112i": {
+    "wpt0112i.bin": {
+      "filename": "wpt0112i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "quicksil": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "eatpm_p7": {
+    "u26-pa7.rom": {
+      "filename": "u26-pa7.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u20.l1": {
+      "filename": "elvi_u20.l1",
+      "type": "sound"
+    },
+    "elvi_u21.l1": {
+      "filename": "elvi_u21.l1",
+      "type": "sound"
+    },
+    "elvi_u19.l1": {
+      "filename": "elvi_u19.l1",
+      "type": "sound"
+    },
+    "elvi_u4.l1": {
+      "filename": "elvi_u4.l1",
+      "type": "sound"
+    },
+    "u27-pa7.rom": {
+      "filename": "u27-pa7.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u22.l1": {
+      "filename": "elvi_u22.l1",
+      "type": "sound"
+    }
+  },
+  "sopr300f": {
+    "sopcpuf.300": {
+      "filename": "sopcpuf.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndf.u17": {
+      "filename": "sopsndf.u17",
+      "type": "sound"
+    },
+    "sopsndf.u21": {
+      "filename": "sopsndf.u21",
+      "type": "sound"
+    },
+    "sopsndf.u37": {
+      "filename": "sopsndf.u37",
+      "type": "sound"
+    },
+    "sopsndf.u7": {
+      "filename": "sopsndf.u7",
+      "type": "sound"
+    },
+    "sopdspf.300": {
+      "filename": "sopdspf.300",
+      "type": "dmd"
+    },
+    "sopsndf.u36": {
+      "filename": "sopsndf.u36",
+      "type": "sound"
+    }
+  },
+  "sopranof": {
+    "sopcpuf.300": {
+      "filename": "sopcpuf.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndf.u21": {
+      "filename": "sopsndf.u21",
+      "type": "sound"
+    },
+    "sopsndf.u37": {
+      "filename": "sopsndf.u37",
+      "type": "sound"
+    },
+    "sopsndf.u7": {
+      "filename": "sopsndf.u7",
+      "type": "sound"
+    },
+    "sopdspf.300": {
+      "filename": "sopdspf.300",
+      "type": "dmd"
+    },
+    "sopsndf.u36": {
+      "filename": "sopsndf.u36",
+      "type": "sound"
+    },
+    "sopsndf.u17": {
+      "filename": "sopsndf.u17",
+      "type": "sound"
+    }
+  },
+  "meteorfp": {
+    "fpmet_u6.716": {
+      "filename": "fpmet_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpmet_u1.716": {
+      "filename": "fpmet_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "motrshwa": {
+    "cpuic14b.rom": {
+      "filename": "cpuic14b.rom",
+      "type": "main",
+      "romType": "mrgame"
+    },
+    "vid_ic56.rom": {
+      "filename": "vid_ic56.rom",
+      "type": "dmd"
+    },
+    "vid_ic14.rom": {
+      "filename": "vid_ic14.rom",
+      "type": "dmd"
+    },
+    "cpuic13a.rom": {
+      "filename": "cpuic13a.rom",
+      "type": "main",
+      "romType": "mrgame"
+    },
+    "snd_ic36.rom": {
+      "filename": "snd_ic36.rom",
+      "type": "sound"
+    },
+    "vid_ic66.rom": {
+      "filename": "vid_ic66.rom",
+      "type": "dmd"
+    },
+    "snd_ic35.rom": {
+      "filename": "snd_ic35.rom",
+      "type": "sound"
+    },
+    "vid_ic55.rom": {
+      "filename": "vid_ic55.rom",
+      "type": "dmd"
+    },
+    "snd_ic22.rom": {
+      "filename": "snd_ic22.rom",
+      "type": "sound"
+    },
+    "snd_ic06.rom": {
+      "filename": "snd_ic06.rom",
+      "type": "sound"
+    }
+  },
+  "aqualand": {
+    "jpaq14sd": {
+      "filename": "jpaq14sd",
+      "type": "sound"
+    },
+    "jpaq10sd": {
+      "filename": "jpaq10sd",
+      "type": "sound"
+    },
+    "jpaq-9sd": {
+      "filename": "jpaq-9sd",
+      "type": "sound"
+    },
+    "jpaqcpu": {
+      "filename": "jpaqcpu",
+      "type": "main",
+      "romType": "jp"
+    },
+    "jpaq-6sd": {
+      "filename": "jpaq-6sd",
+      "type": "sound"
+    },
+    "jpaq13sd": {
+      "filename": "jpaq13sd",
+      "type": "sound"
+    },
+    "jpaq-7sd": {
+      "filename": "jpaq-7sd",
+      "type": "sound"
+    },
+    "jpaq-1sd": {
+      "filename": "jpaq-1sd",
+      "type": "sound"
+    },
+    "jpaq-4sd": {
+      "filename": "jpaq-4sd",
+      "type": "sound"
+    },
+    "jpaq12sd": {
+      "filename": "jpaq12sd",
+      "type": "sound"
+    },
+    "jpaq-5sd": {
+      "filename": "jpaq-5sd",
+      "type": "sound"
+    },
+    "jpaq-8sd": {
+      "filename": "jpaq-8sd",
+      "type": "sound"
+    },
+    "jpaq-2sd": {
+      "filename": "jpaq-2sd",
+      "type": "sound"
+    },
+    "jpaq-3sd": {
+      "filename": "jpaq-3sd",
+      "type": "sound"
+    },
+    "jpaq11sd": {
+      "filename": "jpaq11sd",
+      "type": "sound"
+    },
+    "jpaqsds": {
+      "filename": "jpaqsds",
+      "type": "sound"
+    }
+  },
+  "cntforc7": {
+    "656.snd": {
+      "filename": "656.snd",
+      "type": "sound"
+    },
+    "656-2.cpu": {
+      "filename": "656-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "656-1.cpu": {
+      "filename": "656-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "cntforce": {
+    "656.snd": {
+      "filename": "656.snd",
+      "type": "sound"
+    },
+    "656-2.cpu": {
+      "filename": "656-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "656-1.cpu": {
+      "filename": "656-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "gpr340g": {
+    "gpdspg.303": {
+      "filename": "gpdspg.303",
+      "type": "dmd"
+    },
+    "gpsndg.u17": {
+      "filename": "gpsndg.u17",
+      "type": "sound"
+    },
+    "gpcpug.340": {
+      "filename": "gpcpug.340",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndg.u36": {
+      "filename": "gpsndg.u36",
+      "type": "sound"
+    },
+    "gpsndg.u21": {
+      "filename": "gpsndg.u21",
+      "type": "sound"
+    },
+    "gpsndg.u7": {
+      "filename": "gpsndg.u7",
+      "type": "sound"
+    },
+    "gpsndg.u37": {
+      "filename": "gpsndg.u37",
+      "type": "sound"
+    }
+  },
+  "gpr350g": {
+    "gpdspg.303": {
+      "filename": "gpdspg.303",
+      "type": "dmd"
+    },
+    "gpsndg.u17": {
+      "filename": "gpsndg.u17",
+      "type": "sound"
+    },
+    "gpsndg.u36": {
+      "filename": "gpsndg.u36",
+      "type": "sound"
+    },
+    "gpsndg.u21": {
+      "filename": "gpsndg.u21",
+      "type": "sound"
+    },
+    "gpcpug.350": {
+      "filename": "gpcpug.350",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndg.u7": {
+      "filename": "gpsndg.u7",
+      "type": "sound"
+    },
+    "gpsndg.u37": {
+      "filename": "gpsndg.u37",
+      "type": "sound"
+    }
+  },
+  "gpr352g": {
+    "gpdspg.303": {
+      "filename": "gpdspg.303",
+      "type": "dmd"
+    },
+    "gpsndg.u17": {
+      "filename": "gpsndg.u17",
+      "type": "sound"
+    },
+    "gpsndg.u36": {
+      "filename": "gpsndg.u36",
+      "type": "sound"
+    },
+    "gpsndg.u21": {
+      "filename": "gpsndg.u21",
+      "type": "sound"
+    },
+    "gpsndg.u7": {
+      "filename": "gpsndg.u7",
+      "type": "sound"
+    },
+    "gpcpug.352": {
+      "filename": "gpcpug.352",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndg.u37": {
+      "filename": "gpsndg.u37",
+      "type": "sound"
+    }
+  },
+  "vipr_102": {
+    "vpru37.dat": {
+      "filename": "vpru37.dat",
+      "type": "sound"
+    },
+    "vpru21.dat": {
+      "filename": "vpru21.dat",
+      "type": "sound"
+    },
+    "vipdspa.100": {
+      "filename": "vipdspa.100",
+      "type": "dmd"
+    },
+    "vpru17.dat": {
+      "filename": "vpru17.dat",
+      "type": "sound"
+    },
+    "vipcpu.102": {
+      "filename": "vipcpu.102",
+      "type": "main",
+      "romType": "se"
+    },
+    "vpru36.dat": {
+      "filename": "vpru36.dat",
+      "type": "sound"
+    },
+    "vpru7.dat": {
+      "filename": "vpru7.dat",
+      "type": "sound"
+    }
+  },
+  "viprsega": {
+    "vpru37.dat": {
+      "filename": "vpru37.dat",
+      "type": "sound"
+    },
+    "vpru21.dat": {
+      "filename": "vpru21.dat",
+      "type": "sound"
+    },
+    "vipdspa.201": {
+      "filename": "vipdspa.201",
+      "type": "dmd"
+    },
+    "vipcpu.201": {
+      "filename": "vipcpu.201",
+      "type": "main",
+      "romType": "se"
+    },
+    "vpru17.dat": {
+      "filename": "vpru17.dat",
+      "type": "sound"
+    },
+    "vpru36.dat": {
+      "filename": "vpru36.dat",
+      "type": "sound"
+    },
+    "vpru7.dat": {
+      "filename": "vpru7.dat",
+      "type": "sound"
+    }
+  },
+  "acd_163": {
+    "acd_163.bin": {
+      "filename": "acd_163.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fathomb": {
+    "fathomu6.732": {
+      "filename": "fathomu6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "842-01_4.532": {
+      "filename": "842-01_4.532",
+      "type": "sound"
+    },
+    "842-02_5.532": {
+      "filename": "842-02_5.532",
+      "type": "sound"
+    },
+    "fathomu2.732": {
+      "filename": "fathomu2.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "blackjck": {
+    "720-20_6.716": {
+      "filename": "720-20_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "728-32_2.716": {
+      "filename": "728-32_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "eightbll": {
+    "720-20_6.716": {
+      "filename": "720-20_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "723-20_2.716": {
+      "filename": "723-20_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "evelknie": {
+    "720-20_6.716": {
+      "filename": "720-20_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "722-17_2.716": {
+      "filename": "722-17_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "matahari": {
+    "720-20_6.716": {
+      "filename": "720-20_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "725-21_2.716": {
+      "filename": "725-21_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "nightr20": {
+    "720-20_6.716": {
+      "filename": "720-20_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "721-21_1.716": {
+      "filename": "721-21_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "nightrdr": {
+    "720-20_6.716": {
+      "filename": "720-20_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "721-21_1.716": {
+      "filename": "721-21_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "pwerplay": {
+    "720-20_6.716": {
+      "filename": "720-20_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "724-25_2.716": {
+      "filename": "724-25_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "stk_sprs": {
+    "720-20_6.716": {
+      "filename": "720-20_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "740-16_2.716": {
+      "filename": "740-16_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "bbh_170": {
+    "bbh_v1-7_a.bin": {
+      "filename": "BBH_V1-7_A.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "nbamac": {
+    "nba_mac.cpu": {
+      "filename": "nba_mac.cpu",
+      "type": "main"
+    },
+    "nba_mac.snd": {
+      "filename": "nba_mac.snd",
+      "type": "main"
+    }
+  },
+  "shr_130": {
+    "shr_130.bin": {
+      "filename": "shr_130.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "startrp": {
+    "u21_0291.040": {
+      "filename": "u21_0291.040",
+      "type": "sound"
+    },
+    "sstcpu.201": {
+      "filename": "sstcpu.201",
+      "type": "main",
+      "romType": "se"
+    },
+    "sstdspa.200": {
+      "filename": "sstdspa.200",
+      "type": "dmd"
+    },
+    "u17_152a.040": {
+      "filename": "u17_152a.040",
+      "type": "sound"
+    },
+    "u36_95a7.040": {
+      "filename": "u36_95a7.040",
+      "type": "sound"
+    },
+    "u7_b130.512": {
+      "filename": "u7_b130.512",
+      "type": "sound"
+    }
+  },
+  "startrp2": {
+    "u21_0291.040": {
+      "filename": "u21_0291.040",
+      "type": "sound"
+    },
+    "sstcpu.200": {
+      "filename": "sstcpu.200",
+      "type": "main",
+      "romType": "se"
+    },
+    "sstdspa.200": {
+      "filename": "sstdspa.200",
+      "type": "dmd"
+    },
+    "u17_152a.040": {
+      "filename": "u17_152a.040",
+      "type": "sound"
+    },
+    "u36_95a7.040": {
+      "filename": "u36_95a7.040",
+      "type": "sound"
+    },
+    "u7_b130.512": {
+      "filename": "u7_b130.512",
+      "type": "sound"
+    }
+  },
+  "mnfb_c27": {
+    "mnf-f5-6.512": {
+      "filename": "mnf-f5-6.512",
+      "type": "sound"
+    },
+    "mnfb2-7.c5": {
+      "filename": "mnfb2-7.c5",
+      "type": "main",
+      "romType": "de"
+    },
+    "mnfb2-7.b5": {
+      "filename": "mnfb2-7.b5",
+      "type": "main",
+      "romType": "de"
+    },
+    "mnf-f4-5.512": {
+      "filename": "mnf-f4-5.512",
+      "type": "sound"
+    },
+    "mnf-f7.256": {
+      "filename": "mnf-f7.256",
+      "type": "sound"
+    }
+  },
+  "flashgdf": {
+    "834-23_2.732": {
+      "filename": "834-23_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-36_5.532": {
+      "filename": "834-36_5.532",
+      "type": "sound"
+    },
+    "720-52_6.732": {
+      "filename": "720-52_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-35_2.532": {
+      "filename": "834-35_2.532",
+      "type": "sound"
+    }
+  },
+  "flashgdn": {
+    "834-23_2.732": {
+      "filename": "834-23_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-52_6.732": {
+      "filename": "720-52_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-20_2.532": {
+      "filename": "834-20_2.532",
+      "type": "sound"
+    },
+    "834-18_5.532": {
+      "filename": "834-18_5.532",
+      "type": "sound"
+    }
+  },
+  "flashgdv": {
+    "834-23_2.732": {
+      "filename": "834-23_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-09_7.532": {
+      "filename": "834-09_7.532",
+      "type": "sound"
+    },
+    "834-05_3.532": {
+      "filename": "834-05_3.532",
+      "type": "sound"
+    },
+    "720-52_6.732": {
+      "filename": "720-52_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-08_6.532": {
+      "filename": "834-08_6.532",
+      "type": "sound"
+    },
+    "834-07_5.532": {
+      "filename": "834-07_5.532",
+      "type": "sound"
+    },
+    "834-03_1.532": {
+      "filename": "834-03_1.532",
+      "type": "sound"
+    },
+    "834-06_4.532": {
+      "filename": "834-06_4.532",
+      "type": "sound"
+    },
+    "834-04_2.532": {
+      "filename": "834-04_2.532",
+      "type": "sound"
+    },
+    "834-02_4.532": {
+      "filename": "834-02_4.532",
+      "type": "sound"
+    }
+  },
+  "rally": {
+    "rally_s1.bin": {
+      "filename": "rally_s1.bin",
+      "type": "sound"
+    },
+    "rally3.bin": {
+      "filename": "rally3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "rally4.bin": {
+      "filename": "rally4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "rally_s2.bin": {
+      "filename": "rally_s2.bin",
+      "type": "sound"
+    },
+    "rally1.bin": {
+      "filename": "rally1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "rally2.bin": {
+      "filename": "rally2.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "sorcr_l1": {
+    "spch_u4.732": {
+      "filename": "spch_u4.732",
+      "type": "sound"
+    },
+    "cpu_u19.732": {
+      "filename": "cpu_u19.732",
+      "type": "main",
+      "romType": "s9"
+    },
+    "cpu_u49.128": {
+      "filename": "cpu_u49.128",
+      "type": "sound"
+    },
+    "spch_u6.732": {
+      "filename": "spch_u6.732",
+      "type": "sound"
+    },
+    "spch_u7.732": {
+      "filename": "spch_u7.732",
+      "type": "sound"
+    },
+    "cpu_u20.764": {
+      "filename": "cpu_u20.764",
+      "type": "main",
+      "romType": "s9"
+    },
+    "spch_u5.732": {
+      "filename": "spch_u5.732",
+      "type": "sound"
+    }
+  },
+  "sorcr_l2": {
+    "spch_u4.732": {
+      "filename": "spch_u4.732",
+      "type": "sound"
+    },
+    "cpu_u20.l2": {
+      "filename": "cpu_u20.l2",
+      "type": "main",
+      "romType": "s9"
+    },
+    "cpu_u49.128": {
+      "filename": "cpu_u49.128",
+      "type": "sound"
+    },
+    "spch_u6.732": {
+      "filename": "spch_u6.732",
+      "type": "sound"
+    },
+    "spch_u7.732": {
+      "filename": "spch_u7.732",
+      "type": "sound"
+    },
+    "spch_u5.732": {
+      "filename": "spch_u5.732",
+      "type": "sound"
+    },
+    "cpu_u19.l2": {
+      "filename": "cpu_u19.l2",
+      "type": "main",
+      "romType": "s9"
+    }
+  },
+  "socrkina": {
+    "soccer.ic2": {
+      "filename": "soccer.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound1.c": {
+      "filename": "sound1.c",
+      "type": "sound"
+    },
+    "soccer.ic1": {
+      "filename": "soccer.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound3.f": {
+      "filename": "sound3.f",
+      "type": "sound"
+    },
+    "soccer.1c3": {
+      "filename": "soccer.1c3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound4.g": {
+      "filename": "sound4.g",
+      "type": "sound"
+    },
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    }
+  },
+  "socrking": {
+    "soccer.ic2": {
+      "filename": "soccer.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound1.c": {
+      "filename": "sound1.c",
+      "type": "sound"
+    },
+    "soccer.ic1": {
+      "filename": "soccer.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound3.f": {
+      "filename": "sound3.f",
+      "type": "sound"
+    },
+    "soccer.ic3": {
+      "filename": "soccer.ic3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound4.g": {
+      "filename": "sound4.g",
+      "type": "sound"
+    },
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    }
+  },
+  "socrkngg": {
+    "soccer.ic2": {
+      "filename": "soccer.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sk-de4.g": {
+      "filename": "sk-de4.g",
+      "type": "sound"
+    },
+    "sk-de3.f": {
+      "filename": "sk-de3.f",
+      "type": "sound"
+    },
+    "soccer.ic1": {
+      "filename": "soccer.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "soccer.ic3": {
+      "filename": "soccer.ic3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sk-de1.c": {
+      "filename": "sk-de1.c",
+      "type": "sound"
+    },
+    "sk-de2.e": {
+      "filename": "sk-de2.e",
+      "type": "sound"
+    },
+    "sk-de5.h": {
+      "filename": "sk-de5.h",
+      "type": "sound"
+    }
+  },
+  "socrkngi": {
+    "soccer.ic2": {
+      "filename": "soccer.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sking_it.1f": {
+      "filename": "sking_it.1f",
+      "type": "sound"
+    },
+    "sking_it.1c": {
+      "filename": "sking_it.1c",
+      "type": "sound"
+    },
+    "soccer.ic1": {
+      "filename": "soccer.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "soccer.ic3": {
+      "filename": "soccer.ic3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sking_it.1g": {
+      "filename": "sking_it.1g",
+      "type": "sound"
+    },
+    "sking_it.1e": {
+      "filename": "sking_it.1e",
+      "type": "sound"
+    }
+  },
+  "farffp": {
+    "farffp.ic1": {
+      "filename": "farffp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "farffp.ic2": {
+      "filename": "farffp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rom2.snd": {
+      "filename": "rom2.snd",
+      "type": "sound"
+    },
+    "rom1.snd": {
+      "filename": "rom1.snd",
+      "type": "sound"
+    },
+    "rom3.snd": {
+      "filename": "rom3.snd",
+      "type": "sound"
+    }
+  },
+  "farfifp": {
+    "farffp.ic1": {
+      "filename": "farffp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "farffp.ic2": {
+      "filename": "farffp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rom2.snd": {
+      "filename": "rom2.snd",
+      "type": "sound"
+    },
+    "farsnd3.bin": {
+      "filename": "farsnd3.bin",
+      "type": "sound"
+    },
+    "farsnd1.bin": {
+      "filename": "farsnd1.bin",
+      "type": "sound"
+    }
+  },
+  "cavnegro": {
+    "cn4.bin": {
+      "filename": "cn4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn3.bin": {
+      "filename": "cn3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn1.bin": {
+      "filename": "cn1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn2.bin": {
+      "filename": "cn2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn_s2.bin": {
+      "filename": "cn_s2.bin",
+      "type": "sound"
+    },
+    "cn_s1.bin": {
+      "filename": "cn_s1.bin",
+      "type": "sound"
+    }
+  },
+  "lw3_203": {
+    "lw3cpuu.203": {
+      "filename": "lw3cpuu.203",
+      "type": "main",
+      "romType": "de"
+    },
+    "lw3dsp1.204": {
+      "filename": "lw3dsp1.204",
+      "type": "dmd"
+    },
+    "lw3dsp0.204": {
+      "filename": "lw3dsp0.204",
+      "type": "dmd"
+    }
+  },
+  "totan_12": {
+    "ans2v1_1.rom": {
+      "filename": "ans2v1_1.rom",
+      "type": "sound"
+    },
+    "ans5v1_0.rom": {
+      "filename": "ans5v1_0.rom",
+      "type": "sound"
+    },
+    "ans3v1_0.rom": {
+      "filename": "ans3v1_0.rom",
+      "type": "sound"
+    },
+    "ans4v1_0.rom": {
+      "filename": "ans4v1_0.rom",
+      "type": "sound"
+    },
+    "arab1_2.rom": {
+      "filename": "arab1_2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "totan_13": {
+    "ans2v1_1.rom": {
+      "filename": "ans2v1_1.rom",
+      "type": "sound"
+    },
+    "arab1_3.rom": {
+      "filename": "arab1_3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ans5v1_0.rom": {
+      "filename": "ans5v1_0.rom",
+      "type": "sound"
+    },
+    "ans3v1_0.rom": {
+      "filename": "ans3v1_0.rom",
+      "type": "sound"
+    },
+    "ans4v1_0.rom": {
+      "filename": "ans4v1_0.rom",
+      "type": "sound"
+    }
+  },
+  "totan_14": {
+    "ans2v1_1.rom": {
+      "filename": "ans2v1_1.rom",
+      "type": "sound"
+    },
+    "ans5v1_0.rom": {
+      "filename": "ans5v1_0.rom",
+      "type": "sound"
+    },
+    "ans3v1_0.rom": {
+      "filename": "ans3v1_0.rom",
+      "type": "sound"
+    },
+    "an_g11.1_4": {
+      "filename": "an_g11.1_4",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ans4v1_0.rom": {
+      "filename": "ans4v1_0.rom",
+      "type": "sound"
+    }
+  },
+  "hirol_fr": {
+    "hrccpu.300": {
+      "filename": "hrccpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "hrsndu36.100": {
+      "filename": "hrsndu36.100",
+      "type": "sound"
+    },
+    "hrsndu17.100": {
+      "filename": "hrsndu17.100",
+      "type": "sound"
+    },
+    "hrsndu7.100": {
+      "filename": "hrsndu7.100",
+      "type": "sound"
+    },
+    "hrsndu21.100": {
+      "filename": "hrsndu21.100",
+      "type": "sound"
+    },
+    "hrsndu37.100": {
+      "filename": "hrsndu37.100",
+      "type": "sound"
+    }
+  },
+  "hirol_g3": {
+    "hrccpu.300": {
+      "filename": "hrccpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "hrsndu36.100": {
+      "filename": "hrsndu36.100",
+      "type": "sound"
+    },
+    "hrsndu17.100": {
+      "filename": "hrsndu17.100",
+      "type": "sound"
+    },
+    "hrcdispg.300": {
+      "filename": "hrcdispg.300",
+      "type": "dmd"
+    },
+    "hrsndu7.100": {
+      "filename": "hrsndu7.100",
+      "type": "sound"
+    },
+    "hrsndu21.100": {
+      "filename": "hrsndu21.100",
+      "type": "sound"
+    },
+    "hrsndu37.100": {
+      "filename": "hrsndu37.100",
+      "type": "sound"
+    }
+  },
+  "hirol_it": {
+    "hrccpu.300": {
+      "filename": "hrccpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "hrsndu36.100": {
+      "filename": "hrsndu36.100",
+      "type": "sound"
+    },
+    "hrsndu17.100": {
+      "filename": "hrsndu17.100",
+      "type": "sound"
+    },
+    "hrsndu7.100": {
+      "filename": "hrsndu7.100",
+      "type": "sound"
+    },
+    "hrsndu21.100": {
+      "filename": "hrsndu21.100",
+      "type": "sound"
+    },
+    "hrsndu37.100": {
+      "filename": "hrsndu37.100",
+      "type": "sound"
+    }
+  },
+  "gpr301g": {
+    "gpdspg.301": {
+      "filename": "gpdspg.301",
+      "type": "dmd"
+    },
+    "gpcpug.301": {
+      "filename": "gpcpug.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndg.u17": {
+      "filename": "gpsndg.u17",
+      "type": "sound"
+    },
+    "gpsndg.u36": {
+      "filename": "gpsndg.u36",
+      "type": "sound"
+    },
+    "gpsndg.u21": {
+      "filename": "gpsndg.u21",
+      "type": "sound"
+    },
+    "gpsndg.u7": {
+      "filename": "gpsndg.u7",
+      "type": "sound"
+    },
+    "gpsndg.u37": {
+      "filename": "gpsndg.u37",
+      "type": "sound"
+    }
+  },
+  "petaco2": {
+    "jpsonid4.dat": {
+      "filename": "jpsonid4.dat",
+      "type": "sound"
+    },
+    "jpsonid0.dat": {
+      "filename": "jpsonid0.dat",
+      "type": "sound"
+    },
+    "jpsonid6.dat": {
+      "filename": "jpsonid6.dat",
+      "type": "sound"
+    },
+    "jpsonid5.dat": {
+      "filename": "jpsonid5.dat",
+      "type": "sound"
+    },
+    "jpsonid2.dat": {
+      "filename": "jpsonid2.dat",
+      "type": "sound"
+    },
+    "jpsonid3.dat": {
+      "filename": "jpsonid3.dat",
+      "type": "sound"
+    },
+    "jpsonid1.dat": {
+      "filename": "jpsonid1.dat",
+      "type": "sound"
+    },
+    "jpsonid7.dat": {
+      "filename": "jpsonid7.dat",
+      "type": "sound"
+    }
+  },
+  "mtl_122h": {
+    "mtl_122h.bin": {
+      "filename": "mtl_122h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "t2_l6": {
+    "t2_l6.u6": {
+      "filename": "t2_l6.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "vortex": {
+    "vortex2.bin": {
+      "filename": "vortex2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "vortex4.bin": {
+      "filename": "vortex4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "vrtex_s2.bin": {
+      "filename": "vrtex_s2.bin",
+      "type": "sound"
+    },
+    "vrtex_s1.bin": {
+      "filename": "vrtex_s1.bin",
+      "type": "sound"
+    },
+    "vortex3.bin": {
+      "filename": "vortex3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "vortex1.bin": {
+      "filename": "vortex1.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "alpok_f6": {
+    "5t5016fr.dat": {
+      "filename": "5t5016fr.dat",
+      "type": "sound"
+    },
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "5t5014fr.dat": {
+      "filename": "5t5014fr.dat",
+      "type": "sound"
+    },
+    "gamerom6.716": {
+      "filename": "gamerom6.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "5t5017fr.dat": {
+      "filename": "5t5017fr.dat",
+      "type": "sound"
+    },
+    "5t5015fr.dat": {
+      "filename": "5t5015fr.dat",
+      "type": "sound"
+    }
+  },
+  "dvlrdfp": {
+    "driders.ic2": {
+      "filename": "driders.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "gb01snd2.1e": {
+      "filename": "gb01snd2.1e",
+      "type": "sound"
+    },
+    "gb01snd3.1g": {
+      "filename": "gb01snd3.1g",
+      "type": "sound"
+    },
+    "gb01snd1.1d": {
+      "filename": "gb01snd1.1d",
+      "type": "sound"
+    },
+    "driders.ic1": {
+      "filename": "driders.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "dvlrdgfp": {
+    "driders.ic2": {
+      "filename": "driders.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "g_snd_3.bin": {
+      "filename": "g_snd_3.bin",
+      "type": "sound"
+    },
+    "g_snd_2.bin": {
+      "filename": "g_snd_2.bin",
+      "type": "sound"
+    },
+    "g_snd_1.bin": {
+      "filename": "g_snd_1.bin",
+      "type": "sound"
+    },
+    "driders.ic1": {
+      "filename": "driders.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "sman_140ai": {
+    "spd_1_4_ei.bin": {
+      "filename": "spd_1_4_ei.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fire_l3": {
+    "fire_u4.l1": {
+      "filename": "fire_u4.l1",
+      "type": "sound"
+    },
+    "fire_u22.l2": {
+      "filename": "fire_u22.l2",
+      "type": "sound"
+    },
+    "fire_u21.l2": {
+      "filename": "fire_u21.l2",
+      "type": "sound"
+    },
+    "fire_u26.l3": {
+      "filename": "fire_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "fire_u27.l3": {
+      "filename": "fire_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "sshtlzac": {
+    "spcshtl2.lgc": {
+      "filename": "spcshtl2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "zac_boot.lgc": {
+      "filename": "zac_boot.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spcshtl.snd": {
+      "filename": "spcshtl.snd",
+      "type": "sound"
+    },
+    "spcshtl4.lgc": {
+      "filename": "spcshtl4.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spcshtl3.lgc": {
+      "filename": "spcshtl3.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spcshtl5.lgc": {
+      "filename": "spcshtl5.lgc",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "pb_l5h": {
+    "pbot_u27.l5": {
+      "filename": "pbot_u27.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pbot_u21.l1": {
+      "filename": "pbot_u21.l1",
+      "type": "sound"
+    },
+    "pbot_u19.l1": {
+      "filename": "pbot_u19.l1",
+      "type": "sound"
+    },
+    "pbot_u26.l5": {
+      "filename": "pbot_u26.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pbot_u22.l1": {
+      "filename": "pbot_u22.l1",
+      "type": "sound"
+    },
+    "pbot_u4.l1": {
+      "filename": "pbot_u4.l1",
+      "type": "sound"
+    }
+  },
+  "sopr400f": {
+    "sopsndf.u17": {
+      "filename": "sopsndf.u17",
+      "type": "sound"
+    },
+    "sopsndf.u21": {
+      "filename": "sopsndf.u21",
+      "type": "sound"
+    },
+    "sopsndf.u37": {
+      "filename": "sopsndf.u37",
+      "type": "sound"
+    },
+    "sopsndf.u7": {
+      "filename": "sopsndf.u7",
+      "type": "sound"
+    },
+    "sopsndf.u36": {
+      "filename": "sopsndf.u36",
+      "type": "sound"
+    },
+    "sopcpuf.400": {
+      "filename": "sopcpuf.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopdspf.400": {
+      "filename": "sopdspf.400",
+      "type": "dmd"
+    }
+  },
+  "twst_300": {
+    "twstsnd.u17": {
+      "filename": "twstsnd.u17",
+      "type": "sound"
+    },
+    "twstcpu.300": {
+      "filename": "twstcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "twstsnd.u7": {
+      "filename": "twstsnd.u7",
+      "type": "sound"
+    },
+    "twstdspa.301": {
+      "filename": "twstdspa.301",
+      "type": "dmd"
+    },
+    "twstsnd.u21": {
+      "filename": "twstsnd.u21",
+      "type": "sound"
+    }
+  },
+  "twst_404": {
+    "twstsnd.u17": {
+      "filename": "twstsnd.u17",
+      "type": "sound"
+    },
+    "twstcpu.404": {
+      "filename": "twstcpu.404",
+      "type": "main",
+      "romType": "se"
+    },
+    "twstsnd.u7": {
+      "filename": "twstsnd.u7",
+      "type": "sound"
+    },
+    "twstdspa.400": {
+      "filename": "twstdspa.400",
+      "type": "dmd"
+    },
+    "twstsnd.u21": {
+      "filename": "twstsnd.u21",
+      "type": "sound"
+    }
+  },
+  "twst_405": {
+    "twstsnd.u17": {
+      "filename": "twstsnd.u17",
+      "type": "sound"
+    },
+    "twstsnd.u7": {
+      "filename": "twstsnd.u7",
+      "type": "sound"
+    },
+    "twstcpu.405": {
+      "filename": "twstcpu.405",
+      "type": "main",
+      "romType": "se"
+    },
+    "twstdspa.400": {
+      "filename": "twstdspa.400",
+      "type": "dmd"
+    },
+    "twstsnd.u21": {
+      "filename": "twstsnd.u21",
+      "type": "sound"
+    }
+  },
+  "howzat": {
+    "hz_ic14.snd": {
+      "filename": "hz_ic14.snd",
+      "type": "sound"
+    },
+    "hz_ic2.mpu": {
+      "filename": "hz_ic2.mpu",
+      "type": "main",
+      "romType": "hnk"
+    },
+    "hz_ic3.mpu": {
+      "filename": "hz_ic3.mpu",
+      "type": "main",
+      "romType": "hnk"
+    },
+    "hz_ic3.snd": {
+      "filename": "hz_ic3.snd",
+      "type": "sound"
+    }
+  },
+  "sleicpin": {
+    "sp02-1_1.rom": {
+      "filename": "sp02-1_1.rom",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "sp01-1_1.rom": {
+      "filename": "sp01-1_1.rom",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "sp03-1_1.rom": {
+      "filename": "sp03-1_1.rom",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "sp04-1_1.rom": {
+      "filename": "sp04-1_1.rom",
+      "type": "main",
+      "romType": "sleic"
+    }
+  },
+  "strxt_fr": {
+    "soc.u37": {
+      "filename": "soc.u37",
+      "type": "sound"
+    },
+    "sxcpuf.102": {
+      "filename": "sxcpuf.102",
+      "type": "main",
+      "romType": "se"
+    },
+    "soc.u36": {
+      "filename": "soc.u36",
+      "type": "sound"
+    },
+    "sxdispf.103": {
+      "filename": "sxdispf.103",
+      "type": "dmd"
+    },
+    "soc.u21": {
+      "filename": "soc.u21",
+      "type": "sound"
+    },
+    "soc.u7": {
+      "filename": "soc.u7",
+      "type": "sound"
+    },
+    "soc.u17": {
+      "filename": "soc.u17",
+      "type": "sound"
+    }
+  },
+  "strxt_sp": {
+    "soc.u37": {
+      "filename": "soc.u37",
+      "type": "sound"
+    },
+    "soc.u36": {
+      "filename": "soc.u36",
+      "type": "sound"
+    },
+    "sxdispl.103": {
+      "filename": "sxdispl.103",
+      "type": "dmd"
+    },
+    "sxcpul.102": {
+      "filename": "sxcpul.102",
+      "type": "main",
+      "romType": "se"
+    },
+    "soc.u21": {
+      "filename": "soc.u21",
+      "type": "sound"
+    },
+    "soc.u7": {
+      "filename": "soc.u7",
+      "type": "sound"
+    },
+    "soc.u17": {
+      "filename": "soc.u17",
+      "type": "sound"
+    }
+  },
+  "gork": {
+    "gork4.bin": {
+      "filename": "gork4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gork3.bin": {
+      "filename": "gork3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gork_s2.bin": {
+      "filename": "gork_s2.bin",
+      "type": "sound"
+    },
+    "gork2.bin": {
+      "filename": "gork2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gork_s1.bin": {
+      "filename": "gork_s1.bin",
+      "type": "sound"
+    },
+    "gork1.bin": {
+      "filename": "gork1.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "corv_lx1": {
+    "u6-lx1.rom": {
+      "filename": "u6-lx1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "corvsnd7": {
+      "filename": "corvsnd7",
+      "type": "sound"
+    },
+    "su2-sl1.rom": {
+      "filename": "su2-sl1.rom",
+      "type": "sound"
+    },
+    "corvsnd5": {
+      "filename": "corvsnd5",
+      "type": "sound"
+    },
+    "corvsnd6": {
+      "filename": "corvsnd6",
+      "type": "sound"
+    },
+    "corvsnd3": {
+      "filename": "corvsnd3",
+      "type": "sound"
+    },
+    "corvsnd4": {
+      "filename": "corvsnd4",
+      "type": "sound"
+    }
+  },
+  "gi_l3": {
+    "gi_u14.l2": {
+      "filename": "gi_u14.l2",
+      "type": "sound"
+    },
+    "gi_l3.u6": {
+      "filename": "gi_l3.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "gi_u18.l2": {
+      "filename": "gi_u18.l2",
+      "type": "sound"
+    },
+    "gi_u15.l2": {
+      "filename": "gi_u15.l2",
+      "type": "sound"
+    }
+  },
+  "gi_l4": {
+    "gi_u14.l2": {
+      "filename": "gi_u14.l2",
+      "type": "sound"
+    },
+    "gi_l4.u6": {
+      "filename": "gi_l4.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "gi_u18.l2": {
+      "filename": "gi_u18.l2",
+      "type": "sound"
+    },
+    "gi_u15.l2": {
+      "filename": "gi_u15.l2",
+      "type": "sound"
+    }
+  },
+  "gi_l6": {
+    "gi_u14.l2": {
+      "filename": "gi_u14.l2",
+      "type": "sound"
+    },
+    "gi_l6.u6": {
+      "filename": "gi_l6.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "gi_u18.l2": {
+      "filename": "gi_u18.l2",
+      "type": "sound"
+    },
+    "gi_u15.l2": {
+      "filename": "gi_u15.l2",
+      "type": "sound"
+    }
+  },
+  "gi_l9": {
+    "gi_u14.l2": {
+      "filename": "gi_u14.l2",
+      "type": "sound"
+    },
+    "gilli_l9.rom": {
+      "filename": "gilli_l9.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "gi_u18.l2": {
+      "filename": "gi_u18.l2",
+      "type": "sound"
+    },
+    "gi_u15.l2": {
+      "filename": "gi_u15.l2",
+      "type": "sound"
+    }
+  },
+  "gpr400f": {
+    "gpcpuf.400": {
+      "filename": "gpcpuf.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndf.u17": {
+      "filename": "gpsndf.u17",
+      "type": "sound"
+    },
+    "gpsndf.u36": {
+      "filename": "gpsndf.u36",
+      "type": "sound"
+    },
+    "gpsndf.u7": {
+      "filename": "gpsndf.u7",
+      "type": "sound"
+    },
+    "gpsndf.u21": {
+      "filename": "gpsndf.u21",
+      "type": "sound"
+    },
+    "gpsndf.u37": {
+      "filename": "gpsndf.u37",
+      "type": "sound"
+    },
+    "gpdspf.400": {
+      "filename": "gpdspf.400",
+      "type": "dmd"
+    }
+  },
+  "kissc": {
+    "strekc.u6": {
+      "filename": "strekc.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "kiss2732.u2": {
+      "filename": "kiss2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "missworld": {
+    "strekc.u6": {
+      "filename": "strekc.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "kiss2732.u2": {
+      "filename": "kiss2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "paragonc": {
+    "strekc.u6": {
+      "filename": "strekc.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    },
+    "para2732.u2": {
+      "filename": "para2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "playboyc": {
+    "strekc.u6": {
+      "filename": "strekc.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "play2732.u2": {
+      "filename": "play2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "startrec": {
+    "strekc.u6": {
+      "filename": "strekc.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "star2732.u2": {
+      "filename": "star2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "smmanc": {
+    "strekc.u6": {
+      "filename": "strekc.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "6mi$2732.u2": {
+      "filename": "6mi$2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "sstc": {
+    "strekc.u6": {
+      "filename": "strekc.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "surp2732.u2": {
+      "filename": "surp2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "voltanc": {
+    "strekc.u6": {
+      "filename": "strekc.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "volt2732.u2": {
+      "filename": "volt2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "tz_p3": {
+    "u15-sp1.040": {
+      "filename": "u15-sp1.040",
+      "type": "sound"
+    },
+    "tzu18_p3.rom": {
+      "filename": "tzu18_p3.rom",
+      "type": "sound"
+    },
+    "u14-sp1.040": {
+      "filename": "u14-sp1.040",
+      "type": "sound"
+    },
+    "tz_p3.bin": {
+      "filename": "tz_p3.bin",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "tz_p4": {
+    "u15-sp1.040": {
+      "filename": "u15-sp1.040",
+      "type": "sound"
+    },
+    "tzu18_p3.rom": {
+      "filename": "tzu18_p3.rom",
+      "type": "sound"
+    },
+    "tz_p4.rom": {
+      "filename": "tz_p4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "u14-sp1.040": {
+      "filename": "u14-sp1.040",
+      "type": "sound"
+    }
+  },
+  "tz_pa1": {
+    "u15-sp1.040": {
+      "filename": "u15-sp1.040",
+      "type": "sound"
+    },
+    "u18-sp1.040": {
+      "filename": "u18-sp1.040",
+      "type": "sound"
+    },
+    "u14-sp1.040": {
+      "filename": "u14-sp1.040",
+      "type": "sound"
+    },
+    "u6-pa1.040": {
+      "filename": "u6-pa1.040",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "freedom": {
+    "720-07_6.716": {
+      "filename": "720-07_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-08_1.474": {
+      "filename": "720-08_1.474",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-10_2.474": {
+      "filename": "720-10_2.474",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "tmac_a18": {
+    "tmachf7.rom": {
+      "filename": "tmachf7.rom",
+      "type": "sound"
+    },
+    "tmachf6.rom": {
+      "filename": "tmachf6.rom",
+      "type": "sound"
+    },
+    "tmachf4.rom": {
+      "filename": "tmachf4.rom",
+      "type": "sound"
+    },
+    "tmach1-8.c5": {
+      "filename": "tmach1-8.c5",
+      "type": "main",
+      "romType": "de"
+    },
+    "tmach1-8.b5": {
+      "filename": "tmach1-8.b5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "tmac_a24": {
+    "tmachf7.rom": {
+      "filename": "tmachf7.rom",
+      "type": "sound"
+    },
+    "tmachf6.rom": {
+      "filename": "tmachf6.rom",
+      "type": "sound"
+    },
+    "tmachf4.rom": {
+      "filename": "tmachf4.rom",
+      "type": "sound"
+    },
+    "tmach2-4.b5": {
+      "filename": "tmach2-4.b5",
+      "type": "main",
+      "romType": "de"
+    },
+    "tmach2-4.c5": {
+      "filename": "tmach2-4.c5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "tmac_g18": {
+    "tmachf7.rom": {
+      "filename": "tmachf7.rom",
+      "type": "sound"
+    },
+    "tmachf6.rom": {
+      "filename": "tmachf6.rom",
+      "type": "sound"
+    },
+    "tmachg18.b5": {
+      "filename": "tmachg18.b5",
+      "type": "main",
+      "romType": "de"
+    },
+    "tmachf4.rom": {
+      "filename": "tmachf4.rom",
+      "type": "sound"
+    },
+    "tmachg18.c5": {
+      "filename": "tmachg18.c5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "fg_1000al": {
+    "fg1000al.bin": {
+      "filename": "fg1000al.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "opthund": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "tmfnt_l5": {
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "nba_801": {
+    "nba_v8-01_a.bin": {
+      "filename": "nba_v8-01_a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "hs_l3": {
+    "hs_u4.l1": {
+      "filename": "hs_u4.l1",
+      "type": "sound"
+    },
+    "hs_u27.l4": {
+      "filename": "hs_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "hs_u22.l2": {
+      "filename": "hs_u22.l2",
+      "type": "sound"
+    },
+    "hs_u21.l2": {
+      "filename": "hs_u21.l2",
+      "type": "sound"
+    },
+    "u26-l3.rom": {
+      "filename": "u26-l3.rom",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "hs_l4": {
+    "hs_u4.l1": {
+      "filename": "hs_u4.l1",
+      "type": "sound"
+    },
+    "hs_u27.l4": {
+      "filename": "hs_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "hs_u26.l4": {
+      "filename": "hs_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "hs_u22.l2": {
+      "filename": "hs_u22.l2",
+      "type": "sound"
+    },
+    "hs_u21.l2": {
+      "filename": "hs_u21.l2",
+      "type": "sound"
+    }
+  },
+  "sprbreak": {
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    }
+  },
+  "sprbrka": {
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "prom1a.cpu": {
+      "filename": "prom1a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2a.cpu": {
+      "filename": "prom2a.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "sprbrks": {
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "prom2.rv2": {
+      "filename": "prom2.rv2",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom1.rv2": {
+      "filename": "prom1.rv2",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "xenon": {
+    "811-40_1.716": {
+      "filename": "811-40_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-27_6.532": {
+      "filename": "811-27_6.532",
+      "type": "sound"
+    },
+    "811-41_2.716": {
+      "filename": "811-41_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-25_4.532": {
+      "filename": "811-25_4.532",
+      "type": "sound"
+    },
+    "811-23_2.532": {
+      "filename": "811-23_2.532",
+      "type": "sound"
+    },
+    "811-24_3.532": {
+      "filename": "811-24_3.532",
+      "type": "sound"
+    },
+    "811-26_5.532": {
+      "filename": "811-26_5.532",
+      "type": "sound"
+    },
+    "811-22_1.532": {
+      "filename": "811-22_1.532",
+      "type": "sound"
+    },
+    "811-28_7.532": {
+      "filename": "811-28_7.532",
+      "type": "sound"
+    },
+    "720-40_6.732": {
+      "filename": "720-40_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-35_4.532": {
+      "filename": "811-35_4.532",
+      "type": "sound"
+    }
+  },
+  "mntecrlo": {
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    }
+  },
+  "kiss": {
+    "746-14_2.716": {
+      "filename": "746-14_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-30_6.716": {
+      "filename": "720-30_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "746-11_1.716": {
+      "filename": "746-11_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "play_a24": {
+    "pbsnd5.dat": {
+      "filename": "pbsnd5.dat",
+      "type": "sound"
+    },
+    "play2-4.c5": {
+      "filename": "play2-4.c5",
+      "type": "main",
+      "romType": "de"
+    },
+    "play2-4.b5": {
+      "filename": "play2-4.b5",
+      "type": "main",
+      "romType": "de"
+    },
+    "pbsnd6.dat": {
+      "filename": "pbsnd6.dat",
+      "type": "sound"
+    },
+    "pbsnd7.dat": {
+      "filename": "pbsnd7.dat",
+      "type": "sound"
+    }
+  },
+  "moonlght": {
+    "ci-21.bin": {
+      "filename": "ci-21.bin",
+      "type": "sound"
+    },
+    "ci-22.bin": {
+      "filename": "ci-22.bin",
+      "type": "sound"
+    },
+    "ci-3.bin": {
+      "filename": "ci-3.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "ci-24.bin": {
+      "filename": "ci-24.bin",
+      "type": "sound"
+    },
+    "ci-11.bin": {
+      "filename": "ci-11.bin",
+      "type": "sound"
+    },
+    "ci-23.bin": {
+      "filename": "ci-23.bin",
+      "type": "sound"
+    }
+  },
+  "flashgp2": {
+    "xxx-xx2.u10": {
+      "filename": "xxx-xx2.u10",
+      "type": "main",
+      "romType": "by"
+    },
+    "xxx-xx2.u12": {
+      "filename": "xxx-xx2.u12",
+      "type": "main",
+      "romType": "by"
+    },
+    "fg6801.bin": {
+      "filename": "fg6801.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "xxx-xx2.u11": {
+      "filename": "xxx-xx2.u11",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "br_l1": {
+    "br_u15.l1": {
+      "filename": "br_u15.l1",
+      "type": "sound"
+    },
+    "br_u14.l1": {
+      "filename": "br_u14.l1",
+      "type": "sound"
+    },
+    "br_u18.l1": {
+      "filename": "br_u18.l1",
+      "type": "sound"
+    },
+    "u6-l1.rom": {
+      "filename": "u6-l1.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "br_l3": {
+    "br_u15.l1": {
+      "filename": "br_u15.l1",
+      "type": "sound"
+    },
+    "br_u14.l1": {
+      "filename": "br_u14.l1",
+      "type": "sound"
+    },
+    "br_u18.l1": {
+      "filename": "br_u18.l1",
+      "type": "sound"
+    },
+    "u6-l3.rom": {
+      "filename": "u6-l3.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "br_l4": {
+    "br_u15.l1": {
+      "filename": "br_u15.l1",
+      "type": "sound"
+    },
+    "br_u14.l1": {
+      "filename": "br_u14.l1",
+      "type": "sound"
+    },
+    "br_u18.l1": {
+      "filename": "br_u18.l1",
+      "type": "sound"
+    },
+    "brose_l4.rom": {
+      "filename": "brose_l4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "skflight": {
+    "snd_u4.256": {
+      "filename": "SND_U4.256",
+      "type": "main"
+    },
+    "snd_u3.256": {
+      "filename": "SND_U3.256",
+      "type": "main"
+    },
+    "game_u8.64": {
+      "filename": "GAME_U8.64",
+      "type": "main"
+    },
+    "game_u7.64": {
+      "filename": "GAME_U7.64",
+      "type": "main"
+    }
+  },
+  "bk_l4": {
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech5.532": {
+      "filename": "speech5.532",
+      "type": "sound"
+    },
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech7.532": {
+      "filename": "speech7.532",
+      "type": "sound"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech4.532": {
+      "filename": "speech4.532",
+      "type": "sound"
+    },
+    "speech6.532": {
+      "filename": "speech6.532",
+      "type": "sound"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "stwr_a14": {
+    "swrom0.a14": {
+      "filename": "swrom0.a14",
+      "type": "dmd"
+    },
+    "starcpua.103": {
+      "filename": "starcpua.103",
+      "type": "main",
+      "romType": "de"
+    },
+    "swrom1.a14": {
+      "filename": "swrom1.a14",
+      "type": "dmd"
+    },
+    "s-wars.u17": {
+      "filename": "s-wars.u17",
+      "type": "sound"
+    },
+    "s-wars.u21": {
+      "filename": "s-wars.u21",
+      "type": "sound"
+    },
+    "s-wars.u7": {
+      "filename": "s-wars.u7",
+      "type": "sound"
+    }
+  },
+  "cowboy": {
+    "cauboy.h": {
+      "filename": "cauboy.h",
+      "type": "main",
+      "romType": "ltd"
+    },
+    "cauboy.l": {
+      "filename": "cauboy.l",
+      "type": "main",
+      "romType": "ltd"
+    }
+  },
+  "sopr300": {
+    "sopsnda.u21": {
+      "filename": "sopsnda.u21",
+      "type": "sound"
+    },
+    "sopsnda.u17": {
+      "filename": "sopsnda.u17",
+      "type": "sound"
+    },
+    "sopsnda.u7": {
+      "filename": "sopsnda.u7",
+      "type": "sound"
+    },
+    "sopsnda.u37": {
+      "filename": "sopsnda.u37",
+      "type": "sound"
+    },
+    "sopdspa.300": {
+      "filename": "Sopdspa.300",
+      "type": "dmd"
+    },
+    "sopcpua.300": {
+      "filename": "SOPCPUA.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsnda.u36": {
+      "filename": "sopsnda.u36",
+      "type": "sound"
+    }
+  },
+  "sopr400": {
+    "sopsnda.u21": {
+      "filename": "sopsnda.u21",
+      "type": "sound"
+    },
+    "sopsnda.u17": {
+      "filename": "sopsnda.u17",
+      "type": "sound"
+    },
+    "sopsnda.u7": {
+      "filename": "sopsnda.u7",
+      "type": "sound"
+    },
+    "sopsnda.u37": {
+      "filename": "sopsnda.u37",
+      "type": "sound"
+    },
+    "sopdspa.400": {
+      "filename": "sopdspa.400",
+      "type": "dmd"
+    },
+    "sopcpua.400": {
+      "filename": "sopcpua.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsnda.u36": {
+      "filename": "sopsnda.u36",
+      "type": "sound"
+    }
+  },
+  "sopranos": {
+    "sopsnda.u21": {
+      "filename": "sopsnda.u21",
+      "type": "sound"
+    },
+    "sopdspa.500": {
+      "filename": "sopdspa.500",
+      "type": "dmd"
+    },
+    "sopsnda.u17": {
+      "filename": "sopsnda.u17",
+      "type": "sound"
+    },
+    "sopsnda.u7": {
+      "filename": "sopsnda.u7",
+      "type": "sound"
+    },
+    "sopsnda.u37": {
+      "filename": "sopsnda.u37",
+      "type": "sound"
+    },
+    "sopcpua.500": {
+      "filename": "sopcpua.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsnda.u36": {
+      "filename": "sopsnda.u36",
+      "type": "sound"
+    }
+  },
+  "fpwr2_l2": {
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "elv302g": {
+    "elvisg.u7": {
+      "filename": "Elvisg.u7",
+      "type": "sound"
+    },
+    "elvisg.u36": {
+      "filename": "elvisg.u36",
+      "type": "sound"
+    },
+    "elvsdspg.302": {
+      "filename": "ELVSDSPG.302",
+      "type": "dmd"
+    },
+    "elvisg.u21": {
+      "filename": "elvisg.u21",
+      "type": "sound"
+    },
+    "elvisg.u17": {
+      "filename": "elvisg.u17",
+      "type": "sound"
+    },
+    "elvscpug.302": {
+      "filename": "elvscpug.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisg.u37": {
+      "filename": "elvisg.u37",
+      "type": "sound"
+    }
+  },
+  "elv303g": {
+    "elvisg.u7": {
+      "filename": "Elvisg.u7",
+      "type": "sound"
+    },
+    "elvisg.u36": {
+      "filename": "elvisg.u36",
+      "type": "sound"
+    },
+    "elvsdspg.302": {
+      "filename": "ELVSDSPG.302",
+      "type": "dmd"
+    },
+    "elvscpug.303": {
+      "filename": "ELVSCPUG.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisg.u21": {
+      "filename": "elvisg.u21",
+      "type": "sound"
+    },
+    "elvisg.u17": {
+      "filename": "elvisg.u17",
+      "type": "sound"
+    },
+    "elvisg.u37": {
+      "filename": "elvisg.u37",
+      "type": "sound"
+    }
+  },
+  "elv400g": {
+    "elvisg.u7": {
+      "filename": "Elvisg.u7",
+      "type": "sound"
+    },
+    "elvisg.u36": {
+      "filename": "elvisg.u36",
+      "type": "sound"
+    },
+    "elvisg.u21": {
+      "filename": "elvisg.u21",
+      "type": "sound"
+    },
+    "elvisg.u17": {
+      "filename": "elvisg.u17",
+      "type": "sound"
+    },
+    "elvsdspg.401": {
+      "filename": "elvsdspg.401",
+      "type": "dmd"
+    },
+    "elvscpug.400": {
+      "filename": "elvscpug.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisg.u37": {
+      "filename": "elvisg.u37",
+      "type": "sound"
+    }
+  },
+  "elvisg": {
+    "elvisg.u7": {
+      "filename": "elvisg.u7",
+      "type": "sound"
+    },
+    "elvisg.u36": {
+      "filename": "elvisg.u36",
+      "type": "sound"
+    },
+    "elvisg.u21": {
+      "filename": "elvisg.u21",
+      "type": "sound"
+    },
+    "elvisg.u17": {
+      "filename": "elvisg.u17",
+      "type": "sound"
+    },
+    "elvsdspg.401": {
+      "filename": "elvsdspg.401",
+      "type": "dmd"
+    },
+    "elvscpug.400": {
+      "filename": "elvscpug.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisg.u37": {
+      "filename": "elvisg.u37",
+      "type": "sound"
+    }
+  },
+  "id4": {
+    "id4cpu.202": {
+      "filename": "id4cpu.202",
+      "type": "main",
+      "romType": "se"
+    },
+    "id4dspa.200": {
+      "filename": "id4dspa.200",
+      "type": "dmd"
+    },
+    "id4sdu17.400": {
+      "filename": "id4sdu17.400",
+      "type": "sound"
+    },
+    "id4sndu7.512": {
+      "filename": "id4sndu7.512",
+      "type": "sound"
+    },
+    "id4sdu21.400": {
+      "filename": "id4sdu21.400",
+      "type": "sound"
+    }
+  },
+  "id4f": {
+    "id4cpu.202": {
+      "filename": "id4cpu.202",
+      "type": "main",
+      "romType": "se"
+    },
+    "id4dspf.200": {
+      "filename": "id4dspf.200",
+      "type": "dmd"
+    },
+    "id4sdu17.400": {
+      "filename": "id4sdu17.400",
+      "type": "sound"
+    },
+    "id4sndu7.512": {
+      "filename": "id4sndu7.512",
+      "type": "sound"
+    },
+    "id4sdu21.400": {
+      "filename": "id4sdu21.400",
+      "type": "sound"
+    }
+  },
+  "tz_f10": {
+    "ftz0_10.rom": {
+      "filename": "ftz0_10.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    }
+  },
+  "rocky": {
+    "672-s1.snd": {
+      "filename": "672-s1.snd",
+      "type": "sound"
+    },
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "672-s2.snd": {
+      "filename": "672-s2.snd",
+      "type": "sound"
+    },
+    "672-2x.cpu": {
+      "filename": "672-2x.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "meteorb": {
+    "cpu_u6b.716": {
+      "filename": "cpu_u6b.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2b.716": {
+      "filename": "cpu_u2b.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5b.716": {
+      "filename": "cpu_u5b.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "sc_14": {
+    "g11-14.rom": {
+      "filename": "g11-14.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "safsnds2.rom": {
+      "filename": "safsnds2.rom",
+      "type": "sound"
+    },
+    "safsnds3.rom": {
+      "filename": "safsnds3.rom",
+      "type": "sound"
+    },
+    "safsnds4.rom": {
+      "filename": "safsnds4.rom",
+      "type": "sound"
+    }
+  },
+  "mcastfp": {
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mcastfp.ic1": {
+      "filename": "mcastfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "gb01snd3.1g": {
+      "filename": "gb01snd3.1g",
+      "type": "sound"
+    },
+    "gb01snd1.1d": {
+      "filename": "gb01snd1.1d",
+      "type": "sound"
+    },
+    "gb01snd2.1e": {
+      "filename": "gb01snd2.1e",
+      "type": "sound"
+    }
+  },
+  "mcastgfp": {
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "magic1d.snd": {
+      "filename": "magic1d.snd",
+      "type": "sound"
+    },
+    "magic1g.snd": {
+      "filename": "magic1g.snd",
+      "type": "sound"
+    },
+    "mcastfp.ic1": {
+      "filename": "mcastfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "magic1e.snd": {
+      "filename": "magic1e.snd",
+      "type": "sound"
+    }
+  },
+  "mcastifp": {
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mgic_it.1d": {
+      "filename": "mgic_it.1d",
+      "type": "sound"
+    },
+    "mgic_it.1e": {
+      "filename": "mgic_it.1e",
+      "type": "sound"
+    },
+    "mcastfp.ic1": {
+      "filename": "mcastfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mgic_it.1g": {
+      "filename": "mgic_it.1g",
+      "type": "sound"
+    }
+  },
+  "mcastle": {
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "cpu.ic1": {
+      "filename": "cpu.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "gb01snd3.1g": {
+      "filename": "gb01snd3.1g",
+      "type": "sound"
+    },
+    "gb01snd1.1d": {
+      "filename": "gb01snd1.1d",
+      "type": "sound"
+    },
+    "gb01snd2.1e": {
+      "filename": "gb01snd2.1e",
+      "type": "sound"
+    }
+  },
+  "mcastleg": {
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "magic1d.snd": {
+      "filename": "magic1d.snd",
+      "type": "sound"
+    },
+    "magic1g.snd": {
+      "filename": "magic1g.snd",
+      "type": "sound"
+    },
+    "cpu.ic1": {
+      "filename": "cpu.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "magic1e.snd": {
+      "filename": "magic1e.snd",
+      "type": "sound"
+    }
+  },
+  "mcastlei": {
+    "cpu.ic2": {
+      "filename": "cpu.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mgic_it.1d": {
+      "filename": "mgic_it.1d",
+      "type": "sound"
+    },
+    "cpu.ic1": {
+      "filename": "cpu.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mgic_it.1e": {
+      "filename": "mgic_it.1e",
+      "type": "sound"
+    },
+    "mgic_it.1g": {
+      "filename": "mgic_it.1g",
+      "type": "sound"
+    }
+  },
+  "lectrofp": {
+    "fplect_6.716": {
+      "filename": "fplect_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fplect_2.716": {
+      "filename": "fplect_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "nugentfp": {
+    "fpnugt_6.716": {
+      "filename": "fpnugt_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fpnugt_2.716": {
+      "filename": "fpnugt_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "rock_enc": {
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom2a.snd": {
+      "filename": "yrom2a.snd",
+      "type": "sound"
+    },
+    "yrom1a.snd": {
+      "filename": "yrom1a.snd",
+      "type": "sound"
+    },
+    "drom1a.snd": {
+      "filename": "drom1a.snd",
+      "type": "sound"
+    }
+  },
+  "wipeout": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "thund_p1": {
+    "speech5.532": {
+      "filename": "speech5.532",
+      "type": "sound"
+    },
+    "ic14.532": {
+      "filename": "ic14.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech4.532": {
+      "filename": "speech4.532",
+      "type": "sound"
+    },
+    "speech7.532": {
+      "filename": "speech7.532",
+      "type": "sound"
+    },
+    "ic20.532": {
+      "filename": "ic20.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech6.532": {
+      "filename": "speech6.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    }
+  },
+  "thund_p2": {
+    "speech5.532": {
+      "filename": "speech5.532",
+      "type": "sound"
+    },
+    "speech4.532": {
+      "filename": "speech4.532",
+      "type": "sound"
+    },
+    "speech7.532": {
+      "filename": "speech7.532",
+      "type": "sound"
+    },
+    "ic14_831.532": {
+      "filename": "ic14_831.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20_831.532": {
+      "filename": "ic20_831.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech6.532": {
+      "filename": "speech6.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    }
+  },
+  "fathom": {
+    "842-08_2.732": {
+      "filename": "842-08_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "842-01_4.532": {
+      "filename": "842-01_4.532",
+      "type": "sound"
+    },
+    "842-02_5.532": {
+      "filename": "842-02_5.532",
+      "type": "sound"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "fathoma": {
+    "842-08_2.732": {
+      "filename": "842-08_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "842-01_4.532": {
+      "filename": "842-01_4.532",
+      "type": "sound"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "842-02_5.532": {
+      "filename": "842-02_5.532",
+      "type": "sound"
+    }
+  },
+  "bttf_a21": {
+    "bktofutr.c5": {
+      "filename": "bktofutr.c5",
+      "type": "main",
+      "romType": "de"
+    },
+    "bttfsf5.rom": {
+      "filename": "bttfsf5.rom",
+      "type": "sound"
+    },
+    "bttfsf6.rom": {
+      "filename": "bttfsf6.rom",
+      "type": "sound"
+    },
+    "bttfsf7.rom": {
+      "filename": "bttfsf7.rom",
+      "type": "sound"
+    },
+    "bktofutr.b5": {
+      "filename": "bktofutr.b5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "ali": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "kosteel": {
+    "kngsu3.snd": {
+      "filename": "kngsu3.snd",
+      "type": "sound"
+    },
+    "720-5332.u6": {
+      "filename": "720-5332.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "kngsu4.snd": {
+      "filename": "kngsu4.snd",
+      "type": "sound"
+    },
+    "kngs2732.u2": {
+      "filename": "kngs2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "kosteela": {
+    "kngsu3.snd": {
+      "filename": "kngsu3.snd",
+      "type": "sound"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "kngsu4.snd": {
+      "filename": "kngsu4.snd",
+      "type": "sound"
+    },
+    "kngs2732.u2": {
+      "filename": "kngs2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "tigerrag": {
+    "tigrasnd.u3": {
+      "filename": "TIGRASND.U3",
+      "type": "sound"
+    },
+    "tigerrag.mpu": {
+      "filename": "TIGERRAG.MPU",
+      "type": "main"
+    },
+    "tigrasnd.u4": {
+      "filename": "TIGRASND.U4",
+      "type": "sound"
+    }
+  },
+  "tomy_102": {
+    "tommysnd.u17": {
+      "filename": "tommysnd.u17",
+      "type": "sound"
+    },
+    "tommydva.300": {
+      "filename": "tommydva.300",
+      "type": "dmd"
+    },
+    "tommysnd.u36": {
+      "filename": "tommysnd.u36",
+      "type": "sound"
+    },
+    "tommysnd.u37": {
+      "filename": "tommysnd.u37",
+      "type": "sound"
+    },
+    "tommysnd.u7": {
+      "filename": "tommysnd.u7",
+      "type": "sound"
+    },
+    "tommysnd.u21": {
+      "filename": "tommysnd.u21",
+      "type": "sound"
+    },
+    "tomcpua.102": {
+      "filename": "tomcpua.102",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "tomy_400": {
+    "tommysnd.u17": {
+      "filename": "tommysnd.u17",
+      "type": "sound"
+    },
+    "tommysnd.u36": {
+      "filename": "tommysnd.u36",
+      "type": "sound"
+    },
+    "tommysnd.u37": {
+      "filename": "tommysnd.u37",
+      "type": "sound"
+    },
+    "tommydva.400": {
+      "filename": "tommydva.400",
+      "type": "dmd"
+    },
+    "tommysnd.u7": {
+      "filename": "tommysnd.u7",
+      "type": "sound"
+    },
+    "tommysnd.u21": {
+      "filename": "tommysnd.u21",
+      "type": "sound"
+    },
+    "tomcpua.400": {
+      "filename": "tomcpua.400",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "tomy_h30": {
+    "tommysnd.u17": {
+      "filename": "tommysnd.u17",
+      "type": "sound"
+    },
+    "tomcpuh.300": {
+      "filename": "tomcpuh.300",
+      "type": "main",
+      "romType": "de"
+    },
+    "tommydva.300": {
+      "filename": "tommydva.300",
+      "type": "dmd"
+    },
+    "tommysnd.u36": {
+      "filename": "tommysnd.u36",
+      "type": "sound"
+    },
+    "tommysnd.u37": {
+      "filename": "tommysnd.u37",
+      "type": "sound"
+    },
+    "tommysnd.u7": {
+      "filename": "tommysnd.u7",
+      "type": "sound"
+    },
+    "tommysnd.u21": {
+      "filename": "tommysnd.u21",
+      "type": "sound"
+    }
+  },
+  "rollr_p2": {
+    "rolr_u26.pa2": {
+      "filename": "rolr_u26.pa2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rolr_u4.pa1": {
+      "filename": "rolr_u4.pa1",
+      "type": "sound"
+    },
+    "rolr_u19.pa1": {
+      "filename": "rolr_u19.pa1",
+      "type": "sound"
+    },
+    "rolr_u20.pa1": {
+      "filename": "rolr_u20.pa1",
+      "type": "sound"
+    },
+    "rolr_u27.pa2": {
+      "filename": "rolr_u27.pa2",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "elv303i": {
+    "elvscpui.303": {
+      "filename": "ELVSCPUI.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisi.u21": {
+      "filename": "elvisi.u21",
+      "type": "sound"
+    },
+    "elvsdspi.302": {
+      "filename": "ELVSDSPI.302",
+      "type": "dmd"
+    },
+    "elvisi.u7": {
+      "filename": "Elvisi.u7",
+      "type": "sound"
+    },
+    "elvisi.u37": {
+      "filename": "elvisi.u37",
+      "type": "sound"
+    },
+    "elvisi.u17": {
+      "filename": "elvisi.u17",
+      "type": "sound"
+    },
+    "elvisi.u36": {
+      "filename": "elvisi.u36",
+      "type": "sound"
+    }
+  },
+  "trucksp2": {
+    "u4sndp1.256": {
+      "filename": "u4sndp1.256",
+      "type": "sound"
+    },
+    "u2_p2.128": {
+      "filename": "u2_p2.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "u19sndp1.256": {
+      "filename": "u19sndp1.256",
+      "type": "sound"
+    },
+    "u20sndp1.256": {
+      "filename": "u20sndp1.256",
+      "type": "sound"
+    },
+    "u3_p2.128": {
+      "filename": "u3_p2.128",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "trucksp3": {
+    "u4sndp1.256": {
+      "filename": "u4sndp1.256",
+      "type": "sound"
+    },
+    "u3_p3.128": {
+      "filename": "u3_p3.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "u19sndp1.256": {
+      "filename": "u19sndp1.256",
+      "type": "sound"
+    },
+    "u2_p3.128": {
+      "filename": "u2_p3.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "u20sndp1.256": {
+      "filename": "u20sndp1.256",
+      "type": "sound"
+    }
+  },
+  "nas340": {
+    "nascpua.340": {
+      "filename": "nascpua.340",
+      "type": "main",
+      "romType": "se"
+    },
+    "nassnd.u36": {
+      "filename": "nassnd.u36",
+      "type": "sound"
+    },
+    "nassnd.u7": {
+      "filename": "nassnd.u7",
+      "type": "sound"
+    },
+    "nassnd.u37": {
+      "filename": "nassnd.u37",
+      "type": "sound"
+    },
+    "nassnd.u17": {
+      "filename": "nassnd.u17",
+      "type": "sound"
+    },
+    "nassnd.u21": {
+      "filename": "nassnd.u21",
+      "type": "sound"
+    },
+    "nasdspa.303": {
+      "filename": "nasdspa.303",
+      "type": "dmd"
+    }
+  },
+  "hotshots": {
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "jst_l1": {
+    "ic26-l1.716": {
+      "filename": "ic26-l1.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    },
+    "ic14-l1.716": {
+      "filename": "ic14-l1.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "tom_06": {
+    "tm_u3_s.l2": {
+      "filename": "tm_u3_s.l2",
+      "type": "sound"
+    },
+    "su2-sp1.rom": {
+      "filename": "su2-sp1.rom",
+      "type": "sound"
+    },
+    "tm_u4_s.l2": {
+      "filename": "tm_u4_s.l2",
+      "type": "sound"
+    },
+    "tm_u5_s.l2": {
+      "filename": "tm_u5_s.l2",
+      "type": "sound"
+    },
+    "u6-06a.rom": {
+      "filename": "u6-06a.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tm_u6_s.l2": {
+      "filename": "tm_u6_s.l2",
+      "type": "sound"
+    },
+    "tm_u7_s.l2": {
+      "filename": "tm_u7_s.l2",
+      "type": "sound"
+    }
+  },
+  "tom_10f": {
+    "tm_u3_s.l2": {
+      "filename": "tm_u3_s.l2",
+      "type": "sound"
+    },
+    "tm_u4_s.l2": {
+      "filename": "tm_u4_s.l2",
+      "type": "sound"
+    },
+    "tm_u5_s.l2": {
+      "filename": "tm_u5_s.l2",
+      "type": "sound"
+    },
+    "tm_u2_s.l2": {
+      "filename": "tm_u2_s.l2",
+      "type": "sound"
+    },
+    "tom1.0f": {
+      "filename": "tom1.0f",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tm_u6_s.l2": {
+      "filename": "tm_u6_s.l2",
+      "type": "sound"
+    },
+    "tm_u7_s.l2": {
+      "filename": "tm_u7_s.l2",
+      "type": "sound"
+    }
+  },
+  "tom_12": {
+    "tm_u3_s.l2": {
+      "filename": "tm_u3_s.l2",
+      "type": "sound"
+    },
+    "tm_u4_s.l2": {
+      "filename": "tm_u4_s.l2",
+      "type": "sound"
+    },
+    "tm_u5_s.l2": {
+      "filename": "tm_u5_s.l2",
+      "type": "sound"
+    },
+    "tm_u2_s.l2": {
+      "filename": "tm_u2_s.l2",
+      "type": "sound"
+    },
+    "tom1_2x.rom": {
+      "filename": "tom1_2x.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tm_u6_s.l2": {
+      "filename": "tm_u6_s.l2",
+      "type": "sound"
+    },
+    "tm_u7_s.l2": {
+      "filename": "tm_u7_s.l2",
+      "type": "sound"
+    }
+  },
+  "tom_13": {
+    "tm_u3_s.l2": {
+      "filename": "tm_u3_s.l2",
+      "type": "sound"
+    },
+    "tm_u4_s.l2": {
+      "filename": "tm_u4_s.l2",
+      "type": "sound"
+    },
+    "tm_u5_s.l2": {
+      "filename": "tm_u5_s.l2",
+      "type": "sound"
+    },
+    "tom1_3x.rom": {
+      "filename": "tom1_3x.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tm_u2_s.l2": {
+      "filename": "tm_u2_s.l2",
+      "type": "sound"
+    },
+    "tm_u6_s.l2": {
+      "filename": "tm_u6_s.l2",
+      "type": "sound"
+    },
+    "tm_u7_s.l2": {
+      "filename": "tm_u7_s.l2",
+      "type": "sound"
+    }
+  },
+  "tom_13f": {
+    "tm_u3_s.l2": {
+      "filename": "tm_u3_s.l2",
+      "type": "sound"
+    },
+    "tm_u4_s.l2": {
+      "filename": "tm_u4_s.l2",
+      "type": "sound"
+    },
+    "tm_u5_s.l2": {
+      "filename": "tm_u5_s.l2",
+      "type": "sound"
+    },
+    "tom1_3f.rom": {
+      "filename": "tom1_3f.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tm_u2_s.l2": {
+      "filename": "tm_u2_s.l2",
+      "type": "sound"
+    },
+    "tm_u6_s.l2": {
+      "filename": "tm_u6_s.l2",
+      "type": "sound"
+    },
+    "tm_u7_s.l2": {
+      "filename": "tm_u7_s.l2",
+      "type": "sound"
+    }
+  },
+  "tom_14h": {
+    "tm_u3_s.l2": {
+      "filename": "tm_u3_s.l2",
+      "type": "sound"
+    },
+    "tm_u4_s.l2": {
+      "filename": "tm_u4_s.l2",
+      "type": "sound"
+    },
+    "1_40h.u6": {
+      "filename": "1_40h.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tm_u5_s.l2": {
+      "filename": "tm_u5_s.l2",
+      "type": "sound"
+    },
+    "tm_u2_s.l2": {
+      "filename": "tm_u2_s.l2",
+      "type": "sound"
+    },
+    "tm_u6_s.l2": {
+      "filename": "tm_u6_s.l2",
+      "type": "sound"
+    },
+    "tm_u7_s.l2": {
+      "filename": "tm_u7_s.l2",
+      "type": "sound"
+    }
+  },
+  "tom_14hb": {
+    "tm_u3_s.l2": {
+      "filename": "tm_u3_s.l2",
+      "type": "sound"
+    },
+    "tm_u4_s.l2": {
+      "filename": "tm_u4_s.l2",
+      "type": "sound"
+    },
+    "tm_u5_s.l2": {
+      "filename": "tm_u5_s.l2",
+      "type": "sound"
+    },
+    "1_40hb.u6": {
+      "filename": "1_40hb.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tm_u2_s.l2": {
+      "filename": "tm_u2_s.l2",
+      "type": "sound"
+    },
+    "tm_u6_s.l2": {
+      "filename": "tm_u6_s.l2",
+      "type": "sound"
+    },
+    "tm_u7_s.l2": {
+      "filename": "tm_u7_s.l2",
+      "type": "sound"
+    }
+  },
+  "ladyluck": {
+    "u3.cpu": {
+      "filename": "u3.cpu",
+      "type": "main",
+      "romType": "by"
+    },
+    "u3_snd.532": {
+      "filename": "u3_snd.532",
+      "type": "sound"
+    },
+    "u4_snd.532": {
+      "filename": "u4_snd.532",
+      "type": "sound"
+    }
+  },
+  "wpt_140ai": {
+    "wpt1400ai.bin": {
+      "filename": "wpt1400ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "play203": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.203": {
+      "filename": "Pbcpu.203",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbdisp-a.201": {
+      "filename": "PBDISP-A.201",
+      "type": "dmd"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play203f": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.203": {
+      "filename": "Pbcpu.203",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbdisp-f.201": {
+      "filename": "PBDISP-F.201",
+      "type": "dmd"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play203g": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.203": {
+      "filename": "Pbcpu.203",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    },
+    "pbdisp-g.201": {
+      "filename": "PBDISP-G.201",
+      "type": "dmd"
+    }
+  },
+  "play203i": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbdisp-i.201": {
+      "filename": "PBDISP-I.201",
+      "type": "dmd"
+    },
+    "pbcpu.203": {
+      "filename": "Pbcpu.203",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play203l": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.203": {
+      "filename": "Pbcpu.203",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbdisp-l.201": {
+      "filename": "PBDISP-L.201",
+      "type": "dmd"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play300": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbdispa.300": {
+      "filename": "pbdispa.300",
+      "type": "dmd"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbcpu.300": {
+      "filename": "pbcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play302": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.302": {
+      "filename": "pbcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbdispa.300": {
+      "filename": "pbdispa.300",
+      "type": "dmd"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play302f": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.302": {
+      "filename": "pbcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbdispf.300": {
+      "filename": "pbdispf.300",
+      "type": "dmd"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play302g": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.302": {
+      "filename": "pbcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbdispg.300": {
+      "filename": "pbdispg.300",
+      "type": "dmd"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play302i": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.302": {
+      "filename": "pbcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbdispi.300": {
+      "filename": "pbdispi.300",
+      "type": "dmd"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play302l": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbcpu.302": {
+      "filename": "pbcpu.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbdispl.300": {
+      "filename": "pbdispl.300",
+      "type": "dmd"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play303": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbdispa.300": {
+      "filename": "pbdispa.300",
+      "type": "dmd"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbcpu.303": {
+      "filename": "pbcpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play303f": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbdispf.300": {
+      "filename": "pbdispf.300",
+      "type": "dmd"
+    },
+    "pbcpu.303": {
+      "filename": "pbcpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play303g": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbcpu.303": {
+      "filename": "pbcpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbdispg.300": {
+      "filename": "pbdispg.300",
+      "type": "dmd"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play303i": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbcpu.303": {
+      "filename": "pbcpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbdispi.300": {
+      "filename": "pbdispi.300",
+      "type": "dmd"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play303l": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbcpu.303": {
+      "filename": "pbcpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbdispl.300": {
+      "filename": "pbdispl.300",
+      "type": "dmd"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play401": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbdispa.400": {
+      "filename": "pbdispa.400",
+      "type": "dmd"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbcpu.401": {
+      "filename": "pbcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play401f": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbdispf.400": {
+      "filename": "pbdispf.400",
+      "type": "dmd"
+    },
+    "pbcpu.401": {
+      "filename": "pbcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play401g": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbdispg.400": {
+      "filename": "pbdispg.400",
+      "type": "dmd"
+    },
+    "pbcpu.401": {
+      "filename": "pbcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play401i": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbdispi.400": {
+      "filename": "pbdispi.400",
+      "type": "dmd"
+    },
+    "pbcpu.401": {
+      "filename": "pbcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "play401l": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbdisps.400": {
+      "filename": "pbdisps.400",
+      "type": "dmd"
+    },
+    "pbcpu.401": {
+      "filename": "pbcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "playboyf": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbdispf.500": {
+      "filename": "pbdispf.500",
+      "type": "dmd"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbcpu.500": {
+      "filename": "pbcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "playboyg": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbdispg.500": {
+      "filename": "pbdispg.500",
+      "type": "dmd"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbcpu.500": {
+      "filename": "pbcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "playboyi": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbdispi.500": {
+      "filename": "pbdispi.500",
+      "type": "dmd"
+    },
+    "pbcpu.500": {
+      "filename": "pbcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "playboyl": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbdispl.500": {
+      "filename": "pbdispl.500",
+      "type": "dmd"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbcpu.500": {
+      "filename": "pbcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "playboys": {
+    "pbsndu7.102": {
+      "filename": "pbsndu7.102",
+      "type": "sound"
+    },
+    "pbdispa.500": {
+      "filename": "pbdispa.500",
+      "type": "dmd"
+    },
+    "pbsndu37.100": {
+      "filename": "pbsndu37.100",
+      "type": "sound"
+    },
+    "pbsndu21.100": {
+      "filename": "pbsndu21.100",
+      "type": "sound"
+    },
+    "pbsndu36.100": {
+      "filename": "pbsndu36.100",
+      "type": "sound"
+    },
+    "pbcpu.500": {
+      "filename": "pbcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "pbsndu17.100": {
+      "filename": "pbsndu17.100",
+      "type": "sound"
+    }
+  },
+  "ss_03": {
+    "ss_s2.22": {
+      "filename": "SS_s2.22",
+      "type": "sound"
+    },
+    "ss_s4.21": {
+      "filename": "SS_s4.21",
+      "type": "sound"
+    },
+    "ss_g11.0_3": {
+      "filename": "SS_G11.0_3",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ss_s3.21": {
+      "filename": "SS_s3.21",
+      "type": "sound"
+    }
+  },
+  "galaxyfp": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpgal_u6.716": {
+      "filename": "fpgal_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpgal_u2.716": {
+      "filename": "fpgal_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "mtl_163h": {
+    "mtl163h.bin": {
+      "filename": "mtl163h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "acd_163h": {
+    "acd_163h.bin": {
+      "filename": "acd_163h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wof_300l": {
+    "wof0300l.bin": {
+      "filename": "wof0300l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "eballdlc": {
+    "8bdhun.u2": {
+      "filename": "8bdhun.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-10_5.532": {
+      "filename": "838-10_5.532",
+      "type": "sound"
+    },
+    "8bdhun.u6": {
+      "filename": "8bdhun.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    }
+  },
+  "america": {
+    "b3vi1492.dat": {
+      "filename": "b3vi1492.dat",
+      "type": "sound"
+    },
+    "sbvi1492.dat": {
+      "filename": "sbvi1492.dat",
+      "type": "sound"
+    },
+    "b5vi1492.dat": {
+      "filename": "b5vi1492.dat",
+      "type": "sound"
+    },
+    "b6vi1492.dat": {
+      "filename": "b6vi1492.dat",
+      "type": "sound"
+    },
+    "b4vi1492.dat": {
+      "filename": "b4vi1492.dat",
+      "type": "sound"
+    },
+    "b2vi1492.dat": {
+      "filename": "b2vi1492.dat",
+      "type": "sound"
+    },
+    "b7vi1492.dat": {
+      "filename": "b7vi1492.dat",
+      "type": "sound"
+    },
+    "cpvi1492.dat": {
+      "filename": "cpvi1492.dat",
+      "type": "main",
+      "romType": "jp"
+    },
+    "b1vi1492.dat": {
+      "filename": "b1vi1492.dat",
+      "type": "sound"
+    }
+  },
+  "fg_1000ag": {
+    "fg1000ag.bin": {
+      "filename": "fg1000ag.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "taf_h4": {
+    "tafu18l1.rom": {
+      "filename": "tafu18l1.rom",
+      "type": "sound"
+    },
+    "addam_h4.rom": {
+      "filename": "addam_h4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "taf_l1": {
+    "tafu18l1.rom": {
+      "filename": "tafu18l1.rom",
+      "type": "sound"
+    },
+    "addam_l1.rom": {
+      "filename": "addam_l1.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "taf_l2": {
+    "tafu18l1.rom": {
+      "filename": "tafu18l1.rom",
+      "type": "sound"
+    },
+    "addam_l2.rom": {
+      "filename": "addam_l2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "taf_l3": {
+    "tafu18l1.rom": {
+      "filename": "tafu18l1.rom",
+      "type": "sound"
+    },
+    "addam_l3.rom": {
+      "filename": "addam_l3.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "taf_l4": {
+    "tafu18l1.rom": {
+      "filename": "tafu18l1.rom",
+      "type": "sound"
+    },
+    "addam_l4.rom": {
+      "filename": "addam_l4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "taf_l5": {
+    "tafu18l1.rom": {
+      "filename": "tafu18l1.rom",
+      "type": "sound"
+    },
+    "addam_l5.rom": {
+      "filename": "addam_l5.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "taf_l7": {
+    "tafu18l1.rom": {
+      "filename": "tafu18l1.rom",
+      "type": "sound"
+    },
+    "addam_l7.rom": {
+      "filename": "addam_l7.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "nf_10": {
+    "nfu2s": {
+      "filename": "nfu2s",
+      "type": "sound"
+    },
+    "nfu6s": {
+      "filename": "nfu6s",
+      "type": "sound"
+    },
+    "nfu7s": {
+      "filename": "nfu7s",
+      "type": "sound"
+    },
+    "nfu4s": {
+      "filename": "nfu4s",
+      "type": "sound"
+    },
+    "nfu3s": {
+      "filename": "nfu3s",
+      "type": "sound"
+    },
+    "nfu5s": {
+      "filename": "nfu5s",
+      "type": "sound"
+    },
+    "nofe1_0.rom": {
+      "filename": "nofe1_0.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "nf_11x": {
+    "nfu2s": {
+      "filename": "nfu2s",
+      "type": "sound"
+    },
+    "nofe1_1x.rom": {
+      "filename": "nofe1_1x.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nfu6s": {
+      "filename": "nfu6s",
+      "type": "sound"
+    },
+    "nfu7s": {
+      "filename": "nfu7s",
+      "type": "sound"
+    },
+    "nfu4s": {
+      "filename": "nfu4s",
+      "type": "sound"
+    },
+    "nfu3s": {
+      "filename": "nfu3s",
+      "type": "sound"
+    },
+    "nfu5s": {
+      "filename": "nfu5s",
+      "type": "sound"
+    }
+  },
+  "nf_20": {
+    "nfu2s": {
+      "filename": "nfu2s",
+      "type": "sound"
+    },
+    "nfu6s": {
+      "filename": "nfu6s",
+      "type": "sound"
+    },
+    "nfu7s": {
+      "filename": "nfu7s",
+      "type": "sound"
+    },
+    "nfu4s": {
+      "filename": "nfu4s",
+      "type": "sound"
+    },
+    "nfu3s": {
+      "filename": "nfu3s",
+      "type": "sound"
+    },
+    "nofe2_0a.rom": {
+      "filename": "nofe2_0a.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nfu5s": {
+      "filename": "nfu5s",
+      "type": "sound"
+    }
+  },
+  "nf_22": {
+    "nfu2s": {
+      "filename": "nfu2s",
+      "type": "sound"
+    },
+    "nfu6s": {
+      "filename": "nfu6s",
+      "type": "sound"
+    },
+    "nfu7s": {
+      "filename": "nfu7s",
+      "type": "sound"
+    },
+    "nofe2_2a.rom": {
+      "filename": "nofe2_2a.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nfu4s": {
+      "filename": "nfu4s",
+      "type": "sound"
+    },
+    "nfu3s": {
+      "filename": "nfu3s",
+      "type": "sound"
+    },
+    "nfu5s": {
+      "filename": "nfu5s",
+      "type": "sound"
+    }
+  },
+  "nf_23": {
+    "nfu2s": {
+      "filename": "nfu2s",
+      "type": "sound"
+    },
+    "nfu6s": {
+      "filename": "nfu6s",
+      "type": "sound"
+    },
+    "nofe2_3.rom": {
+      "filename": "nofe2_3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nfu7s": {
+      "filename": "nfu7s",
+      "type": "sound"
+    },
+    "nfu4s": {
+      "filename": "nfu4s",
+      "type": "sound"
+    },
+    "nfu3s": {
+      "filename": "nfu3s",
+      "type": "sound"
+    },
+    "nfu5s": {
+      "filename": "nfu5s",
+      "type": "sound"
+    }
+  },
+  "nf_23f": {
+    "nfu2s": {
+      "filename": "nfu2s",
+      "type": "sound"
+    },
+    "nfu6s": {
+      "filename": "nfu6s",
+      "type": "sound"
+    },
+    "nfu7s": {
+      "filename": "nfu7s",
+      "type": "sound"
+    },
+    "nfu4s": {
+      "filename": "nfu4s",
+      "type": "sound"
+    },
+    "nfu3s": {
+      "filename": "nfu3s",
+      "type": "sound"
+    },
+    "nofe2_3f.rom": {
+      "filename": "nofe2_3f.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nfu5s": {
+      "filename": "nfu5s",
+      "type": "sound"
+    }
+  },
+  "nf_23x": {
+    "nfu2s": {
+      "filename": "nfu2s",
+      "type": "sound"
+    },
+    "nfu6s": {
+      "filename": "nfu6s",
+      "type": "sound"
+    },
+    "nfu7s": {
+      "filename": "nfu7s",
+      "type": "sound"
+    },
+    "nfu4s": {
+      "filename": "nfu4s",
+      "type": "sound"
+    },
+    "nfu3s": {
+      "filename": "nfu3s",
+      "type": "sound"
+    },
+    "nofe2_3x.rom": {
+      "filename": "nofe2_3x.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nfu5s": {
+      "filename": "nfu5s",
+      "type": "sound"
+    }
+  },
+  "sopr107l": {
+    "sopsndl.u7": {
+      "filename": "sopsndl.u7",
+      "type": "sound"
+    },
+    "sopsndl.u36": {
+      "filename": "sopsndl.u36",
+      "type": "sound"
+    },
+    "sopdspl.100": {
+      "filename": "sopdspl.100",
+      "type": "dmd"
+    },
+    "sopsndl.u17": {
+      "filename": "sopsndl.u17",
+      "type": "sound"
+    },
+    "sopsndl1.u21": {
+      "filename": "sopsndl1.u21",
+      "type": "sound"
+    },
+    "sopcpul.107": {
+      "filename": "sopcpul.107",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndl.u37": {
+      "filename": "sopsndl.u37",
+      "type": "sound"
+    }
+  },
+  "sopranol": {
+    "sopsndl.u7": {
+      "filename": "sopsndl.u7",
+      "type": "sound"
+    },
+    "sopsndl.u36": {
+      "filename": "sopsndl.u36",
+      "type": "sound"
+    },
+    "sopcpul.300": {
+      "filename": "sopcpul.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndl.u17": {
+      "filename": "sopsndl.u17",
+      "type": "sound"
+    },
+    "sopsndl.u21": {
+      "filename": "sopsndl.u21",
+      "type": "sound"
+    },
+    "sopsndl.u37": {
+      "filename": "sopsndl.u37",
+      "type": "sound"
+    },
+    "sopdspl.300": {
+      "filename": "sopdspl.300",
+      "type": "dmd"
+    }
+  },
+  "lotr_sp8": {
+    "lotrdspl.800": {
+      "filename": "LOTRDSPL.800",
+      "type": "dmd"
+    },
+    "lotrcpul.800": {
+      "filename": "LOTRCPUL.800",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrlu36.100": {
+      "filename": "lotrlu36.100",
+      "type": "sound"
+    },
+    "lotrlu37.100": {
+      "filename": "lotrlu37.100",
+      "type": "sound"
+    },
+    "lotrlu7.100": {
+      "filename": "lotrlu7.100",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrlu17.100": {
+      "filename": "lotrlu17.100",
+      "type": "sound"
+    },
+    "lotrlu21.100": {
+      "filename": "lotrlu21.100",
+      "type": "sound"
+    }
+  },
+  "lotr_gr7": {
+    "lotrdspg.700": {
+      "filename": "lotrdspg.700",
+      "type": "dmd"
+    },
+    "lotrcpu.700": {
+      "filename": "lotrcpu.700",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "atlantis": {
+    "u19_snd.rom": {
+      "filename": "u19_snd.rom",
+      "type": "sound"
+    },
+    "u4_snd.rom": {
+      "filename": "u4_snd.rom",
+      "type": "sound"
+    },
+    "u27_cpu.rom": {
+      "filename": "u27_cpu.rom",
+      "type": "main",
+      "romType": "by"
+    },
+    "u26_cpu.rom": {
+      "filename": "u26_cpu.rom",
+      "type": "main",
+      "romType": "by"
+    },
+    "u20_snd.rom": {
+      "filename": "u20_snd.rom",
+      "type": "sound"
+    }
+  },
+  "cv_20h": {
+    "cv200h.rom": {
+      "filename": "cv200h.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "s6v0_4.rom": {
+      "filename": "s6v0_4.rom",
+      "type": "sound"
+    },
+    "s2v1_0.rom": {
+      "filename": "s2v1_0.rom",
+      "type": "sound"
+    },
+    "s5v0_4.rom": {
+      "filename": "s5v0_4.rom",
+      "type": "sound"
+    },
+    "s3v0_4.rom": {
+      "filename": "s3v0_4.rom",
+      "type": "sound"
+    },
+    "s4v0_4.rom": {
+      "filename": "s4v0_4.rom",
+      "type": "sound"
+    }
+  },
+  "zankor": {
+    "zan_ic6.128": {
+      "filename": "zan_ic6.128",
+      "type": "sound"
+    },
+    "zan_ic2.764": {
+      "filename": "zan_ic2.764",
+      "type": "main",
+      "romType": "zac"
+    },
+    "zan_1f.128": {
+      "filename": "zan_1f.128",
+      "type": "sound"
+    },
+    "zan_ic5.128": {
+      "filename": "zan_ic5.128",
+      "type": "sound"
+    },
+    "zan_ic1.764": {
+      "filename": "zan_ic1.764",
+      "type": "main",
+      "romType": "zac"
+    },
+    "zan_ic4.128": {
+      "filename": "zan_ic4.128",
+      "type": "sound"
+    }
+  },
+  "zankorfp": {
+    "zan_ic6.128": {
+      "filename": "zan_ic6.128",
+      "type": "sound"
+    },
+    "zankorfp.ic2": {
+      "filename": "zankorfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "zan_1f.128": {
+      "filename": "zan_1f.128",
+      "type": "sound"
+    },
+    "zankorfp.ic1": {
+      "filename": "zankorfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "1en.64": {
+      "filename": "1en.64",
+      "type": "sound"
+    },
+    "zan_ic5.128": {
+      "filename": "zan_ic5.128",
+      "type": "sound"
+    },
+    "zan_ic4.128": {
+      "filename": "zan_ic4.128",
+      "type": "sound"
+    }
+  },
+  "afm_11": {
+    "mars1_1.rom": {
+      "filename": "mars1_1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "afm_s3.l1": {
+      "filename": "afm_s3.l1",
+      "type": "sound"
+    },
+    "afm_s4.l1": {
+      "filename": "afm_s4.l1",
+      "type": "sound"
+    },
+    "afm_s2.l1": {
+      "filename": "afm_s2.l1",
+      "type": "sound"
+    }
+  },
+  "fireact": {
+    "fire_s1.bin": {
+      "filename": "fire_s1.bin",
+      "type": "sound"
+    },
+    "fire1.bin": {
+      "filename": "fire1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "fire4.bin": {
+      "filename": "fire4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "fire2.bin": {
+      "filename": "fire2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "fire3.bin": {
+      "filename": "fire3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "fire_s2.bin": {
+      "filename": "fire_s2.bin",
+      "type": "sound"
+    }
+  },
+  "strike": {
+    "strike2.bin": {
+      "filename": "strike2.bin",
+      "type": "main"
+    },
+    "strike1.bin": {
+      "filename": "strike1.bin",
+      "type": "main"
+    },
+    "strike4.bin": {
+      "filename": "strike4.bin",
+      "type": "main"
+    },
+    "strike3.bin": {
+      "filename": "strike3.bin",
+      "type": "main"
+    }
+  },
+  "arenaa": {
+    "prom2a.cpu": {
+      "filename": "prom2a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1a.cpu": {
+      "filename": "prom1a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    }
+  },
+  "frpwr_d7": {
+    "fire7717.532": {
+      "filename": "fire7717.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "fire7714.716": {
+      "filename": "fire7714.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "fire7720.716": {
+      "filename": "fire7720.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    }
+  },
+  "phntmshp": {
+    "sonido3.bin": {
+      "filename": "sonido3.bin",
+      "type": "sound"
+    },
+    "video1.bin": {
+      "filename": "video1.BIN",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "sonido1.bin": {
+      "filename": "sonido1.BIN",
+      "type": "sound"
+    },
+    "video2.bin": {
+      "filename": "video2.BIN",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "sonido4.bin": {
+      "filename": "sonido4.BIN",
+      "type": "sound"
+    },
+    "sonido2.bin": {
+      "filename": "sonido2.BIN",
+      "type": "sound"
+    }
+  },
+  "sshtl_l3": {
+    "spch_u5.732": {
+      "filename": "spch_u5.732",
+      "type": "sound"
+    },
+    "cpu_u49.128": {
+      "filename": "cpu_u49.128",
+      "type": "sound"
+    },
+    "spch_u4.732": {
+      "filename": "spch_u4.732",
+      "type": "sound"
+    },
+    "spch_u6.732": {
+      "filename": "spch_u6.732",
+      "type": "sound"
+    },
+    "cpu_u20.l3": {
+      "filename": "cpu_u20.l3",
+      "type": "main",
+      "romType": "s9"
+    }
+  },
+  "sshtl_l7": {
+    "spch_u5.732": {
+      "filename": "spch_u5.732",
+      "type": "sound"
+    },
+    "cpu_u49.128": {
+      "filename": "cpu_u49.128",
+      "type": "sound"
+    },
+    "cpu_u20.128": {
+      "filename": "cpu_u20.128",
+      "type": "main",
+      "romType": "s9"
+    },
+    "spch_u4.732": {
+      "filename": "spch_u4.732",
+      "type": "sound"
+    },
+    "spch_u6.732": {
+      "filename": "spch_u6.732",
+      "type": "sound"
+    }
+  },
+  "firemntn": {
+    "firemt_5.lgc": {
+      "filename": "firemt_5.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "zac_boot.lgc": {
+      "filename": "zac_boot.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "firemt_4.lgc": {
+      "filename": "firemt_4.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "firemt_2.lgc": {
+      "filename": "firemt_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "firemt_3.lgc": {
+      "filename": "firemt_3.lgc",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "circa33": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "disco79": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "erosone": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "foathens": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "heartspd": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "hoedown": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "royclark": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "starshot": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "suprpick": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "takefive": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "thndbolt": {
+    "alliedu3.bin": {
+      "filename": "alliedu3.bin",
+      "type": "main"
+    },
+    "alliedu6.bin": {
+      "filename": "alliedu6.bin",
+      "type": "main"
+    },
+    "alliedu5.bin": {
+      "filename": "alliedu5.bin",
+      "type": "main"
+    }
+  },
+  "mav_100": {
+    "mavcpu.100": {
+      "filename": "mavcpu.100",
+      "type": "main",
+      "romType": "de"
+    },
+    "mavdsp0.100": {
+      "filename": "mavdsp0.100",
+      "type": "dmd"
+    },
+    "mavu7.dat": {
+      "filename": "mavu7.dat",
+      "type": "sound"
+    },
+    "mavu21.dat": {
+      "filename": "mavu21.dat",
+      "type": "sound"
+    },
+    "mavu17.dat": {
+      "filename": "mavu17.dat",
+      "type": "sound"
+    },
+    "mavdsp3.100": {
+      "filename": "mavdsp3.100",
+      "type": "dmd"
+    }
+  },
+  "pinchamg": {
+    "pinchamp.ic1": {
+      "filename": "pinchamp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_de.1g": {
+      "filename": "pchmp_de.1g",
+      "type": "sound"
+    },
+    "pchmp_de.1c": {
+      "filename": "pchmp_de.1c",
+      "type": "sound"
+    },
+    "pchmp_de.1e": {
+      "filename": "pchmp_de.1e",
+      "type": "sound"
+    },
+    "pinchamp.ic2": {
+      "filename": "pinchamp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pinchamp.ic3": {
+      "filename": "pinchamp.ic3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_de.1f": {
+      "filename": "pchmp_de.1f",
+      "type": "sound"
+    }
+  },
+  "pinchami": {
+    "pinchamp.ic1": {
+      "filename": "pinchamp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_gb.1e": {
+      "filename": "pchmp_gb.1e",
+      "type": "sound"
+    },
+    "pchmp_it.1g": {
+      "filename": "pchmp_it.1g",
+      "type": "sound"
+    },
+    "pchmp_it.1f": {
+      "filename": "pchmp_it.1f",
+      "type": "sound"
+    },
+    "pchmp_it.1c": {
+      "filename": "pchmp_it.1c",
+      "type": "sound"
+    },
+    "pinchamp.ic2": {
+      "filename": "pinchamp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pinchamp.ic3": {
+      "filename": "pinchamp.ic3",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "pinchamp": {
+    "pinchamp.ic1": {
+      "filename": "pinchamp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    },
+    "sound4.g": {
+      "filename": "sound4.g",
+      "type": "sound"
+    },
+    "pinchamp.ic2": {
+      "filename": "pinchamp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound3.f": {
+      "filename": "sound3.f",
+      "type": "sound"
+    },
+    "pinchamp.ic3": {
+      "filename": "pinchamp.ic3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound1.c": {
+      "filename": "sound1.c",
+      "type": "sound"
+    }
+  },
+  "bushido": {
+    "e-musica.bin": {
+      "filename": "e-musica.bin",
+      "type": "sound"
+    },
+    "d-musica.bin": {
+      "filename": "d-musica.bin",
+      "type": "sound"
+    },
+    "c-sonido.bin": {
+      "filename": "c-sonido.bin",
+      "type": "sound"
+    },
+    "0-z80.bin": {
+      "filename": "0-z80.bin",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "1-z80.old": {
+      "filename": "1-z80.old",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "f-musica.bin": {
+      "filename": "f-musica.bin",
+      "type": "sound"
+    },
+    "g-disply.bin": {
+      "filename": "g-disply.bin",
+      "type": "dmd"
+    },
+    "b-sonido.bin": {
+      "filename": "b-sonido.bin",
+      "type": "sound"
+    },
+    "a-sonido.bin": {
+      "filename": "a-sonido.bin",
+      "type": "sound"
+    }
+  },
+  "bushidoa": {
+    "e-musica.bin": {
+      "filename": "e-musica.bin",
+      "type": "sound"
+    },
+    "d-musica.bin": {
+      "filename": "d-musica.bin",
+      "type": "sound"
+    },
+    "c-sonido.bin": {
+      "filename": "c-sonido.bin",
+      "type": "sound"
+    },
+    "0-cpu.bin": {
+      "filename": "0-cpu.bin",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "f-musica.bin": {
+      "filename": "f-musica.bin",
+      "type": "sound"
+    },
+    "g-disply.bin": {
+      "filename": "g-disply.bin",
+      "type": "dmd"
+    },
+    "1-cpu.bin": {
+      "filename": "1-cpu.bin",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "b-sonido.bin": {
+      "filename": "b-sonido.bin",
+      "type": "sound"
+    },
+    "a-sonido.bin": {
+      "filename": "a-sonido.bin",
+      "type": "sound"
+    }
+  },
+  "corv_21": {
+    "corvsnd7": {
+      "filename": "corvsnd7",
+      "type": "sound"
+    },
+    "corvsnd5": {
+      "filename": "corvsnd5",
+      "type": "sound"
+    },
+    "corv_2_1.rom": {
+      "filename": "corv_2_1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "corvsnd6": {
+      "filename": "corvsnd6",
+      "type": "sound"
+    },
+    "corvsnd2": {
+      "filename": "corvsnd2",
+      "type": "sound"
+    },
+    "corvsnd3": {
+      "filename": "corvsnd3",
+      "type": "sound"
+    },
+    "corvsnd4": {
+      "filename": "corvsnd4",
+      "type": "sound"
+    }
+  },
+  "corv_f61": {
+    "corvsnd7": {
+      "filename": "corvsnd7",
+      "type": "sound"
+    },
+    "corvsnd5": {
+      "filename": "corvsnd5",
+      "type": "sound"
+    },
+    "corf0_61.rom": {
+      "filename": "corf0_61.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "corvsnd6": {
+      "filename": "corvsnd6",
+      "type": "sound"
+    },
+    "corvsnd2": {
+      "filename": "corvsnd2",
+      "type": "sound"
+    },
+    "corvsnd3": {
+      "filename": "corvsnd3",
+      "type": "sound"
+    },
+    "corvsnd4": {
+      "filename": "corvsnd4",
+      "type": "sound"
+    }
+  },
+  "corv_la1": {
+    "corvsnd7": {
+      "filename": "corvsnd7",
+      "type": "sound"
+    },
+    "su2-sl1.rom": {
+      "filename": "su2-sl1.rom",
+      "type": "sound"
+    },
+    "u6-la1.rom": {
+      "filename": "u6-la1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "corvsnd5": {
+      "filename": "corvsnd5",
+      "type": "sound"
+    },
+    "corvsnd6": {
+      "filename": "corvsnd6",
+      "type": "sound"
+    },
+    "corvsnd3": {
+      "filename": "corvsnd3",
+      "type": "sound"
+    },
+    "corvsnd4": {
+      "filename": "corvsnd4",
+      "type": "sound"
+    }
+  },
+  "corv_lx2": {
+    "corvsnd7": {
+      "filename": "corvsnd7",
+      "type": "sound"
+    },
+    "su2-sl1.rom": {
+      "filename": "su2-sl1.rom",
+      "type": "sound"
+    },
+    "u6-lx2.rom": {
+      "filename": "u6-lx2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "corvsnd5": {
+      "filename": "corvsnd5",
+      "type": "sound"
+    },
+    "corvsnd6": {
+      "filename": "corvsnd6",
+      "type": "sound"
+    },
+    "corvsnd3": {
+      "filename": "corvsnd3",
+      "type": "sound"
+    },
+    "corvsnd4": {
+      "filename": "corvsnd4",
+      "type": "sound"
+    }
+  },
+  "corv_px4": {
+    "corvsnd7": {
+      "filename": "corvsnd7",
+      "type": "sound"
+    },
+    "corvsnd5": {
+      "filename": "corvsnd5",
+      "type": "sound"
+    },
+    "corvsnd6": {
+      "filename": "corvsnd6",
+      "type": "sound"
+    },
+    "corvsnd2": {
+      "filename": "corvsnd2",
+      "type": "sound"
+    },
+    "corvsnd3": {
+      "filename": "corvsnd3",
+      "type": "sound"
+    },
+    "corvsnd4": {
+      "filename": "corvsnd4",
+      "type": "sound"
+    },
+    "u6-px4.rom": {
+      "filename": "u6-px4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "rip300l": {
+    "ripsndl.u21": {
+      "filename": "ripsndl.u21",
+      "type": "sound"
+    },
+    "ripsndl.u7": {
+      "filename": "ripsndl.u7",
+      "type": "sound"
+    },
+    "ripsndl.u37": {
+      "filename": "ripsndl.u37",
+      "type": "sound"
+    },
+    "ripcpu.300": {
+      "filename": "ripcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsndl.u17": {
+      "filename": "ripsndl.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndl.u36": {
+      "filename": "ripsndl.u36",
+      "type": "sound"
+    },
+    "ripdispl.300": {
+      "filename": "ripdispl.300",
+      "type": "dmd"
+    }
+  },
+  "rip301l": {
+    "ripsndl.u21": {
+      "filename": "ripsndl.u21",
+      "type": "sound"
+    },
+    "ripsndl.u7": {
+      "filename": "ripsndl.u7",
+      "type": "sound"
+    },
+    "ripsndl.u37": {
+      "filename": "ripsndl.u37",
+      "type": "sound"
+    },
+    "ripdispl.301": {
+      "filename": "ripdispl.301",
+      "type": "dmd"
+    },
+    "ripcpu.301": {
+      "filename": "ripcpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsndl.u17": {
+      "filename": "ripsndl.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndl.u36": {
+      "filename": "ripsndl.u36",
+      "type": "sound"
+    }
+  },
+  "rip302l": {
+    "ripsndl.u21": {
+      "filename": "ripsndl.u21",
+      "type": "sound"
+    },
+    "ripsndl.u7": {
+      "filename": "ripsndl.u7",
+      "type": "sound"
+    },
+    "ripsndl.u37": {
+      "filename": "ripsndl.u37",
+      "type": "sound"
+    },
+    "ripdispl.301": {
+      "filename": "RIPDISPL.301",
+      "type": "dmd"
+    },
+    "ripsndl.u17": {
+      "filename": "ripsndl.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndl.u36": {
+      "filename": "ripsndl.u36",
+      "type": "sound"
+    },
+    "ripcpu.302": {
+      "filename": "RIPCPU.302",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "rip310l": {
+    "ripsndl.u21": {
+      "filename": "ripsndl.u21",
+      "type": "sound"
+    },
+    "ripsndl.u7": {
+      "filename": "ripsndl.u7",
+      "type": "sound"
+    },
+    "ripsndl.u37": {
+      "filename": "ripsndl.u37",
+      "type": "sound"
+    },
+    "ripdispl.301": {
+      "filename": "RIPDISPL.301",
+      "type": "dmd"
+    },
+    "ripcpu.310": {
+      "filename": "ripcpu.310",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsndl.u17": {
+      "filename": "ripsndl.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndl.u36": {
+      "filename": "ripsndl.u36",
+      "type": "sound"
+    }
+  },
+  "ripleysl": {
+    "ripsndl.u21": {
+      "filename": "ripsndl.u21",
+      "type": "sound"
+    },
+    "ripsndl.u7": {
+      "filename": "ripsndl.u7",
+      "type": "sound"
+    },
+    "ripsndl.u37": {
+      "filename": "ripsndl.u37",
+      "type": "sound"
+    },
+    "ripdispl.301": {
+      "filename": "ripdispl.301",
+      "type": "dmd"
+    },
+    "ripsndl.u17": {
+      "filename": "ripsndl.u17",
+      "type": "sound"
+    },
+    "ripcpu.320": {
+      "filename": "ripcpu.320",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndl.u36": {
+      "filename": "ripsndl.u36",
+      "type": "sound"
+    }
+  },
+  "rip300i": {
+    "ripsndi.u21": {
+      "filename": "ripsndi.u21",
+      "type": "sound"
+    },
+    "ripsndi.u36": {
+      "filename": "ripsndi.u36",
+      "type": "sound"
+    },
+    "ripsndi.u37": {
+      "filename": "ripsndi.u37",
+      "type": "sound"
+    },
+    "ripsndi.u7": {
+      "filename": "ripsndi.u7",
+      "type": "sound"
+    },
+    "ripcpu.300": {
+      "filename": "ripcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsndi.u17": {
+      "filename": "ripsndi.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispi.300": {
+      "filename": "RIPDISPI.300",
+      "type": "dmd"
+    }
+  },
+  "rip301i": {
+    "ripsndi.u21": {
+      "filename": "ripsndi.u21",
+      "type": "sound"
+    },
+    "ripsndi.u36": {
+      "filename": "ripsndi.u36",
+      "type": "sound"
+    },
+    "ripsndi.u37": {
+      "filename": "ripsndi.u37",
+      "type": "sound"
+    },
+    "ripsndi.u7": {
+      "filename": "ripsndi.u7",
+      "type": "sound"
+    },
+    "ripsndi.u17": {
+      "filename": "ripsndi.u17",
+      "type": "sound"
+    },
+    "ripcpu.301": {
+      "filename": "ripcpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispi.300": {
+      "filename": "ripdispi.300",
+      "type": "dmd"
+    }
+  },
+  "rip302i": {
+    "ripsndi.u21": {
+      "filename": "ripsndi.u21",
+      "type": "sound"
+    },
+    "ripsndi.u36": {
+      "filename": "ripsndi.u36",
+      "type": "sound"
+    },
+    "ripsndi.u37": {
+      "filename": "ripsndi.u37",
+      "type": "sound"
+    },
+    "ripsndi.u7": {
+      "filename": "ripsndi.u7",
+      "type": "sound"
+    },
+    "ripsndi.u17": {
+      "filename": "ripsndi.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispi.300": {
+      "filename": "RIPDISPI.300",
+      "type": "dmd"
+    },
+    "ripcpu.302": {
+      "filename": "RIPCPU.302",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "rip310i": {
+    "ripsndi.u21": {
+      "filename": "ripsndi.u21",
+      "type": "sound"
+    },
+    "ripcpu.310": {
+      "filename": "ripcpu.310",
+      "type": "main",
+      "romType": "se"
+    },
+    "ripsndi.u36": {
+      "filename": "ripsndi.u36",
+      "type": "sound"
+    },
+    "ripsndi.u37": {
+      "filename": "ripsndi.u37",
+      "type": "sound"
+    },
+    "ripsndi.u7": {
+      "filename": "ripsndi.u7",
+      "type": "sound"
+    },
+    "ripsndi.u17": {
+      "filename": "ripsndi.u17",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispi.300": {
+      "filename": "RIPDISPI.300",
+      "type": "dmd"
+    }
+  },
+  "ripleysi": {
+    "ripsndi.u21": {
+      "filename": "ripsndi.u21",
+      "type": "sound"
+    },
+    "ripsndi.u36": {
+      "filename": "ripsndi.u36",
+      "type": "sound"
+    },
+    "ripsndi.u37": {
+      "filename": "ripsndi.u37",
+      "type": "sound"
+    },
+    "ripsndi.u7": {
+      "filename": "ripsndi.u7",
+      "type": "sound"
+    },
+    "ripsndi.u17": {
+      "filename": "ripsndi.u17",
+      "type": "sound"
+    },
+    "ripcpu.320": {
+      "filename": "ripcpu.320",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripdispi.300": {
+      "filename": "ripdispi.300",
+      "type": "dmd"
+    }
+  },
+  "sman_160gf": {
+    "spd_1-6_gf.bin": {
+      "filename": "spd_1-6_gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mav_400": {
+    "mavdisp3.400": {
+      "filename": "MAVDISP3.400",
+      "type": "dmd"
+    },
+    "mavu7.dat": {
+      "filename": "mavu7.dat",
+      "type": "sound"
+    },
+    "mavdisp0.400": {
+      "filename": "MAVDISP0.400",
+      "type": "dmd"
+    },
+    "mavu21.dat": {
+      "filename": "mavu21.dat",
+      "type": "sound"
+    },
+    "mavu17.dat": {
+      "filename": "mavu17.dat",
+      "type": "sound"
+    },
+    "mavgc5.400": {
+      "filename": "MAVGC5.400",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "hawkman": {
+    "hawk3.bin": {
+      "filename": "hawk3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "hawk_s2.bin": {
+      "filename": "hawk_s2.bin",
+      "type": "sound"
+    },
+    "hawk_s1.bin": {
+      "filename": "hawk_s1.bin",
+      "type": "sound"
+    },
+    "hawk2.bin": {
+      "filename": "hawk2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "hawk1.bin": {
+      "filename": "hawk1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "hawk4.bin": {
+      "filename": "hawk4.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "hawkman1": {
+    "hawk3.bin": {
+      "filename": "hawk3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "hawk_s2.bin": {
+      "filename": "hawk_s2.bin",
+      "type": "sound"
+    },
+    "hawk_s1.bin": {
+      "filename": "hawk_s1.bin",
+      "type": "sound"
+    },
+    "hawk2.bin": {
+      "filename": "hawk2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "hawk4a.bin": {
+      "filename": "hawk4a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "hawk1a.bin": {
+      "filename": "hawk1a.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "spacejm2": {
+    "spcjam.u21": {
+      "filename": "spcjam.u21",
+      "type": "sound"
+    },
+    "jamdspa.200": {
+      "filename": "jamdspa.200",
+      "type": "dmd"
+    },
+    "spcjam.u36": {
+      "filename": "spcjam.u36",
+      "type": "sound"
+    },
+    "spcjam.u7": {
+      "filename": "spcjam.u7",
+      "type": "sound"
+    },
+    "spcjam.u17": {
+      "filename": "spcjam.u17",
+      "type": "sound"
+    },
+    "jamcpu.200": {
+      "filename": "jamcpu.200",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "f1gp": {
+    "snd_u8b": {
+      "filename": "snd_u8b",
+      "type": "main"
+    },
+    "cpu_u7": {
+      "filename": "cpu_u7",
+      "type": "main"
+    },
+    "snd_u11b": {
+      "filename": "snd_u11b",
+      "type": "main"
+    },
+    "snd_u8a": {
+      "filename": "snd_u8a",
+      "type": "main"
+    },
+    "snd_u10a": {
+      "filename": "snd_u10a",
+      "type": "main"
+    },
+    "snd_u9a": {
+      "filename": "snd_u9a",
+      "type": "main"
+    },
+    "snd_u9b": {
+      "filename": "snd_u9b",
+      "type": "main"
+    },
+    "snd_u11a": {
+      "filename": "snd_u11a",
+      "type": "main"
+    },
+    "snd_u10b": {
+      "filename": "snd_u10b",
+      "type": "main"
+    }
+  },
+  "sman_170gf": {
+    "spd_1-7_gf.bin": {
+      "filename": "spd_1-7_gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cftbl_l4": {
+    "bl_u15.l1": {
+      "filename": "bl_u15.l1",
+      "type": "sound"
+    },
+    "bl_u14.l1": {
+      "filename": "bl_u14.l1",
+      "type": "sound"
+    },
+    "bl_u18.l1": {
+      "filename": "bl_u18.l1",
+      "type": "sound"
+    },
+    "creat_l4.rom": {
+      "filename": "creat_l4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "csi_104": {
+    "csi104a.bin": {
+      "filename": "csi104a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "pz_l3": {
+    "pzonel_3.rom": {
+      "filename": "pzonel_3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "pz_u15.l1": {
+      "filename": "pz_u15.l1",
+      "type": "sound"
+    },
+    "pz_u14.l1": {
+      "filename": "pz_u14.l1",
+      "type": "sound"
+    },
+    "pz_u18.l1": {
+      "filename": "pz_u18.l1",
+      "type": "sound"
+    }
+  },
+  "btmn_g13": {
+    "bat_dspg.104": {
+      "filename": "bat_dspg.104",
+      "type": "dmd"
+    },
+    "batman.u21": {
+      "filename": "batman.u21",
+      "type": "sound"
+    },
+    "batbcpug.103": {
+      "filename": "batbcpug.103",
+      "type": "main",
+      "romType": "de"
+    },
+    "batccpug.103": {
+      "filename": "batccpug.103",
+      "type": "main",
+      "romType": "de"
+    },
+    "batman.u7": {
+      "filename": "batman.u7",
+      "type": "sound"
+    },
+    "batman.u17": {
+      "filename": "batman.u17",
+      "type": "sound"
+    }
+  },
+  "nstrphfp": {
+    "snd_ic24.bin": {
+      "filename": "snd_ic24.bin",
+      "type": "sound"
+    },
+    "snd_ic05.bin": {
+      "filename": "snd_ic05.bin",
+      "type": "sound"
+    },
+    "strsphfp.ic1": {
+      "filename": "strsphfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "snd_ic40.bin": {
+      "filename": "snd_ic40.bin",
+      "type": "sound"
+    },
+    "snd_ic06.bin": {
+      "filename": "snd_ic06.bin",
+      "type": "sound"
+    },
+    "strsphfp.ic2": {
+      "filename": "strsphfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "snd_ic25.bin": {
+      "filename": "snd_ic25.bin",
+      "type": "sound"
+    }
+  },
+  "nstrphnx": {
+    "snd_ic24.bin": {
+      "filename": "snd_ic24.bin",
+      "type": "sound"
+    },
+    "strphnx1.cpu": {
+      "filename": "strphnx1.cpu",
+      "type": "main",
+      "romType": "zac"
+    },
+    "snd_ic05.bin": {
+      "filename": "snd_ic05.bin",
+      "type": "sound"
+    },
+    "snd_ic40.bin": {
+      "filename": "snd_ic40.bin",
+      "type": "sound"
+    },
+    "snd_ic06.bin": {
+      "filename": "snd_ic06.bin",
+      "type": "sound"
+    },
+    "snd_ic25.bin": {
+      "filename": "snd_ic25.bin",
+      "type": "sound"
+    },
+    "strphnx2.cpu": {
+      "filename": "strphnx2.cpu",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "strsphfp": {
+    "snd_ic24.bin": {
+      "filename": "snd_ic24.bin",
+      "type": "sound"
+    },
+    "snd_ic05.bin": {
+      "filename": "snd_ic05.bin",
+      "type": "sound"
+    },
+    "strsphfp.ic1": {
+      "filename": "strsphfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "snd_ic40.bin": {
+      "filename": "snd_ic40.bin",
+      "type": "sound"
+    },
+    "snd_ic06.bin": {
+      "filename": "snd_ic06.bin",
+      "type": "sound"
+    },
+    "strsphfp.ic2": {
+      "filename": "strsphfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "snd_ic25.bin": {
+      "filename": "snd_ic25.bin",
+      "type": "sound"
+    }
+  },
+  "strsphnx": {
+    "snd_ic24.bin": {
+      "filename": "snd_ic24.bin",
+      "type": "sound"
+    },
+    "strphnx1.cpu": {
+      "filename": "strphnx1.cpu",
+      "type": "main",
+      "romType": "zac"
+    },
+    "snd_ic05.bin": {
+      "filename": "snd_ic05.bin",
+      "type": "sound"
+    },
+    "snd_ic40.bin": {
+      "filename": "snd_ic40.bin",
+      "type": "sound"
+    },
+    "snd_ic06.bin": {
+      "filename": "snd_ic06.bin",
+      "type": "sound"
+    },
+    "snd_ic25.bin": {
+      "filename": "snd_ic25.bin",
+      "type": "sound"
+    },
+    "strphnx2.cpu": {
+      "filename": "strphnx2.cpu",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "alpok_b6": {
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    }
+  },
+  "alpok_l2": {
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    }
+  },
+  "alpok_l6": {
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom6.716": {
+      "filename": "gamerom6.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    }
+  },
+  "esha_pr4": {
+    "eshk_u26.f1": {
+      "filename": "eshk_u26.f1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u4.l1": {
+      "filename": "eshk_u4.l1",
+      "type": "sound"
+    },
+    "eshk_u22.l1": {
+      "filename": "eshk_u22.l1",
+      "type": "sound"
+    },
+    "eshk_u27.f1": {
+      "filename": "eshk_u27.f1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u19.l1": {
+      "filename": "eshk_u19.l1",
+      "type": "sound"
+    },
+    "eshk_u21.l1": {
+      "filename": "eshk_u21.l1",
+      "type": "sound"
+    }
+  },
+  "nba_700": {
+    "nba_v7-0_a.bin": {
+      "filename": "nba_v7-0_a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "carhop": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "flash_t1": {
+    "green2a.716": {
+      "filename": "green2a.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "frpwr_t6": {
+    "green2a.716": {
+      "filename": "green2a.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "prom3.474": {
+      "filename": "prom3.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "prom1_6.474": {
+      "filename": "prom1_6.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "prom2.474": {
+      "filename": "prom2.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    }
+  },
+  "lzbal_t2": {
+    "green2a.716": {
+      "filename": "green2a.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound2.716": {
+      "filename": "sound2.716",
+      "type": "sound"
+    }
+  },
+  "scrpn_t1": {
+    "green2a.716": {
+      "filename": "green2a.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "tmwrp_t2": {
+    "green2a.716": {
+      "filename": "green2a.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "trizn_t1": {
+    "green2a.716": {
+      "filename": "GREEN2A.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "motrshow": {
+    "vid_ic56.rom": {
+      "filename": "vid_ic56.rom",
+      "type": "dmd"
+    },
+    "vid_ic14.rom": {
+      "filename": "vid_ic14.rom",
+      "type": "dmd"
+    },
+    "snd_ic36.rom": {
+      "filename": "snd_ic36.rom",
+      "type": "sound"
+    },
+    "vid_ic66.rom": {
+      "filename": "vid_ic66.rom",
+      "type": "dmd"
+    },
+    "snd_ic35.rom": {
+      "filename": "snd_ic35.rom",
+      "type": "sound"
+    },
+    "vid_ic55.rom": {
+      "filename": "vid_ic55.rom",
+      "type": "dmd"
+    },
+    "cpu_ic14.rom": {
+      "filename": "cpu_ic14.rom",
+      "type": "main",
+      "romType": "mrgame"
+    },
+    "snd_ic22.rom": {
+      "filename": "snd_ic22.rom",
+      "type": "sound"
+    },
+    "cpu_ic13.rom": {
+      "filename": "cpu_ic13.rom",
+      "type": "main",
+      "romType": "mrgame"
+    },
+    "snd_ic06.rom": {
+      "filename": "snd_ic06.rom",
+      "type": "sound"
+    }
+  },
+  "spacejmf": {
+    "jamdspf.300": {
+      "filename": "jamdspf.300",
+      "type": "dmd"
+    },
+    "spcjam.u36": {
+      "filename": "spcjam.u36",
+      "type": "sound"
+    },
+    "jamcpu.300": {
+      "filename": "jamcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "spcjam.u21": {
+      "filename": "spcjam.u21",
+      "type": "sound"
+    },
+    "spcjam.u7": {
+      "filename": "spcjam.u7",
+      "type": "sound"
+    },
+    "spcjam.u17": {
+      "filename": "spcjam.u17",
+      "type": "sound"
+    }
+  },
+  "pz_l1": {
+    "pz_u15.l1": {
+      "filename": "pz_u15.l1",
+      "type": "sound"
+    },
+    "u6-l1.rom": {
+      "filename": "u6-l1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "pz_u14.l1": {
+      "filename": "pz_u14.l1",
+      "type": "sound"
+    },
+    "pz_u18.l1": {
+      "filename": "pz_u18.l1",
+      "type": "sound"
+    }
+  },
+  "pz_l2": {
+    "pz_u15.l1": {
+      "filename": "pz_u15.l1",
+      "type": "sound"
+    },
+    "pz_u6.l2": {
+      "filename": "pz_u6.l2",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "pz_u14.l1": {
+      "filename": "pz_u14.l1",
+      "type": "sound"
+    },
+    "pz_u18.l1": {
+      "filename": "pz_u18.l1",
+      "type": "sound"
+    }
+  },
+  "lotr_g51": {
+    "lotrdspg.501": {
+      "filename": "lotrdspg.501",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.501": {
+      "filename": "lotrcpu.501",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "mac_zois": {
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "dsprommz.bin": {
+      "filename": "dsprommz.bin",
+      "type": "dmd"
+    },
+    "arom1mz.bin": {
+      "filename": "arom1mz.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "dmd"
+    },
+    "arom2mz.bin": {
+      "filename": "arom2mz.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "tftc_200": {
+    "tftcdot.a20": {
+      "filename": "tftcdot.a20",
+      "type": "dmd"
+    },
+    "sndu17.dat": {
+      "filename": "sndu17.dat",
+      "type": "sound"
+    },
+    "sndu7.dat": {
+      "filename": "sndu7.dat",
+      "type": "sound"
+    },
+    "tftcgc5.a20": {
+      "filename": "tftcgc5.a20",
+      "type": "main",
+      "romType": "de"
+    },
+    "sndu21.dat": {
+      "filename": "sndu21.dat",
+      "type": "sound"
+    }
+  },
+  "batmanf2": {
+    "bmfrom0.200": {
+      "filename": "bmfrom0.200",
+      "type": "dmd"
+    },
+    "batcpua.202": {
+      "filename": "batcpua.202",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bmfrom3.200": {
+      "filename": "bmfrom3.200",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "ladylukt": {
+    "lluck4.bin": {
+      "filename": "lluck4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "lluck2.bin": {
+      "filename": "lluck2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "lluck_s1.bin": {
+      "filename": "lluck_s1.bin",
+      "type": "sound"
+    },
+    "lluck_s2.bin": {
+      "filename": "lluck_s2.bin",
+      "type": "sound"
+    },
+    "lluck1.bin": {
+      "filename": "lluck1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "lluck3.bin": {
+      "filename": "lluck3.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "ssvc_a26": {
+    "ssvc2-6.c5": {
+      "filename": "ssvc2-6.c5",
+      "type": "main",
+      "romType": "de"
+    },
+    "ssv2f4.rom": {
+      "filename": "ssv2f4.rom",
+      "type": "sound"
+    },
+    "sssndf7.rom": {
+      "filename": "sssndf7.rom",
+      "type": "sound"
+    },
+    "ssv1f6.rom": {
+      "filename": "ssv1f6.rom",
+      "type": "sound"
+    },
+    "ssvc2-6.b5": {
+      "filename": "ssvc2-6.b5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "ssvc_b26": {
+    "ssvc2-6.c5": {
+      "filename": "ssvc2-6.c5",
+      "type": "main",
+      "romType": "de"
+    },
+    "sssndf7b.bin": {
+      "filename": "sssndf7b.bin",
+      "type": "sound"
+    },
+    "ssv2f4.rom": {
+      "filename": "ssv2f4.rom",
+      "type": "sound"
+    },
+    "ssv1f6.rom": {
+      "filename": "ssv1f6.rom",
+      "type": "sound"
+    },
+    "ssvc2-6.b5": {
+      "filename": "ssvc2-6.b5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "cueball2": {
+    "gprom.r2": {
+      "filename": "gprom.r2",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "dsprom.r2": {
+      "filename": "dsprom.r2",
+      "type": "dmd"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "term3_3": {
+    "t3cpu.301": {
+      "filename": "t3cpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u37": {
+      "filename": "T3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "T3100.u21",
+      "type": "sound"
+    },
+    "t3dispa.300": {
+      "filename": "t3dispa.300",
+      "type": "dmd"
+    },
+    "t3100.u7": {
+      "filename": "T3100.u7",
+      "type": "sound"
+    },
+    "t3100.u36": {
+      "filename": "T3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "T3100.u17",
+      "type": "sound"
+    }
+  },
+  "term3f_3": {
+    "t3cpu.301": {
+      "filename": "t3cpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u37": {
+      "filename": "T3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "T3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "T3100.u7",
+      "type": "sound"
+    },
+    "t3100.u36": {
+      "filename": "T3100.u36",
+      "type": "sound"
+    },
+    "t3dispf.300": {
+      "filename": "t3dispf.300",
+      "type": "dmd"
+    },
+    "t3100.u17": {
+      "filename": "T3100.u17",
+      "type": "sound"
+    }
+  },
+  "term3g_3": {
+    "t3cpu.301": {
+      "filename": "t3cpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u37": {
+      "filename": "T3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "T3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "T3100.u7",
+      "type": "sound"
+    },
+    "t3dispg.300": {
+      "filename": "t3dispg.300",
+      "type": "dmd"
+    },
+    "t3100.u36": {
+      "filename": "T3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "T3100.u17",
+      "type": "sound"
+    }
+  },
+  "term3i_3": {
+    "t3cpu.301": {
+      "filename": "t3cpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3dispi.300": {
+      "filename": "t3dispi.300",
+      "type": "dmd"
+    },
+    "t3100.u37": {
+      "filename": "T3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "T3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "T3100.u7",
+      "type": "sound"
+    },
+    "t3100.u36": {
+      "filename": "T3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "T3100.u17",
+      "type": "sound"
+    }
+  },
+  "term3l_3": {
+    "t3cpu.301": {
+      "filename": "t3cpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3displ.300": {
+      "filename": "t3displ.300",
+      "type": "dmd"
+    },
+    "t3100.u37": {
+      "filename": "T3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "T3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "T3100.u7",
+      "type": "sound"
+    },
+    "t3100.u36": {
+      "filename": "T3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "T3100.u17",
+      "type": "sound"
+    }
+  },
+  "ss_14": {
+    "stiffg11.1_4": {
+      "filename": "stiffg11.1_4",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sssnd_11.s2": {
+      "filename": "sssnd_11.s2",
+      "type": "sound"
+    },
+    "sssnd_11.s4": {
+      "filename": "sssnd_11.s4",
+      "type": "sound"
+    },
+    "sssnd_11.s3": {
+      "filename": "sssnd_11.s3",
+      "type": "sound"
+    }
+  },
+  "tz_f100": {
+    "ftz1_00.rom": {
+      "filename": "ftz1_00.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    }
+  },
+  "frpwr_a6": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "fire6620.716": {
+      "filename": "fire6620.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "fire6614.732": {
+      "filename": "fire6614.732",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "fire6617.716": {
+      "filename": "fire6617.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    }
+  },
+  "frpwr_a7": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "fire6720.716": {
+      "filename": "fire6720.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "fire6717.532": {
+      "filename": "fire6717.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "fire6714.716": {
+      "filename": "fire6714.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "frpwr_b6": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "f6p7ic20.716": {
+      "filename": "f6p7ic20.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "f6p7ic17.716": {
+      "filename": "f6p7ic17.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "f6p7ic14.732": {
+      "filename": "f6p7ic14.732",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    }
+  },
+  "frpwr_b7": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "f7ic20ga.716": {
+      "filename": "f7ic20ga.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "f7ic17gr.532": {
+      "filename": "f7ic17gr.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "f7ic14pr.716": {
+      "filename": "f7ic14pr.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    }
+  },
+  "frpwr_c6": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "fire7620.716": {
+      "filename": "fire7620.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "fire7614.732": {
+      "filename": "fire7614.732",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "fire7617.716": {
+      "filename": "fire7617.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    }
+  },
+  "frpwr_c7": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "f7ic17gr.532": {
+      "filename": "f7ic17gr.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "f7ic14pr.716": {
+      "filename": "f7ic14pr.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "f7ic20ga.716": {
+      "filename": "f7ic20ga.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic4.532": {
+      "filename": "v_ic4.532",
+      "type": "sound"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "f7ic26.716": {
+      "filename": "f7ic26.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "frpwr_d6": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "fir6d620.716": {
+      "filename": "fir6d620.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "fir6d617.716": {
+      "filename": "fir6d617.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "fir6d614.732": {
+      "filename": "fir6d614.732",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    }
+  },
+  "frpwr_e7": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "fir6d720.716": {
+      "filename": "fir6d720.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "fir6d714.716": {
+      "filename": "fir6d714.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "fir6d717.532": {
+      "filename": "fir6d717.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    }
+  },
+  "frpwr_l2": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "prom3.474": {
+      "filename": "prom3.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "prom2.474": {
+      "filename": "prom2.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "prom1.474": {
+      "filename": "prom1.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    }
+  },
+  "frpwr_l6": {
+    "v_ic5.532": {
+      "filename": "v_ic5.532",
+      "type": "sound"
+    },
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "prom3.474": {
+      "filename": "prom3.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "v_ic7.532": {
+      "filename": "v_ic7.532",
+      "type": "sound"
+    },
+    "prom1_6.474": {
+      "filename": "prom1_6.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "v_ic6.532": {
+      "filename": "v_ic6.532",
+      "type": "sound"
+    },
+    "prom2.474": {
+      "filename": "prom2.474",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    }
+  },
+  "pincfp": {
+    "pincfp.ic1": {
+      "filename": "pincfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_gb.1e": {
+      "filename": "pchmp_gb.1e",
+      "type": "sound"
+    },
+    "pchmp_gb.1g": {
+      "filename": "pchmp_gb.1g",
+      "type": "sound"
+    },
+    "pincfp.ic2": {
+      "filename": "pincfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_gb.1f": {
+      "filename": "pchmp_gb.1f",
+      "type": "sound"
+    },
+    "pchmp_gb.1c": {
+      "filename": "pchmp_gb.1c",
+      "type": "sound"
+    }
+  },
+  "pincgfp": {
+    "pincfp.ic1": {
+      "filename": "pincfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_de.1g": {
+      "filename": "pchmp_de.1g",
+      "type": "sound"
+    },
+    "pincfp.ic2": {
+      "filename": "pincfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_de.1c": {
+      "filename": "pchmp_de.1c",
+      "type": "sound"
+    },
+    "pchmp_de.1e": {
+      "filename": "pchmp_de.1e",
+      "type": "sound"
+    },
+    "pchmp_de.1f": {
+      "filename": "pchmp_de.1f",
+      "type": "sound"
+    }
+  },
+  "pincifp": {
+    "pincfp.ic1": {
+      "filename": "pincfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_gb.1e": {
+      "filename": "pchmp_gb.1e",
+      "type": "sound"
+    },
+    "pchmp_it.1g": {
+      "filename": "pchmp_it.1g",
+      "type": "sound"
+    },
+    "pchmp_it.1f": {
+      "filename": "pchmp_it.1f",
+      "type": "sound"
+    },
+    "pincfp.ic2": {
+      "filename": "pincfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_it.1c": {
+      "filename": "pchmp_it.1c",
+      "type": "sound"
+    }
+  },
+  "lazrlord": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "wpt_106i": {
+    "wpt0106i.bin": {
+      "filename": "wpt0106i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "locomotn": {
+    "loc-4.fil": {
+      "filename": "loc-4.fil",
+      "type": "main",
+      "romType": "zac"
+    },
+    "loc-snd.fil": {
+      "filename": "loc-snd.fil",
+      "type": "sound"
+    },
+    "loc-3.fil": {
+      "filename": "loc-3.fil",
+      "type": "main",
+      "romType": "zac"
+    },
+    "loc-1.fil": {
+      "filename": "loc-1.fil",
+      "type": "main",
+      "romType": "zac"
+    },
+    "loc-2.fil": {
+      "filename": "loc-2.fil",
+      "type": "main",
+      "romType": "zac"
+    },
+    "loc-5.fil": {
+      "filename": "loc-5.fil",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "ft_l5p": {
+    "fshtd_5p.rom": {
+      "filename": "fshtd_5p.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "dragfisb": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "dragfist": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "sttng_g7": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "ng_u2_s.l1": {
+      "filename": "ng_u2_s.l1",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    },
+    "trek_lg7.rom": {
+      "filename": "trek_lg7.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "sttng_l1": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "trek_lx1.rom": {
+      "filename": "trek_lx1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "ng_u2_s.l1": {
+      "filename": "ng_u2_s.l1",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "sttng_l2": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "ng_u2_s.l1": {
+      "filename": "ng_u2_s.l1",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    },
+    "trek_lx2.rom": {
+      "filename": "trek_lx2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "sttng_l3": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "trek_lx3.rom": {
+      "filename": "trek_lx3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "ng_u2_s.l1": {
+      "filename": "ng_u2_s.l1",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "sttng_l7": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "ng_u2_s.l1": {
+      "filename": "ng_u2_s.l1",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "trek_lx7.rom": {
+      "filename": "trek_lx7.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "sttng_p4": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "sttng_p4.u6": {
+      "filename": "sttng_p4.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "ng_u2_s.l1": {
+      "filename": "ng_u2_s.l1",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "sttng_p5": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "sttng_p5.u6": {
+      "filename": "sttng_p5.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ng_u2_s.l1": {
+      "filename": "ng_u2_s.l1",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "sttng_p8": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "sttng_p8.u6": {
+      "filename": "sttng_p8.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ng_u2_s.l1": {
+      "filename": "ng_u2_s.l1",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "sttng_s7": {
+    "ng_u4_s.l1": {
+      "filename": "ng_u4_s.l1",
+      "type": "sound"
+    },
+    "ng_u5_s.l1": {
+      "filename": "ng_u5_s.l1",
+      "type": "sound"
+    },
+    "ng_u3_s.l1": {
+      "filename": "ng_u3_s.l1",
+      "type": "sound"
+    },
+    "ng_u6_s.l1": {
+      "filename": "ng_u6_s.l1",
+      "type": "sound"
+    },
+    "su2-sp1.rom": {
+      "filename": "su2-sp1.rom",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "trek_lx7.rom": {
+      "filename": "trek_lx7.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ng_u7_s.l1": {
+      "filename": "ng_u7_s.l1",
+      "type": "sound"
+    }
+  },
+  "antar2": {
+    "antar11a.bin": {
+      "filename": "ANTAR11a.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "antar09.bin": {
+      "filename": "Antar09.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "antar10a.bin": {
+      "filename": "ANTAR10a.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "antar08.bin": {
+      "filename": "Antar08.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "cc_12": {
+    "cc_g11.1_2": {
+      "filename": "cc_g11.1_2",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sav5_8.rom": {
+      "filename": "sav5_8.rom",
+      "type": "sound"
+    },
+    "sav6_8.rom": {
+      "filename": "sav6_8.rom",
+      "type": "sound"
+    },
+    "sav7_8.rom": {
+      "filename": "sav7_8.rom",
+      "type": "sound"
+    },
+    "sav2_8.rom": {
+      "filename": "sav2_8.rom",
+      "type": "sound"
+    },
+    "sav3_8.rom": {
+      "filename": "sav3_8.rom",
+      "type": "sound"
+    },
+    "sav4_8.rom": {
+      "filename": "sav4_8.rom",
+      "type": "sound"
+    }
+  },
+  "stargate": {
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "bop_l2": {
+    "bop_l2.u6": {
+      "filename": "bop_l2.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mach_u14.l1": {
+      "filename": "mach_u14.l1",
+      "type": "sound"
+    },
+    "mach_u18.l1": {
+      "filename": "mach_u18.l1",
+      "type": "sound"
+    },
+    "mach_u15.l1": {
+      "filename": "mach_u15.l1",
+      "type": "sound"
+    }
+  },
+  "term3l_2": {
+    "t3displ.201": {
+      "filename": "t3displ.201",
+      "type": "dmd"
+    },
+    "t3cpu.205": {
+      "filename": "t3cpu.205",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "snake": {
+    "snake_s2.bin": {
+      "filename": "snake_s2.bin",
+      "type": "sound"
+    },
+    "snake2.bin": {
+      "filename": "snake2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "snake3.bin": {
+      "filename": "snake3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "snake1.bin": {
+      "filename": "snake1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "snake4.bin": {
+      "filename": "snake4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "snake_s1.bin": {
+      "filename": "snake_s1.bin",
+      "type": "sound"
+    }
+  },
+  "ironball": {
+    "video.bin": {
+      "filename": "Video.BIN",
+      "type": "main"
+    },
+    "sound.bin": {
+      "filename": "Sound.BIN",
+      "type": "main"
+    }
+  },
+  "rollr_ex": {
+    "rolr_u27.ea3": {
+      "filename": "rolr_u27.ea3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rolr_u19.l3": {
+      "filename": "rolr_u19.l3",
+      "type": "sound"
+    },
+    "rolr_u20.l3": {
+      "filename": "rolr_u20.l3",
+      "type": "sound"
+    },
+    "rolr-u26.ea3": {
+      "filename": "rolr-u26.ea3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rolr_u4.l3": {
+      "filename": "rolr_u4.l3",
+      "type": "sound"
+    }
+  },
+  "lsrcu_l2": {
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "f14_p4": {
+    "u27_l4.256": {
+      "filename": "u27_l4.256",
+      "type": "main",
+      "romType": "s11"
+    },
+    "f14_u4.l1": {
+      "filename": "F14_U4.L1",
+      "type": "sound"
+    },
+    "u26_l4.128": {
+      "filename": "u26_l4.128",
+      "type": "main",
+      "romType": "s11"
+    },
+    "f14_u22.l1": {
+      "filename": "F14_U22.L1",
+      "type": "sound"
+    },
+    "f14_u19.l1": {
+      "filename": "F14_U19.L1",
+      "type": "sound"
+    },
+    "f14_u21.l1": {
+      "filename": "F14_U21.L1",
+      "type": "sound"
+    }
+  },
+  "bbh_150": {
+    "bbh150.bin": {
+      "filename": "bbh150.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "gpr301f": {
+    "gpsndf.u17": {
+      "filename": "gpsndf.u17",
+      "type": "sound"
+    },
+    "gpsndf.u36": {
+      "filename": "gpsndf.u36",
+      "type": "sound"
+    },
+    "gpcpuf.301": {
+      "filename": "gpcpuf.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndf.u7": {
+      "filename": "gpsndf.u7",
+      "type": "sound"
+    },
+    "gpdspf.301": {
+      "filename": "gpdspf.301",
+      "type": "dmd"
+    },
+    "gpsndf.u21": {
+      "filename": "gpsndf.u21",
+      "type": "sound"
+    },
+    "gpsndf.u37": {
+      "filename": "gpsndf.u37",
+      "type": "sound"
+    }
+  },
+  "gpr340f": {
+    "gpsndf.u17": {
+      "filename": "gpsndf.u17",
+      "type": "sound"
+    },
+    "gpsndf.u36": {
+      "filename": "gpsndf.u36",
+      "type": "sound"
+    },
+    "gpsndf.u7": {
+      "filename": "gpsndf.u7",
+      "type": "sound"
+    },
+    "gpsndf.u21": {
+      "filename": "gpsndf.u21",
+      "type": "sound"
+    },
+    "gpcpuf.340": {
+      "filename": "gpcpuf.340",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndf.u37": {
+      "filename": "gpsndf.u37",
+      "type": "sound"
+    },
+    "gpdspf.303": {
+      "filename": "gpdspf.303",
+      "type": "dmd"
+    }
+  },
+  "gpr350f": {
+    "gpsndf.u17": {
+      "filename": "gpsndf.u17",
+      "type": "sound"
+    },
+    "gpsndf.u36": {
+      "filename": "gpsndf.u36",
+      "type": "sound"
+    },
+    "gpsndf.u7": {
+      "filename": "gpsndf.u7",
+      "type": "sound"
+    },
+    "gpcpuf.350": {
+      "filename": "gpcpuf.350",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndf.u21": {
+      "filename": "gpsndf.u21",
+      "type": "sound"
+    },
+    "gpsndf.u37": {
+      "filename": "gpsndf.u37",
+      "type": "sound"
+    },
+    "gpdspf.303": {
+      "filename": "gpdspf.303",
+      "type": "dmd"
+    }
+  },
+  "gpr352f": {
+    "gpsndf.u17": {
+      "filename": "gpsndf.u17",
+      "type": "sound"
+    },
+    "gpsndf.u36": {
+      "filename": "gpsndf.u36",
+      "type": "sound"
+    },
+    "gpcpuf.352": {
+      "filename": "gpcpuf.352",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndf.u7": {
+      "filename": "gpsndf.u7",
+      "type": "sound"
+    },
+    "gpsndf.u21": {
+      "filename": "gpsndf.u21",
+      "type": "sound"
+    },
+    "gpsndf.u37": {
+      "filename": "gpsndf.u37",
+      "type": "sound"
+    },
+    "gpdspf.303": {
+      "filename": "gpdspf.303",
+      "type": "dmd"
+    }
+  },
+  "gprixf": {
+    "gpsndf.u17": {
+      "filename": "gpsndf.u17",
+      "type": "sound"
+    },
+    "gpsndf.u36": {
+      "filename": "gpsndf.u36",
+      "type": "sound"
+    },
+    "gpsndf.u7": {
+      "filename": "gpsndf.u7",
+      "type": "sound"
+    },
+    "gpcpuf.450": {
+      "filename": "gpcpuf.450",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndf.u21": {
+      "filename": "gpsndf.u21",
+      "type": "sound"
+    },
+    "gpsndf.u37": {
+      "filename": "gpsndf.u37",
+      "type": "sound"
+    },
+    "gpdspf.400": {
+      "filename": "gpdspf.400",
+      "type": "dmd"
+    }
+  },
+  "sopr107f": {
+    "sopdspf.100": {
+      "filename": "sopdspf.100",
+      "type": "dmd"
+    },
+    "sopcpuf.107": {
+      "filename": "sopcpuf.107",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndf.u21": {
+      "filename": "sopsndf.u21",
+      "type": "sound"
+    },
+    "sopsndf.u37": {
+      "filename": "sopsndf.u37",
+      "type": "sound"
+    },
+    "sopsndf.u7": {
+      "filename": "sopsndf.u7",
+      "type": "sound"
+    },
+    "sopsndf.u36": {
+      "filename": "sopsndf.u36",
+      "type": "sound"
+    },
+    "sopsndf1.u17": {
+      "filename": "sopsndf1.u17",
+      "type": "sound"
+    }
+  },
+  "wcsoccd2": {
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "dsprom2.bin": {
+      "filename": "dsprom2.bin",
+      "type": "dmd"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "wcsoccer": {
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "mrblack1": {
+    "mrb5a.bin": {
+      "filename": "mrb5a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb_s3.bin": {
+      "filename": "mrb_s3.bin",
+      "type": "sound"
+    },
+    "mrb_s2.bin": {
+      "filename": "mrb_s2.bin",
+      "type": "sound"
+    },
+    "mrb4.bin": {
+      "filename": "mrb4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb1a.bin": {
+      "filename": "mrb1a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb2.bin": {
+      "filename": "mrb2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb3.bin": {
+      "filename": "mrb3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb_s1.bin": {
+      "filename": "mrb_s1.bin",
+      "type": "sound"
+    }
+  },
+  "andromea": {
+    "850.snd": {
+      "filename": "850.snd",
+      "type": "sound"
+    },
+    "850.a": {
+      "filename": "850.a",
+      "type": "sound"
+    },
+    "850b.rom": {
+      "filename": "850b.rom",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "andromed": {
+    "850.snd": {
+      "filename": "850.snd",
+      "type": "sound"
+    },
+    "850.b": {
+      "filename": "850.b",
+      "type": "sound"
+    },
+    "850.a": {
+      "filename": "850.a",
+      "type": "sound"
+    }
+  },
+  "mtl_151h": {
+    "mtl151le.bin": {
+      "filename": "MTL151LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "pnkpnthr": {
+    "664.snd": {
+      "filename": "664.snd",
+      "type": "sound"
+    },
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "664-1.cpu": {
+      "filename": "664-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "pnkpntr7": {
+    "664.snd": {
+      "filename": "664.snd",
+      "type": "sound"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "664-1.cpu": {
+      "filename": "664-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "elv302i": {
+    "elvisi.u21": {
+      "filename": "elvisi.u21",
+      "type": "sound"
+    },
+    "elvsdspi.302": {
+      "filename": "ELVSDSPI.302",
+      "type": "dmd"
+    },
+    "elvisi.u7": {
+      "filename": "Elvisi.u7",
+      "type": "sound"
+    },
+    "elvisi.u37": {
+      "filename": "elvisi.u37",
+      "type": "sound"
+    },
+    "elvscpui.302": {
+      "filename": "elvscpui.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisi.u17": {
+      "filename": "elvisi.u17",
+      "type": "sound"
+    },
+    "elvisi.u36": {
+      "filename": "elvisi.u36",
+      "type": "sound"
+    }
+  },
+  "elv400i": {
+    "elvisi.u21": {
+      "filename": "elvisi.u21",
+      "type": "sound"
+    },
+    "elvsdspi.401": {
+      "filename": "elvsdspi.401",
+      "type": "dmd"
+    },
+    "elvisi.u7": {
+      "filename": "Elvisi.u7",
+      "type": "sound"
+    },
+    "elvisi.u37": {
+      "filename": "elvisi.u37",
+      "type": "sound"
+    },
+    "elvisi.u17": {
+      "filename": "elvisi.u17",
+      "type": "sound"
+    },
+    "elvscpui.400": {
+      "filename": "elvscpui.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisi.u36": {
+      "filename": "elvisi.u36",
+      "type": "sound"
+    }
+  },
+  "elvisi": {
+    "elvisi.u21": {
+      "filename": "elvisi.u21",
+      "type": "sound"
+    },
+    "elvsdspi.401": {
+      "filename": "elvsdspi.401",
+      "type": "dmd"
+    },
+    "elvisi.u7": {
+      "filename": "elvisi.u7",
+      "type": "sound"
+    },
+    "elvisi.u37": {
+      "filename": "elvisi.u37",
+      "type": "sound"
+    },
+    "elvisi.u17": {
+      "filename": "elvisi.u17",
+      "type": "sound"
+    },
+    "elvscpui.400": {
+      "filename": "elvscpui.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvisi.u36": {
+      "filename": "elvisi.u36",
+      "type": "sound"
+    }
+  },
+  "nautilus": {
+    "nautilus.cpu": {
+      "filename": "Nautilus.cpu",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "nautilus.snd": {
+      "filename": "nautilus.snd",
+      "type": "sound"
+    }
+  },
+  "spacejam": {
+    "jamdspa.300": {
+      "filename": "jamdspa.300",
+      "type": "dmd"
+    },
+    "spcjam.u36": {
+      "filename": "spcjam.u36",
+      "type": "sound"
+    },
+    "jamcpu.300": {
+      "filename": "jamcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "spcjam.u21": {
+      "filename": "spcjam.u21",
+      "type": "sound"
+    },
+    "spcjam.u7": {
+      "filename": "spcjam.u7",
+      "type": "sound"
+    },
+    "spcjam.u17": {
+      "filename": "spcjam.u17",
+      "type": "sound"
+    }
+  },
+  "coneyis": {
+    "130b.716": {
+      "filename": "130b.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "130c.716": {
+      "filename": "130c.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "130a.716": {
+      "filename": "130a.716",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "lizard": {
+    "130b.716": {
+      "filename": "130b.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "lizard.u10": {
+      "filename": "lizard.u10",
+      "type": "sound"
+    },
+    "lizard.u9": {
+      "filename": "lizard.u9",
+      "type": "sound"
+    },
+    "130c.716": {
+      "filename": "130c.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "130a.716": {
+      "filename": "130a.716",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "sshooter": {
+    "130b.716": {
+      "filename": "130b.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "130c.716": {
+      "filename": "130c.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "130a.716": {
+      "filename": "130a.716",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "sshootr2": {
+    "130b.716": {
+      "filename": "130b.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "730u10.snd": {
+      "filename": "730u10.snd",
+      "type": "sound"
+    },
+    "730c": {
+      "filename": "730c",
+      "type": "main",
+      "romType": "gp"
+    },
+    "130a.716": {
+      "filename": "130a.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "730u9.snd": {
+      "filename": "730u9.snd",
+      "type": "sound"
+    }
+  },
+  "rdkng_l1": {
+    "road_u26.l1": {
+      "filename": "road_u26.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "road_u27.l1": {
+      "filename": "road_u27.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "road_u4.l1": {
+      "filename": "road_u4.l1",
+      "type": "sound"
+    },
+    "road_u22.l1": {
+      "filename": "road_u22.l1",
+      "type": "sound"
+    },
+    "road_u21.l1": {
+      "filename": "road_u21.l1",
+      "type": "sound"
+    }
+  },
+  "rdkng_l2": {
+    "road_u26.l1": {
+      "filename": "road_u26.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "road_u4.l1": {
+      "filename": "road_u4.l1",
+      "type": "sound"
+    },
+    "road_u22.l1": {
+      "filename": "road_u22.l1",
+      "type": "sound"
+    },
+    "road_u27.l2": {
+      "filename": "road_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "road_u21.l1": {
+      "filename": "road_u21.l1",
+      "type": "sound"
+    }
+  },
+  "lotr5": {
+    "lotrdspa.500": {
+      "filename": "lotrdspa.500",
+      "type": "dmd"
+    },
+    "lotrcpu.500": {
+      "filename": "lotrcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "pstlpkr": {
+    "p_parom3.c20": {
+      "filename": "p_parom3.c20",
+      "type": "sound"
+    },
+    "p_peteu5.c20": {
+      "filename": "p_peteu5.c20",
+      "type": "dmd"
+    },
+    "p_peteu6.c20": {
+      "filename": "p_peteu6.c20",
+      "type": "dmd"
+    },
+    "p_peteu2.512": {
+      "filename": "p_peteu2.512",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "p_parom0.c20": {
+      "filename": "p_parom0.c20",
+      "type": "sound"
+    },
+    "p_parom1.c20": {
+      "filename": "p_parom1.c20",
+      "type": "sound"
+    },
+    "p_pu102.512": {
+      "filename": "p_pu102.512",
+      "type": "sound"
+    },
+    "p_peteu4.512": {
+      "filename": "p_peteu4.512",
+      "type": "dmd"
+    },
+    "p_parom2.c20": {
+      "filename": "p_parom2.c20",
+      "type": "sound"
+    }
+  },
+  "pstlpkr1": {
+    "p_parom3.c20": {
+      "filename": "p_parom3.c20",
+      "type": "sound"
+    },
+    "p_peteu5.c20": {
+      "filename": "p_peteu5.c20",
+      "type": "dmd"
+    },
+    "p_peteu6.c20": {
+      "filename": "p_peteu6.c20",
+      "type": "dmd"
+    },
+    "u2-ddff.512": {
+      "filename": "u2-ddff.512",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "p_parom0.c20": {
+      "filename": "p_parom0.c20",
+      "type": "sound"
+    },
+    "p_parom1.c20": {
+      "filename": "p_parom1.c20",
+      "type": "sound"
+    },
+    "p_pu102.512": {
+      "filename": "p_pu102.512",
+      "type": "sound"
+    },
+    "p_peteu4.512": {
+      "filename": "p_peteu4.512",
+      "type": "dmd"
+    },
+    "p_parom2.c20": {
+      "filename": "p_parom2.c20",
+      "type": "sound"
+    }
+  },
+  "strxt_gr": {
+    "sxvoiceg.u17": {
+      "filename": "sxvoiceg.u17",
+      "type": "sound"
+    },
+    "sxvoiceg.u37": {
+      "filename": "sxvoiceg.u37",
+      "type": "sound"
+    },
+    "sxsoundg.u7": {
+      "filename": "sxsoundg.u7",
+      "type": "sound"
+    },
+    "sxdispg.103": {
+      "filename": "sxdispg.103",
+      "type": "dmd"
+    },
+    "sxvoiceg.u21": {
+      "filename": "sxvoiceg.u21",
+      "type": "sound"
+    },
+    "sxvoiceg.u36": {
+      "filename": "sxvoiceg.u36",
+      "type": "sound"
+    }
+  },
+  "polic_l3": {
+    "pfrc_u26.l4": {
+      "filename": "pfrc_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pfrc_u22.l1": {
+      "filename": "pfrc_u22.l1",
+      "type": "sound"
+    },
+    "pfrc_u21.l1": {
+      "filename": "pfrc_u21.l1",
+      "type": "sound"
+    },
+    "pfrc_u4.l2": {
+      "filename": "pfrc_u4.l2",
+      "type": "sound"
+    },
+    "pfrc_u19.l1": {
+      "filename": "pfrc_u19.l1",
+      "type": "sound"
+    },
+    "pfrc_u27.lx3": {
+      "filename": "pfrc_u27.lx3",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "polic_l4": {
+    "pfrc_u26.l4": {
+      "filename": "pfrc_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pfrc_u22.l1": {
+      "filename": "pfrc_u22.l1",
+      "type": "sound"
+    },
+    "pfrc_u27.l4": {
+      "filename": "pfrc_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pfrc_u21.l1": {
+      "filename": "pfrc_u21.l1",
+      "type": "sound"
+    },
+    "pfrc_u4.l2": {
+      "filename": "pfrc_u4.l2",
+      "type": "sound"
+    },
+    "pfrc_u19.l1": {
+      "filename": "pfrc_u19.l1",
+      "type": "sound"
+    }
+  },
+  "sopr300i": {
+    "sopcpui.300": {
+      "filename": "sopcpui.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndi.u21": {
+      "filename": "sopsndi.u21",
+      "type": "sound"
+    },
+    "sopsndi.u36": {
+      "filename": "sopsndi.u36",
+      "type": "sound"
+    },
+    "sopsndi.u7": {
+      "filename": "sopsndi.u7",
+      "type": "sound"
+    },
+    "sopsndi.u37": {
+      "filename": "sopsndi.u37",
+      "type": "sound"
+    },
+    "sopdspi.300": {
+      "filename": "sopdspi.300",
+      "type": "dmd"
+    },
+    "sopsndi.u17": {
+      "filename": "sopsndi.u17",
+      "type": "sound"
+    }
+  },
+  "sopranoi": {
+    "sopcpui.300": {
+      "filename": "sopcpui.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndi.u21": {
+      "filename": "sopsndi.u21",
+      "type": "sound"
+    },
+    "sopsndi.u36": {
+      "filename": "sopsndi.u36",
+      "type": "sound"
+    },
+    "sopsndi.u17": {
+      "filename": "sopsndi.u17",
+      "type": "sound"
+    },
+    "sopsndi.u7": {
+      "filename": "sopsndi.u7",
+      "type": "sound"
+    },
+    "sopsndi.u37": {
+      "filename": "sopsndi.u37",
+      "type": "sound"
+    },
+    "sopdspi.300": {
+      "filename": "sopdspi.300",
+      "type": "dmd"
+    }
+  },
+  "afm_10": {
+    "afm_1_00.g11": {
+      "filename": "afm_1_00.g11",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "afm_s3.l1": {
+      "filename": "afm_s3.l1",
+      "type": "sound"
+    },
+    "afm_s4.l1": {
+      "filename": "afm_s4.l1",
+      "type": "sound"
+    },
+    "afm_1_00.s2": {
+      "filename": "afm_1_00.s2",
+      "type": "sound"
+    }
+  },
+  "stargzfp": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpsg_u1.716": {
+      "filename": "fpsg_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpsg_u5.716": {
+      "filename": "fpsg_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "stargzr": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "mntecrla": {
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2a.cpu": {
+      "filename": "prom2a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "prom1a.cpu": {
+      "filename": "prom1a.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "rip300g": {
+    "ripdispg.300": {
+      "filename": "RIPDISPG.300",
+      "type": "dmd"
+    },
+    "ripsndg.u37": {
+      "filename": "ripsndg.u37",
+      "type": "sound"
+    },
+    "ripsndg.u36": {
+      "filename": "ripsndg.u36",
+      "type": "sound"
+    },
+    "ripsndg.u7": {
+      "filename": "ripsndg.u7",
+      "type": "sound"
+    },
+    "ripsndg.u21": {
+      "filename": "ripsndg.u21",
+      "type": "sound"
+    },
+    "ripcpu.300": {
+      "filename": "ripcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndg.u17": {
+      "filename": "ripsndg.u17",
+      "type": "sound"
+    }
+  },
+  "rip301g": {
+    "ripdispg.300": {
+      "filename": "ripdispg.300",
+      "type": "dmd"
+    },
+    "ripsndg.u37": {
+      "filename": "ripsndg.u37",
+      "type": "sound"
+    },
+    "ripsndg.u36": {
+      "filename": "ripsndg.u36",
+      "type": "sound"
+    },
+    "ripsndg.u7": {
+      "filename": "ripsndg.u7",
+      "type": "sound"
+    },
+    "ripsndg.u21": {
+      "filename": "ripsndg.u21",
+      "type": "sound"
+    },
+    "ripcpu.301": {
+      "filename": "ripcpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndg.u17": {
+      "filename": "ripsndg.u17",
+      "type": "sound"
+    }
+  },
+  "rip302g": {
+    "ripdispg.300": {
+      "filename": "RIPDISPG.300",
+      "type": "dmd"
+    },
+    "ripsndg.u37": {
+      "filename": "ripsndg.u37",
+      "type": "sound"
+    },
+    "ripsndg.u36": {
+      "filename": "ripsndg.u36",
+      "type": "sound"
+    },
+    "ripsndg.u7": {
+      "filename": "ripsndg.u7",
+      "type": "sound"
+    },
+    "ripsndg.u21": {
+      "filename": "ripsndg.u21",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndg.u17": {
+      "filename": "ripsndg.u17",
+      "type": "sound"
+    },
+    "ripcpu.302": {
+      "filename": "RIPCPU.302",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "rip310g": {
+    "ripdispg.300": {
+      "filename": "RIPDISPG.300",
+      "type": "dmd"
+    },
+    "ripsndg.u37": {
+      "filename": "ripsndg.u37",
+      "type": "sound"
+    },
+    "ripsndg.u36": {
+      "filename": "ripsndg.u36",
+      "type": "sound"
+    },
+    "ripsndg.u7": {
+      "filename": "ripsndg.u7",
+      "type": "sound"
+    },
+    "ripsndg.u21": {
+      "filename": "ripsndg.u21",
+      "type": "sound"
+    },
+    "ripcpu.310": {
+      "filename": "ripcpu.310",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndg.u17": {
+      "filename": "ripsndg.u17",
+      "type": "sound"
+    }
+  },
+  "ripleysg": {
+    "ripdispg.300": {
+      "filename": "ripdispg.300",
+      "type": "dmd"
+    },
+    "ripsndg.u37": {
+      "filename": "ripsndg.u37",
+      "type": "sound"
+    },
+    "ripsndg.u36": {
+      "filename": "ripsndg.u36",
+      "type": "sound"
+    },
+    "ripsndg.u7": {
+      "filename": "ripsndg.u7",
+      "type": "sound"
+    },
+    "ripsndg.u21": {
+      "filename": "ripsndg.u21",
+      "type": "sound"
+    },
+    "ripcpu.320": {
+      "filename": "ripcpu.320",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "ripsndg.u17": {
+      "filename": "ripsndg.u17",
+      "type": "sound"
+    }
+  },
+  "afv_l4": {
+    "su2-addamsfamilyvalues-l1-9600-4m.bin": {
+      "filename": "SU2-AddamsFamilyValues-L1-9600-4M.bin",
+      "type": "sound"
+    },
+    "u6-addamsfamilyvalues-l4-e004-4m.bin": {
+      "filename": "U6-AddamsFamilyValues-L4-E004-4M.bin",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "fbclass": {
+    "fbcu3.snd": {
+      "filename": "fbcu3.snd",
+      "type": "sound"
+    },
+    "fb-class.u2": {
+      "filename": "fb-class.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "fbcu4.snd": {
+      "filename": "fbcu4.snd",
+      "type": "sound"
+    },
+    "720-5332.u6": {
+      "filename": "720-5332.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "fbclassa": {
+    "fbcu3.snd": {
+      "filename": "fbcu3.snd",
+      "type": "sound"
+    },
+    "fb-class.u2": {
+      "filename": "fb-class.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "fbcu4.snd": {
+      "filename": "fbcu4.snd",
+      "type": "sound"
+    }
+  },
+  "lotr41": {
+    "lotrdspa.404": {
+      "filename": "lotrdspa.404",
+      "type": "dmd"
+    },
+    "lotrcpu.410": {
+      "filename": "lotrcpu.410",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "ss_12": {
+    "sssnd_11.s2": {
+      "filename": "sssnd_11.s2",
+      "type": "sound"
+    },
+    "sssnd_11.s4": {
+      "filename": "sssnd_11.s4",
+      "type": "sound"
+    },
+    "stiffg11.1_2": {
+      "filename": "stiffg11.1_2",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sssnd_11.s3": {
+      "filename": "sssnd_11.s3",
+      "type": "sound"
+    }
+  },
+  "ss_15": {
+    "sssnd_11.s2": {
+      "filename": "sssnd_11.s2",
+      "type": "sound"
+    },
+    "sssnd_11.s4": {
+      "filename": "sssnd_11.s4",
+      "type": "sound"
+    },
+    "ss_g11.1_5": {
+      "filename": "ss_g11.1_5",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sssnd_11.s3": {
+      "filename": "sssnd_11.s3",
+      "type": "sound"
+    }
+  },
+  "galaxyb": {
+    "cpu_u5b.716": {
+      "filename": "cpu_u5b.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1b.716": {
+      "filename": "cpu_u1b.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6b.716": {
+      "filename": "cpu_u6b.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2b.716": {
+      "filename": "cpu_u2b.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "cc_10": {
+    "sav5_8.rom": {
+      "filename": "sav5_8.rom",
+      "type": "sound"
+    },
+    "sav6_8.rom": {
+      "filename": "sav6_8.rom",
+      "type": "sound"
+    },
+    "sav7_8.rom": {
+      "filename": "sav7_8.rom",
+      "type": "sound"
+    },
+    "sav2_8.rom": {
+      "filename": "sav2_8.rom",
+      "type": "sound"
+    },
+    "sav3_8.rom": {
+      "filename": "sav3_8.rom",
+      "type": "sound"
+    },
+    "cc_g11.1_0": {
+      "filename": "cc_g11.1_0",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sav4_8.rom": {
+      "filename": "sav4_8.rom",
+      "type": "sound"
+    }
+  },
+  "cc_104": {
+    "sav5_8.rom": {
+      "filename": "sav5_8.rom",
+      "type": "sound"
+    },
+    "cc_g11.104": {
+      "filename": "cc_g11.104",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sav6_8.rom": {
+      "filename": "sav6_8.rom",
+      "type": "sound"
+    },
+    "sav7_8.rom": {
+      "filename": "sav7_8.rom",
+      "type": "sound"
+    },
+    "sav2_8.rom": {
+      "filename": "sav2_8.rom",
+      "type": "sound"
+    },
+    "sav3_8.rom": {
+      "filename": "sav3_8.rom",
+      "type": "sound"
+    },
+    "sav4_8.rom": {
+      "filename": "sav4_8.rom",
+      "type": "sound"
+    }
+  },
+  "cc_13": {
+    "sav5_8.rom": {
+      "filename": "sav5_8.rom",
+      "type": "sound"
+    },
+    "sav6_8.rom": {
+      "filename": "sav6_8.rom",
+      "type": "sound"
+    },
+    "cc_g11.1_3": {
+      "filename": "cc_g11.1_3",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sav7_8.rom": {
+      "filename": "sav7_8.rom",
+      "type": "sound"
+    },
+    "sav2_8.rom": {
+      "filename": "sav2_8.rom",
+      "type": "sound"
+    },
+    "sav3_8.rom": {
+      "filename": "sav3_8.rom",
+      "type": "sound"
+    },
+    "sav4_8.rom": {
+      "filename": "sav4_8.rom",
+      "type": "sound"
+    }
+  },
+  "cc_13k": {
+    "sav5_8.rom": {
+      "filename": "sav5_8.rom",
+      "type": "sound"
+    },
+    "sav6_8.rom": {
+      "filename": "sav6_8.rom",
+      "type": "sound"
+    },
+    "cc_g11k.1_3": {
+      "filename": "cc_g11k.1_3",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sav7_8.rom": {
+      "filename": "sav7_8.rom",
+      "type": "sound"
+    },
+    "sav2_8.rom": {
+      "filename": "sav2_8.rom",
+      "type": "sound"
+    },
+    "sav3_8.rom": {
+      "filename": "sav3_8.rom",
+      "type": "sound"
+    },
+    "sav4_8.rom": {
+      "filename": "sav4_8.rom",
+      "type": "sound"
+    }
+  },
+  "sockifp": {
+    "sking_it.1f": {
+      "filename": "sking_it.1f",
+      "type": "sound"
+    },
+    "sking_it.1c": {
+      "filename": "sking_it.1c",
+      "type": "sound"
+    },
+    "socfp.ic1": {
+      "filename": "socfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sking_it.1g": {
+      "filename": "sking_it.1g",
+      "type": "sound"
+    },
+    "socfp.ic2": {
+      "filename": "socfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sking_it.1e": {
+      "filename": "sking_it.1e",
+      "type": "sound"
+    }
+  },
+  "lw3_200": {
+    "lw3dsp1.204": {
+      "filename": "lw3dsp1.204",
+      "type": "dmd"
+    },
+    "lw3u21.dat": {
+      "filename": "lw3u21.dat",
+      "type": "sound"
+    },
+    "lw3u7.dat": {
+      "filename": "lw3u7.dat",
+      "type": "sound"
+    },
+    "lw3dsp0.204": {
+      "filename": "lw3dsp0.204",
+      "type": "dmd"
+    },
+    "lw3cpu.200": {
+      "filename": "lw3cpu.200",
+      "type": "main",
+      "romType": "de"
+    },
+    "lw3u17.dat": {
+      "filename": "lw3u17.dat",
+      "type": "sound"
+    }
+  },
+  "hercules": {
+    "atari_m.rom": {
+      "filename": "atari_m.rom",
+      "type": "main",
+      "romType": "atari"
+    },
+    "atari_j.rom": {
+      "filename": "atari_j.rom",
+      "type": "main",
+      "romType": "atari"
+    },
+    "herc_k.rom": {
+      "filename": "herc_k.rom",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "superman": {
+    "atari_m.rom": {
+      "filename": "atari_m.rom",
+      "type": "main",
+      "romType": "atari"
+    },
+    "atari_j.rom": {
+      "filename": "atari_j.rom",
+      "type": "main",
+      "romType": "atari"
+    },
+    "supmn_k.rom": {
+      "filename": "supmn_k.rom",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "polar": {
+    "polar4.bin": {
+      "filename": "polar4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "polar3.bin": {
+      "filename": "polar3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "polar_s2.bin": {
+      "filename": "polar_s2.bin",
+      "type": "sound"
+    },
+    "polar_s1.bin": {
+      "filename": "polar_s1.bin",
+      "type": "sound"
+    },
+    "polar_s3.bin": {
+      "filename": "polar_s3.bin",
+      "type": "sound"
+    },
+    "polar2.bin": {
+      "filename": "polar2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "polar1.bin": {
+      "filename": "polar1.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "potc_113af": {
+    "potc0113af.bin": {
+      "filename": "potc0113af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_120h": {
+    "mtl120le.bin": {
+      "filename": "MTL120LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "acd_161h": {
+    "acd_161h.bin": {
+      "filename": "acd_161h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "algar_l1": {
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound4.716": {
+      "filename": "sound4.716",
+      "type": "sound"
+    }
+  },
+  "blkou_f1": {
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "speech4f.532": {
+      "filename": "speech4f.532",
+      "type": "sound"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "speech5f.532": {
+      "filename": "speech5f.532",
+      "type": "sound"
+    },
+    "speech6f.532": {
+      "filename": "speech6f.532",
+      "type": "sound"
+    },
+    "speech7f.532": {
+      "filename": "speech7f.532",
+      "type": "sound"
+    },
+    "sound2.716": {
+      "filename": "sound2.716",
+      "type": "sound"
+    }
+  },
+  "flash_l1": {
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "lzbal_l2": {
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound2.716": {
+      "filename": "sound2.716",
+      "type": "sound"
+    }
+  },
+  "scrpn_l1": {
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "tmwrp_l2": {
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "trizn_l1": {
+    "green2.716": {
+      "filename": "green2.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "green1.716": {
+      "filename": "green1.716",
+      "type": "main",
+      "romType": "s6"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "dw_l1": {
+    "dw_u18.l1": {
+      "filename": "dw_u18.l1",
+      "type": "sound"
+    },
+    "dw_u14.l1": {
+      "filename": "dw_u14.l1",
+      "type": "sound"
+    },
+    "dw_u15.l1": {
+      "filename": "dw_u15.l1",
+      "type": "sound"
+    },
+    "dw_l1.u6": {
+      "filename": "dw_l1.u6",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "dw_l2": {
+    "dw_u18.l1": {
+      "filename": "dw_u18.l1",
+      "type": "sound"
+    },
+    "dw_u14.l1": {
+      "filename": "dw_u14.l1",
+      "type": "sound"
+    },
+    "drwho_l2.rom": {
+      "filename": "drwho_l2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dw_u15.l1": {
+      "filename": "dw_u15.l1",
+      "type": "sound"
+    }
+  },
+  "dw_p5": {
+    "dw_u18.l1": {
+      "filename": "dw_u18.l1",
+      "type": "sound"
+    },
+    "dw_p5.u6": {
+      "filename": "dw_p5.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dw_u14.l1": {
+      "filename": "dw_u14.l1",
+      "type": "sound"
+    },
+    "dw_u15.l1": {
+      "filename": "dw_u15.l1",
+      "type": "sound"
+    }
+  },
+  "afm_113": {
+    "afm_s3.l1": {
+      "filename": "afm_s3.l1",
+      "type": "sound"
+    },
+    "afm_s4.l1": {
+      "filename": "afm_s4.l1",
+      "type": "sound"
+    },
+    "afm_s2.l1": {
+      "filename": "afm_s2.l1",
+      "type": "sound"
+    },
+    "afm_1_13.bin": {
+      "filename": "afm_1_13.bin",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "afm_113b": {
+    "afm_s3.l1": {
+      "filename": "afm_s3.l1",
+      "type": "sound"
+    },
+    "afm_113b.bin": {
+      "filename": "afm_113b.bin",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "afm_s4.l1": {
+      "filename": "afm_s4.l1",
+      "type": "sound"
+    },
+    "afm_s2.l1": {
+      "filename": "afm_s2.l1",
+      "type": "sound"
+    }
+  },
+  "afm_11u": {
+    "afm_s3.l1": {
+      "filename": "afm_s3.l1",
+      "type": "sound"
+    },
+    "afm_s4.l1": {
+      "filename": "afm_s4.l1",
+      "type": "sound"
+    },
+    "afm_s2.l1": {
+      "filename": "afm_s2.l1",
+      "type": "sound"
+    },
+    "marsu1_1.rom": {
+      "filename": "marsu1_1.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "afm_f10": {
+    "afm_s3.l1": {
+      "filename": "afm_s3.l1",
+      "type": "sound"
+    },
+    "afm_s4.l1": {
+      "filename": "afm_s4.l1",
+      "type": "sound"
+    },
+    "afm_s2.l1": {
+      "filename": "afm_s2.l1",
+      "type": "sound"
+    },
+    "fafm0_10.rom": {
+      "filename": "fafm0_10.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "afm_f20": {
+    "afm_s3.l1": {
+      "filename": "afm_s3.l1",
+      "type": "sound"
+    },
+    "fafm0_20.rom": {
+      "filename": "fafm0_20.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "afm_s4.l1": {
+      "filename": "afm_s4.l1",
+      "type": "sound"
+    },
+    "afm_s2.l1": {
+      "filename": "afm_s2.l1",
+      "type": "sound"
+    }
+  },
+  "afm_f32": {
+    "afm_s3.l1": {
+      "filename": "afm_s3.l1",
+      "type": "sound"
+    },
+    "afm_s4.l1": {
+      "filename": "afm_s4.l1",
+      "type": "sound"
+    },
+    "afm_s2.l1": {
+      "filename": "afm_s2.l1",
+      "type": "sound"
+    },
+    "fafm0_32.rom": {
+      "filename": "fafm0_32.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "poolcafp": {
+    "poolcfp.ic1": {
+      "filename": "poolcfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound1.f": {
+      "filename": "sound1.f",
+      "type": "sound"
+    },
+    "poolcfp.ic2": {
+      "filename": "poolcfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "poolcfp": {
+    "poolcfp.ic1": {
+      "filename": "poolcfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "poolcfp.ic2": {
+      "filename": "poolcfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "poolcham.1f": {
+      "filename": "poolcham.1f",
+      "type": "sound"
+    }
+  },
+  "poolcifp": {
+    "poolcfp.ic1": {
+      "filename": "poolcfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "poolc_it.1e": {
+      "filename": "poolc_it.1e",
+      "type": "sound"
+    },
+    "poolcfp.ic2": {
+      "filename": "poolcfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "stest": {
+    "stest4.bin": {
+      "filename": "stest4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "stest3.bin": {
+      "filename": "stest3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "stest2.bin": {
+      "filename": "stest2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "stest_s2.bin": {
+      "filename": "stest_s2.bin",
+      "type": "sound"
+    },
+    "stest_s1.bin": {
+      "filename": "stest_s1.bin",
+      "type": "sound"
+    },
+    "stest1.bin": {
+      "filename": "stest1.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "pop_pa3": {
+    "peye_pa3.rom": {
+      "filename": "peye_pa3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "popsndp0.u2": {
+      "filename": "popsndp0.u2",
+      "type": "sound"
+    },
+    "popsndl2.u5": {
+      "filename": "popsndl2.u5",
+      "type": "sound"
+    },
+    "popsndl2.u6": {
+      "filename": "popsndl2.u6",
+      "type": "sound"
+    },
+    "popsndl2.u3": {
+      "filename": "popsndl2.u3",
+      "type": "sound"
+    },
+    "popsndl2.u4": {
+      "filename": "popsndl2.u4",
+      "type": "sound"
+    },
+    "popsndl2.u7": {
+      "filename": "popsndl2.u7",
+      "type": "sound"
+    }
+  },
+  "ts_lx4": {
+    "u6-lx4.rom": {
+      "filename": "u6-lx4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "ts_u2_s.l1": {
+      "filename": "ts_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "pinball": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "stingray": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "gamatros": {
+    "gama_a.bin": {
+      "filename": "gama_a.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "gama_b.bin": {
+      "filename": "gama_b.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "elv302": {
+    "elvis.u7": {
+      "filename": "Elvis.u7",
+      "type": "sound"
+    },
+    "elvscpua.302": {
+      "filename": "elvscpua.302",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvis.u37": {
+      "filename": "elvis.u37",
+      "type": "sound"
+    },
+    "elvsdspa.302": {
+      "filename": "ELVSDSPA.302",
+      "type": "dmd"
+    },
+    "elvis.u21": {
+      "filename": "elvis.u21",
+      "type": "sound"
+    },
+    "elvis.u36": {
+      "filename": "elvis.u36",
+      "type": "sound"
+    },
+    "elvis.u17": {
+      "filename": "elvis.u17",
+      "type": "sound"
+    }
+  },
+  "elv303": {
+    "elvis.u7": {
+      "filename": "Elvis.u7",
+      "type": "sound"
+    },
+    "elvis.u37": {
+      "filename": "elvis.u37",
+      "type": "sound"
+    },
+    "elvsdspa.302": {
+      "filename": "ELVSDSPA.302",
+      "type": "dmd"
+    },
+    "elvscpua.303": {
+      "filename": "ELVSCPUA.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvis.u21": {
+      "filename": "elvis.u21",
+      "type": "sound"
+    },
+    "elvis.u36": {
+      "filename": "elvis.u36",
+      "type": "sound"
+    },
+    "elvis.u17": {
+      "filename": "elvis.u17",
+      "type": "sound"
+    }
+  },
+  "elv400": {
+    "elvis.u7": {
+      "filename": "Elvis.u7",
+      "type": "sound"
+    },
+    "elvscpua.400": {
+      "filename": "elvscpua.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvis.u37": {
+      "filename": "elvis.u37",
+      "type": "sound"
+    },
+    "elvis.u21": {
+      "filename": "elvis.u21",
+      "type": "sound"
+    },
+    "elvis.u36": {
+      "filename": "elvis.u36",
+      "type": "sound"
+    },
+    "elvsdspa.401": {
+      "filename": "elvsdspa.401",
+      "type": "dmd"
+    },
+    "elvis.u17": {
+      "filename": "elvis.u17",
+      "type": "sound"
+    }
+  },
+  "elvis": {
+    "elvis.u7": {
+      "filename": "elvis.u7",
+      "type": "sound"
+    },
+    "elvsdspa.500": {
+      "filename": "elvsdspa.500",
+      "type": "dmd"
+    },
+    "elvis.u37": {
+      "filename": "elvis.u37",
+      "type": "sound"
+    },
+    "elvscpua.500": {
+      "filename": "elvscpua.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "elvis.u21": {
+      "filename": "elvis.u21",
+      "type": "sound"
+    },
+    "elvis.u36": {
+      "filename": "elvis.u36",
+      "type": "sound"
+    },
+    "elvis.u17": {
+      "filename": "elvis.u17",
+      "type": "sound"
+    }
+  },
+  "xenona": {
+    "811-27_6.532": {
+      "filename": "811-27_6.532",
+      "type": "sound"
+    },
+    "811-25_4.532": {
+      "filename": "811-25_4.532",
+      "type": "sound"
+    },
+    "811-23_2.532": {
+      "filename": "811-23_2.532",
+      "type": "sound"
+    },
+    "7406fn.u6": {
+      "filename": "7406fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-24_3.532": {
+      "filename": "811-24_3.532",
+      "type": "sound"
+    },
+    "xeno2732.u2": {
+      "filename": "xeno2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "811-26_5.532": {
+      "filename": "811-26_5.532",
+      "type": "sound"
+    },
+    "811-22_1.532": {
+      "filename": "811-22_1.532",
+      "type": "sound"
+    },
+    "811-28_7.532": {
+      "filename": "811-28_7.532",
+      "type": "sound"
+    },
+    "811-35_4.532": {
+      "filename": "811-35_4.532",
+      "type": "sound"
+    }
+  },
+  "dungdrag": {
+    "snd_u13.512": {
+      "filename": "snd_u13.512",
+      "type": "sound"
+    },
+    "cpu_u3.128": {
+      "filename": "cpu_u3.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u2.128": {
+      "filename": "cpu_u2.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "snd_u11.512": {
+      "filename": "snd_u11.512",
+      "type": "sound"
+    },
+    "snd_u12.512": {
+      "filename": "snd_u12.512",
+      "type": "sound"
+    },
+    "snd_u14.512": {
+      "filename": "snd_u14.512",
+      "type": "sound"
+    }
+  },
+  "ladyshot": {
+    "830b.716": {
+      "filename": "830b.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "830a.716": {
+      "filename": "830a.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "830c.716": {
+      "filename": "830c.716",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "blkhole2": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "668-s1.snd": {
+      "filename": "668-s1.snd",
+      "type": "sound"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "668-s2.snd": {
+      "filename": "668-s2.snd",
+      "type": "sound"
+    },
+    "668-2.cpu": {
+      "filename": "668-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "blkholea": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "668-a-s.snd": {
+      "filename": "668-a-s.snd",
+      "type": "sound"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "668-a2.cpu": {
+      "filename": "668-a2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "eclipse": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "671-a-s.snd": {
+      "filename": "671-a-s.snd",
+      "type": "sound"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "671-a.cpu": {
+      "filename": "671-a.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "forceii": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "661.snd": {
+      "filename": "661.snd",
+      "type": "sound"
+    },
+    "661-2.cpu": {
+      "filename": "661-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "hh": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "669-s1.snd": {
+      "filename": "669-s1.snd",
+      "type": "sound"
+    },
+    "669-s2.snd": {
+      "filename": "669-s2.snd",
+      "type": "sound"
+    },
+    "669-2.cpu": {
+      "filename": "669-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "hh_1": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "669-s1.snd": {
+      "filename": "669-s1.snd",
+      "type": "sound"
+    },
+    "669-1.cpu": {
+      "filename": "669-1.cpu",
+      "type": "sound"
+    },
+    "669-s2.snd": {
+      "filename": "669-s2.snd",
+      "type": "sound"
+    }
+  },
+  "jamesb": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "658.snd": {
+      "filename": "658.snd",
+      "type": "sound"
+    },
+    "658-1.cpu": {
+      "filename": "658-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "jamesb2": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "658.snd": {
+      "filename": "658.snd",
+      "type": "sound"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "658-x.cpu": {
+      "filename": "658-x.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "mars": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "666-1.cpu": {
+      "filename": "666-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "666-s1.snd": {
+      "filename": "666-s1.snd",
+      "type": "sound"
+    },
+    "666-s2.snd": {
+      "filename": "666-s2.snd",
+      "type": "sound"
+    }
+  },
+  "panthera": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "652.snd": {
+      "filename": "652.snd",
+      "type": "sound"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "652.cpu": {
+      "filename": "652.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "spidermn": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "653-1.cpu": {
+      "filename": "653-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "653.snd": {
+      "filename": "653.snd",
+      "type": "sound"
+    },
+    "653-2.cpu": {
+      "filename": "653-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "starrace": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "657-1.cpu": {
+      "filename": "657-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "657.snd": {
+      "filename": "657.snd",
+      "type": "sound"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "657-2.cpu": {
+      "filename": "657-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "timeline": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "659.snd": {
+      "filename": "659.snd",
+      "type": "sound"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "659.cpu": {
+      "filename": "659.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "vlcno_1a": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "667-1a.cpu": {
+      "filename": "667-1a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "667-a-s.snd": {
+      "filename": "667-a-s.snd",
+      "type": "sound"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "vlcno_1b": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "667-a-s.snd": {
+      "filename": "667-a-s.snd",
+      "type": "sound"
+    },
+    "667-1b.cpu": {
+      "filename": "667-1b.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    }
+  },
+  "vlcno_1c": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "667-a-s.snd": {
+      "filename": "667-a-s.snd",
+      "type": "sound"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "667-1c.cpu": {
+      "filename": "667-1c.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "vlcno_ax": {
+    "u3_80.bin": {
+      "filename": "u3_80.bin",
+      "type": "main"
+    },
+    "667-a-x.cpu": {
+      "filename": "667-a-x.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2_80.bin": {
+      "filename": "u2_80.bin",
+      "type": "main"
+    },
+    "667-s2.snd": {
+      "filename": "667-s2.snd",
+      "type": "sound"
+    },
+    "667-s1.snd": {
+      "filename": "667-s1.snd",
+      "type": "sound"
+    }
+  },
+  "time2000": {
+    "time.e0": {
+      "filename": "time.e0",
+      "type": "main",
+      "romType": "atari"
+    },
+    "time.e00": {
+      "filename": "time.e00",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "goldbalc": {
+    "go102732.u2": {
+      "filename": "go102732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "gb_u4.532": {
+      "filename": "gb_u4.532",
+      "type": "sound"
+    },
+    "gold10u6.bin": {
+      "filename": "gold10u6.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "mexicofp": {
+    "mex86fp.ic1": {
+      "filename": "mex86fp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mex86_f.snd": {
+      "filename": "mex86_f.snd",
+      "type": "sound"
+    },
+    "mex86fp.ic2": {
+      "filename": "mex86fp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mex86_e.snd": {
+      "filename": "mex86_e.snd",
+      "type": "sound"
+    }
+  },
+  "tz_l2": {
+    "tz_l2.u6": {
+      "filename": "tz_l2.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    }
+  },
+  "gemini": {
+    "gemini3.bin": {
+      "filename": "gemini3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gemin_s2.bin": {
+      "filename": "gemin_s2.bin",
+      "type": "sound"
+    },
+    "gemini1.bin": {
+      "filename": "gemini1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gemini2.bin": {
+      "filename": "gemini2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gemin_s1.bin": {
+      "filename": "gemin_s1.bin",
+      "type": "sound"
+    },
+    "gemini4.bin": {
+      "filename": "gemini4.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "gemini1": {
+    "gemini3.bin": {
+      "filename": "gemini3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gemin_s2.bin": {
+      "filename": "gemin_s2.bin",
+      "type": "sound"
+    },
+    "gemini4a.bin": {
+      "filename": "gemini4a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gemini2.bin": {
+      "filename": "gemini2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gemini1a.bin": {
+      "filename": "gemini1a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "gemin_s1.bin": {
+      "filename": "gemin_s1.bin",
+      "type": "sound"
+    }
+  },
+  "trn_170": {
+    "trn_v1-7_e.bin": {
+      "filename": "TRN_V1-7_E.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "vlcno_a7": {
+    "667-a-x.cpu": {
+      "filename": "667-a-x.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "667-s2.snd": {
+      "filename": "667-s2.snd",
+      "type": "sound"
+    },
+    "667-s1.snd": {
+      "filename": "667-s1.snd",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "andrett4": {
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "gpromt4.bin": {
+      "filename": "gpromt4.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "andretti": {
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "wpt_112f": {
+    "wpt0112f.bin": {
+      "filename": "wpt0112f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "brvteam": {
+    "brv-tea.m0": {
+      "filename": "brv-tea.m0",
+      "type": "main",
+      "romType": "inder"
+    },
+    "brv-tea.m1": {
+      "filename": "brv-tea.m1",
+      "type": "main",
+      "romType": "inder"
+    }
+  },
+  "rs_l6": {
+    "rs_u5_s.l1": {
+      "filename": "rs_u5_s.l1",
+      "type": "sound"
+    },
+    "rshw_l6.rom": {
+      "filename": "rshw_l6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "rs_u7_s.l1": {
+      "filename": "rs_u7_s.l1",
+      "type": "sound"
+    },
+    "rs_u2_s.l1": {
+      "filename": "rs_u2_s.l1",
+      "type": "sound"
+    },
+    "rs_u3_s.l1": {
+      "filename": "rs_u3_s.l1",
+      "type": "sound"
+    },
+    "rs_u8_s.l1": {
+      "filename": "rs_u8_s.l1",
+      "type": "sound"
+    },
+    "rs_u4_s.l1": {
+      "filename": "rs_u4_s.l1",
+      "type": "sound"
+    },
+    "rs_u6_s.l1": {
+      "filename": "rs_u6_s.l1",
+      "type": "sound"
+    }
+  },
+  "rs_la4": {
+    "rs_u5_s.l1": {
+      "filename": "rs_u5_s.l1",
+      "type": "sound"
+    },
+    "rs_u7_s.l1": {
+      "filename": "rs_u7_s.l1",
+      "type": "sound"
+    },
+    "rs_u2_s.l1": {
+      "filename": "rs_u2_s.l1",
+      "type": "sound"
+    },
+    "rs_u3_s.l1": {
+      "filename": "rs_u3_s.l1",
+      "type": "sound"
+    },
+    "rs_u8_s.l1": {
+      "filename": "rs_u8_s.l1",
+      "type": "sound"
+    },
+    "rs_u4_s.l1": {
+      "filename": "rs_u4_s.l1",
+      "type": "sound"
+    },
+    "u6_la4.rom": {
+      "filename": "u6_la4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "rs_u6_s.l1": {
+      "filename": "rs_u6_s.l1",
+      "type": "sound"
+    }
+  },
+  "rs_la5": {
+    "rs_u5_s.l1": {
+      "filename": "rs_u5_s.l1",
+      "type": "sound"
+    },
+    "rs_u7_s.l1": {
+      "filename": "rs_u7_s.l1",
+      "type": "sound"
+    },
+    "rs_u2_s.l1": {
+      "filename": "rs_u2_s.l1",
+      "type": "sound"
+    },
+    "u6_la5.rom": {
+      "filename": "u6_la5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "rs_u3_s.l1": {
+      "filename": "rs_u3_s.l1",
+      "type": "sound"
+    },
+    "rs_u8_s.l1": {
+      "filename": "rs_u8_s.l1",
+      "type": "sound"
+    },
+    "rs_u4_s.l1": {
+      "filename": "rs_u4_s.l1",
+      "type": "sound"
+    },
+    "rs_u6_s.l1": {
+      "filename": "rs_u6_s.l1",
+      "type": "sound"
+    }
+  },
+  "rs_lx2": {
+    "rs_u5_s.l1": {
+      "filename": "rs_u5_s.l1",
+      "type": "sound"
+    },
+    "rshw_lx2.rom": {
+      "filename": "rshw_lx2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "rs_u7_s.l1": {
+      "filename": "rs_u7_s.l1",
+      "type": "sound"
+    },
+    "rs_u2_s.l1": {
+      "filename": "rs_u2_s.l1",
+      "type": "sound"
+    },
+    "rs_u3_s.l1": {
+      "filename": "rs_u3_s.l1",
+      "type": "sound"
+    },
+    "rs_u8_s.l1": {
+      "filename": "rs_u8_s.l1",
+      "type": "sound"
+    },
+    "rs_u4_s.l1": {
+      "filename": "rs_u4_s.l1",
+      "type": "sound"
+    },
+    "rs_u6_s.l1": {
+      "filename": "rs_u6_s.l1",
+      "type": "sound"
+    }
+  },
+  "rs_lx3": {
+    "rs_u5_s.l1": {
+      "filename": "rs_u5_s.l1",
+      "type": "sound"
+    },
+    "rs_u7_s.l1": {
+      "filename": "rs_u7_s.l1",
+      "type": "sound"
+    },
+    "rs_u2_s.l1": {
+      "filename": "rs_u2_s.l1",
+      "type": "sound"
+    },
+    "u6-lx3.rom": {
+      "filename": "u6-lx3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "rs_u3_s.l1": {
+      "filename": "rs_u3_s.l1",
+      "type": "sound"
+    },
+    "rs_u8_s.l1": {
+      "filename": "rs_u8_s.l1",
+      "type": "sound"
+    },
+    "rs_u4_s.l1": {
+      "filename": "rs_u4_s.l1",
+      "type": "sound"
+    },
+    "rs_u6_s.l1": {
+      "filename": "rs_u6_s.l1",
+      "type": "sound"
+    }
+  },
+  "rs_lx4": {
+    "rs_u5_s.l1": {
+      "filename": "rs_u5_s.l1",
+      "type": "sound"
+    },
+    "rs_u7_s.l1": {
+      "filename": "rs_u7_s.l1",
+      "type": "sound"
+    },
+    "rs_u2_s.l1": {
+      "filename": "rs_u2_s.l1",
+      "type": "sound"
+    },
+    "rs_u3_s.l1": {
+      "filename": "rs_u3_s.l1",
+      "type": "sound"
+    },
+    "rshw_lx4.rom": {
+      "filename": "rshw_lx4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "rs_u8_s.l1": {
+      "filename": "rs_u8_s.l1",
+      "type": "sound"
+    },
+    "rs_u4_s.l1": {
+      "filename": "rs_u4_s.l1",
+      "type": "sound"
+    },
+    "rs_u6_s.l1": {
+      "filename": "rs_u6_s.l1",
+      "type": "sound"
+    }
+  },
+  "rs_lx5": {
+    "rs_u5_s.l1": {
+      "filename": "rs_u5_s.l1",
+      "type": "sound"
+    },
+    "rs_u7_s.l1": {
+      "filename": "rs_u7_s.l1",
+      "type": "sound"
+    },
+    "rs_u2_s.l1": {
+      "filename": "rs_u2_s.l1",
+      "type": "sound"
+    },
+    "rs_u3_s.l1": {
+      "filename": "rs_u3_s.l1",
+      "type": "sound"
+    },
+    "u6_lx5.rom": {
+      "filename": "u6_lx5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "rs_u8_s.l1": {
+      "filename": "rs_u8_s.l1",
+      "type": "sound"
+    },
+    "rs_u4_s.l1": {
+      "filename": "rs_u4_s.l1",
+      "type": "sound"
+    },
+    "rs_u6_s.l1": {
+      "filename": "rs_u6_s.l1",
+      "type": "sound"
+    }
+  },
+  "gpr301i": {
+    "gpdspi.301": {
+      "filename": "gpdspi.301",
+      "type": "dmd"
+    },
+    "gpsndi.u7": {
+      "filename": "gpsndi.u7",
+      "type": "sound"
+    },
+    "gpsndi.u17": {
+      "filename": "gpsndi.u17",
+      "type": "sound"
+    },
+    "gpsndi.u37": {
+      "filename": "gpsndi.u37",
+      "type": "sound"
+    },
+    "gpsndi.u21": {
+      "filename": "gpsndi.u21",
+      "type": "sound"
+    },
+    "gpcpui.301": {
+      "filename": "gpcpui.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndi.u36": {
+      "filename": "gpsndi.u36",
+      "type": "sound"
+    }
+  },
+  "btmn_101": {
+    "batcpuc5.101": {
+      "filename": "batcpuc5.101",
+      "type": "main",
+      "romType": "de"
+    },
+    "batman.u21": {
+      "filename": "batman.u21",
+      "type": "sound"
+    },
+    "batdsp.102": {
+      "filename": "batdsp.102",
+      "type": "dmd"
+    },
+    "batcpub5.101": {
+      "filename": "batcpub5.101",
+      "type": "main",
+      "romType": "de"
+    },
+    "batman.u7": {
+      "filename": "batman.u7",
+      "type": "sound"
+    },
+    "batman.u17": {
+      "filename": "batman.u17",
+      "type": "sound"
+    }
+  },
+  "bbeltzac": {
+    "bbz-e.snd": {
+      "filename": "bbz-e.snd",
+      "type": "sound"
+    },
+    "bbz-1.fil": {
+      "filename": "bbz-1.fil",
+      "type": "main",
+      "romType": "zac"
+    },
+    "bbz-f.snd": {
+      "filename": "bbz-f.snd",
+      "type": "sound"
+    },
+    "bbz-2.fil": {
+      "filename": "bbz-2.fil",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "bbeltzfp": {
+    "bbz-e.snd": {
+      "filename": "bbz-e.snd",
+      "type": "sound"
+    },
+    "bbz-f.snd": {
+      "filename": "bbz-f.snd",
+      "type": "sound"
+    },
+    "bkbeltfp.ic1": {
+      "filename": "bkbeltfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "bkbeltfp.ic2": {
+      "filename": "bkbeltfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "wolfman": {
+    "memoriaa.bin": {
+      "filename": "memoriaa.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "memoriac.bin": {
+      "filename": "memoriac.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "memoriab.bin": {
+      "filename": "memoriab.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "xmen_130": {
+    "xmen_130.bin": {
+      "filename": "xmen_130.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "hook_401": {
+    "hokcpua.401": {
+      "filename": "hokcpua.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "hokdspa.401": {
+      "filename": "hokdspa.401",
+      "type": "dmd"
+    },
+    "hooksnd.u7": {
+      "filename": "hooksnd.u7",
+      "type": "sound"
+    },
+    "hook-voi.u17": {
+      "filename": "hook-voi.u17",
+      "type": "sound"
+    },
+    "hook-voi.u21": {
+      "filename": "hook-voi.u21",
+      "type": "sound"
+    }
+  },
+  "wpt_112l": {
+    "wpt0112l.bin": {
+      "filename": "wpt0112l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cntintl2": {
+    "u36.bin": {
+      "filename": "u36.bin",
+      "type": "main"
+    },
+    "u48.bin": {
+      "filename": "u48.bin",
+      "type": "main"
+    }
+  },
+  "attila": {
+    "260.c": {
+      "filename": "260.c",
+      "type": "main",
+      "romType": "gp"
+    },
+    "260.snd": {
+      "filename": "260.snd",
+      "type": "sound"
+    },
+    "260.a": {
+      "filename": "260.a",
+      "type": "main",
+      "romType": "gp"
+    },
+    "260.b": {
+      "filename": "260.b",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "lotr7": {
+    "lotrcpu.700": {
+      "filename": "lotrcpu.700",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrdspa.700": {
+      "filename": "lotrdspa.700",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "lotr_fr7": {
+    "lotrcpu.700": {
+      "filename": "lotrcpu.700",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrdspf.700": {
+      "filename": "lotrdspf.700",
+      "type": "dmd"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "lotr_it7": {
+    "lotrcpu.700": {
+      "filename": "lotrcpu.700",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrdspi.700": {
+      "filename": "lotrdspi.700",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "lca": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "dmd"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "lca2": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom2.bin": {
+      "filename": "gprom2.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "embryonb": {
+    "embd71u6.bin": {
+      "filename": "embd71u6.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "embd71u2.bin": {
+      "filename": "embd71u2.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "841-02_5.532": {
+      "filename": "841-02_5.532",
+      "type": "sound"
+    },
+    "841-01_4.716": {
+      "filename": "841-01_4.716",
+      "type": "sound"
+    }
+  },
+  "silvslug": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "prtyanig": {
+    "snd_u11.512": {
+      "filename": "snd_u11.512",
+      "type": "sound"
+    },
+    "snd_u12.512": {
+      "filename": "snd_u12.512",
+      "type": "sound"
+    },
+    "snd_u14.512": {
+      "filename": "snd_u14.512",
+      "type": "sound"
+    },
+    "cpu_u2g.128": {
+      "filename": "cpu_u2g.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "snd_u13.512": {
+      "filename": "snd_u13.512",
+      "type": "sound"
+    },
+    "cpu_u3g.128": {
+      "filename": "cpu_u3g.128",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "prtyanim": {
+    "snd_u11.512": {
+      "filename": "snd_u11.512",
+      "type": "sound"
+    },
+    "snd_u12.512": {
+      "filename": "snd_u12.512",
+      "type": "sound"
+    },
+    "snd_u14.512": {
+      "filename": "snd_u14.512",
+      "type": "sound"
+    },
+    "cpu_u2.128": {
+      "filename": "cpu_u2.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "snd_u13.512": {
+      "filename": "snd_u13.512",
+      "type": "sound"
+    },
+    "cpu_u3.128": {
+      "filename": "cpu_u3.128",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "hulk": {
+    "433.snd": {
+      "filename": "433.snd",
+      "type": "sound"
+    },
+    "6530sys1.bin": {
+      "filename": "6530sys1.bin",
+      "type": "sound"
+    },
+    "433.cpu": {
+      "filename": "433.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "term3g": {
+    "t3dispg.400": {
+      "filename": "t3dispg.400",
+      "type": "dmd"
+    },
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3cpu.400": {
+      "filename": "t3cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "totan_04": {
+    "an_g11.0_4": {
+      "filename": "AN_G11.0_4",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ans5v1_0.rom": {
+      "filename": "ANS5V1_0.ROM",
+      "type": "sound"
+    },
+    "ans3v1_0.rom": {
+      "filename": "ANS3V1_0.ROM",
+      "type": "sound"
+    },
+    "ans4v1_0.rom": {
+      "filename": "ANS4V1_0.ROM",
+      "type": "sound"
+    }
+  },
+  "sc_091": {
+    "safsnds2.rom": {
+      "filename": "safsnds2.rom",
+      "type": "sound"
+    },
+    "safsnds3.rom": {
+      "filename": "safsnds3.rom",
+      "type": "sound"
+    },
+    "safsnds4.rom": {
+      "filename": "safsnds4.rom",
+      "type": "sound"
+    },
+    "sc_091.bin": {
+      "filename": "sc_091.bin",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "sc_17": {
+    "safsnds2.rom": {
+      "filename": "safsnds2.rom",
+      "type": "sound"
+    },
+    "safsnds3.rom": {
+      "filename": "safsnds3.rom",
+      "type": "sound"
+    },
+    "safsnds4.rom": {
+      "filename": "safsnds4.rom",
+      "type": "sound"
+    },
+    "g11-17g.rom": {
+      "filename": "g11-17g.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "sc_17n": {
+    "safsnds2.rom": {
+      "filename": "safsnds2.rom",
+      "type": "sound"
+    },
+    "g11-17n.rom": {
+      "filename": "g11-17n.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "safsnds3.rom": {
+      "filename": "safsnds3.rom",
+      "type": "sound"
+    },
+    "safsnds4.rom": {
+      "filename": "safsnds4.rom",
+      "type": "sound"
+    }
+  },
+  "sc_18": {
+    "safsnds2.rom": {
+      "filename": "safsnds2.rom",
+      "type": "sound"
+    },
+    "safsnds3.rom": {
+      "filename": "safsnds3.rom",
+      "type": "sound"
+    },
+    "safsnds4.rom": {
+      "filename": "safsnds4.rom",
+      "type": "sound"
+    },
+    "safe_18g.rom": {
+      "filename": "safe_18g.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "sc_18n": {
+    "safsnds2.rom": {
+      "filename": "safsnds2.rom",
+      "type": "sound"
+    },
+    "safe_18n.rom": {
+      "filename": "safe_18n.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "safsnds3.rom": {
+      "filename": "safsnds3.rom",
+      "type": "sound"
+    },
+    "safsnds4.rom": {
+      "filename": "safsnds4.rom",
+      "type": "sound"
+    }
+  },
+  "trn_174": {
+    "trn_174.bin": {
+      "filename": "TRN_174.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mt_145h": {
+    "mt_145h.bin": {
+      "filename": "mt_145h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "eballdp2": {
+    "838-18.u12": {
+      "filename": "838-18.U12",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-16_5.532": {
+      "filename": "838-16_5.532",
+      "type": "sound"
+    },
+    "720-56.u10": {
+      "filename": "720-56.U10",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-57.u14": {
+      "filename": "720-57.U14",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    },
+    "720-58.u13": {
+      "filename": "720-58.U13",
+      "type": "main",
+      "romType": "by"
+    },
+    "ebd68701.2": {
+      "filename": "ebd68701.2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "ldyshot2": {
+    "830b2.716": {
+      "filename": "830b2.716",
+      "type": "sound"
+    },
+    "830a2.716": {
+      "filename": "830a2.716",
+      "type": "sound"
+    },
+    "830c2.716": {
+      "filename": "830c2.716",
+      "type": "sound"
+    }
+  },
+  "bmf_be": {
+    "batnovb.401": {
+      "filename": "batnovb.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bfdrom0f.401": {
+      "filename": "bfdrom0f.401",
+      "type": "dmd"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    },
+    "bfdrom3f.401": {
+      "filename": "bfdrom3f.401",
+      "type": "dmd"
+    }
+  },
+  "ffv104": {
+    "u1h_v104.bin": {
+      "filename": "u1h_v104.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u31_v101.bin": {
+      "filename": "u31_v101.bin",
+      "type": "sound"
+    },
+    "u1l_v104.bin": {
+      "filename": "u1l_v104.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_v101.bin": {
+      "filename": "u28_v101.bin",
+      "type": "sound"
+    },
+    "u4l_v104.bin": {
+      "filename": "u4l_v104.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u3h_v104.bin": {
+      "filename": "u3h_v104.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u2h_v104.bin": {
+      "filename": "u2h_v104.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u3l_v104.bin": {
+      "filename": "u3l_v104.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u2l_v104.bin": {
+      "filename": "u2l_v104.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u29_v101.bin": {
+      "filename": "u29_v101.bin",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u30_v101.bin": {
+      "filename": "u30_v101.bin",
+      "type": "sound"
+    },
+    "u4h_v104.bin": {
+      "filename": "u4h_v104.bin",
+      "type": "main",
+      "romType": "capcom"
+    }
+  },
+  "fg_1000ai": {
+    "fg1000ai.bin": {
+      "filename": "fg1000ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "term3_2": {
+    "t3cpu.205": {
+      "filename": "t3cpu.205",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3dispa.201": {
+      "filename": "t3dispa.201",
+      "type": "dmd"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "term3f_2": {
+    "t3cpu.205": {
+      "filename": "t3cpu.205",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3dispf.201": {
+      "filename": "t3dispf.201",
+      "type": "dmd"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "term3i_2": {
+    "t3cpu.205": {
+      "filename": "t3cpu.205",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3dispi.201": {
+      "filename": "t3dispi.201",
+      "type": "dmd"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "rab_320": {
+    "rabcpua.320": {
+      "filename": "rabcpua.320",
+      "type": "main",
+      "romType": "de"
+    },
+    "rab.u21": {
+      "filename": "rab.u21",
+      "type": "sound"
+    },
+    "rab.u17": {
+      "filename": "rab.u17",
+      "type": "sound"
+    },
+    "rbdspa.300": {
+      "filename": "rbdspa.300",
+      "type": "dmd"
+    },
+    "rab.u7": {
+      "filename": "rab.u7",
+      "type": "sound"
+    }
+  },
+  "metalman": {
+    "sound_m1.bin": {
+      "filename": "Sound_M1.bin",
+      "type": "main"
+    },
+    "cpu_1.bin": {
+      "filename": "CPU_1.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "sound_m2.bin": {
+      "filename": "Sound_M2.bin",
+      "type": "main"
+    },
+    "sound_e1.bin": {
+      "filename": "Sound_E1.bin",
+      "type": "main"
+    },
+    "sound_e2.bin": {
+      "filename": "Sound_E2.bin",
+      "type": "main"
+    },
+    "cpu_0.bin": {
+      "filename": "CPU_0.bin",
+      "type": "main",
+      "romType": "inder"
+    }
+  },
+  "ator": {
+    "ator.u6": {
+      "filename": "ator.u6",
+      "type": "main"
+    }
+  },
+  "xmen_151h": {
+    "xmle1-51.bin": {
+      "filename": "XMLE1-51.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "beatclck": {
+    "btc_u3.snd": {
+      "filename": "btc_u3.snd",
+      "type": "sound"
+    },
+    "btc_u5.snd": {
+      "filename": "btc_u5.snd",
+      "type": "sound"
+    },
+    "btc_u3.cpu": {
+      "filename": "btc_u3.cpu",
+      "type": "sound"
+    },
+    "btc_u4.snd": {
+      "filename": "btc_u4.snd",
+      "type": "sound"
+    },
+    "btc_u2.snd": {
+      "filename": "btc_u2.snd",
+      "type": "sound"
+    }
+  },
+  "surfnsaf": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "apollo1": {
+    "a13dps.100": {
+      "filename": "a13dps.100",
+      "type": "dmd"
+    },
+    "apollo13.u21": {
+      "filename": "apollo13.u21",
+      "type": "sound"
+    },
+    "apollo13.u17": {
+      "filename": "apollo13.u17",
+      "type": "sound"
+    },
+    "a13cpu.100": {
+      "filename": "a13cpu.100",
+      "type": "main",
+      "romType": "se"
+    },
+    "apollo13.u36": {
+      "filename": "apollo13.u36",
+      "type": "sound"
+    },
+    "apollo13.u7": {
+      "filename": "apollo13.u7",
+      "type": "sound"
+    }
+  },
+  "t2_f19": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    },
+    "ft20_19.rom": {
+      "filename": "ft20_19.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "t2_f20": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "ft20_20.rom": {
+      "filename": "ft20_20.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "t2_f32": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "ft20_32.rom": {
+      "filename": "ft20_32.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "t2_l2": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    },
+    "u6-l2.rom": {
+      "filename": "u6-l2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "t2_l3": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "u6-l3.rom": {
+      "filename": "u6-l3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "t2_l4": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "u6-l4.rom": {
+      "filename": "u6-l4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "t2_l8": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_l8.rom": {
+      "filename": "t2_l8.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "t2_l81": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_l81.rom": {
+      "filename": "t2_l81.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "t2_l82": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "t2_u14.l3": {
+      "filename": "t2_u14.l3",
+      "type": "sound"
+    },
+    "t2_l82.rom": {
+      "filename": "t2_l82.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "t2_p2f": {
+    "t2_u18.l3": {
+      "filename": "t2_u18.l3",
+      "type": "sound"
+    },
+    "u6-nasty.rom": {
+      "filename": "u6-nasty.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "u14-nsty.rom": {
+      "filename": "u14-nsty.rom",
+      "type": "sound"
+    },
+    "t2_u15.l3": {
+      "filename": "t2_u15.l3",
+      "type": "sound"
+    }
+  },
+  "flightfp": {
+    "free2ku6.716": {
+      "filename": "free2ku6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "free2ku5.716": {
+      "filename": "free2ku5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "lw3_207": {
+    "lw3drom0.a26": {
+      "filename": "lw3drom0.a26",
+      "type": "dmd"
+    },
+    "lw3gc5.207": {
+      "filename": "lw3gc5.207",
+      "type": "main",
+      "romType": "de"
+    },
+    "lw3drom1.a26": {
+      "filename": "lw3drom1.a26",
+      "type": "dmd"
+    },
+    "lw3u21.dat": {
+      "filename": "lw3u21.dat",
+      "type": "sound"
+    },
+    "lw3u7.dat": {
+      "filename": "lw3u7.dat",
+      "type": "sound"
+    },
+    "lw3u17.dat": {
+      "filename": "lw3u17.dat",
+      "type": "sound"
+    }
+  },
+  "lw3_208": {
+    "lw3drom0.a26": {
+      "filename": "lw3drom0.a26",
+      "type": "dmd"
+    },
+    "lw3drom1.a26": {
+      "filename": "lw3drom1.a26",
+      "type": "dmd"
+    },
+    "lw3u21.dat": {
+      "filename": "lw3u21.dat",
+      "type": "sound"
+    },
+    "lw3cpuu.208": {
+      "filename": "lw3cpuu.208",
+      "type": "main",
+      "romType": "de"
+    },
+    "lw3u7.dat": {
+      "filename": "lw3u7.dat",
+      "type": "sound"
+    },
+    "lw3u17.dat": {
+      "filename": "lw3u17.dat",
+      "type": "sound"
+    }
+  },
+  "bmf_it": {
+    "bfdrom0i.401": {
+      "filename": "bfdrom0i.401",
+      "type": "dmd"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "batnovi.401": {
+      "filename": "batnovi.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bfdrom3i.401": {
+      "filename": "bfdrom3i.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "splitsfp": {
+    "fpspscu5.716": {
+      "filename": "fpspscu5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpspscu6.716": {
+      "filename": "fpspscu6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    }
+  },
+  "worlddfp": {
+    "worlddfp.764": {
+      "filename": "worlddfp.764",
+      "type": "main"
+    },
+    "wodefsnd.764": {
+      "filename": "WODEFSND.764",
+      "type": "sound"
+    }
+  },
+  "firebird": {
+    "nsmf02.764": {
+      "filename": "nsmf02.764",
+      "type": "main"
+    },
+    "nsmf04.764": {
+      "filename": "nsmf04.764",
+      "type": "main"
+    },
+    "nsmf03.764": {
+      "filename": "nsmf03.764",
+      "type": "main"
+    }
+  },
+  "cueball": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "cueball3": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "dsprom.r2": {
+      "filename": "dsprom.r2",
+      "type": "dmd"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom.r3": {
+      "filename": "gprom.r3",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "dalejr": {
+    "nassnd.u36": {
+      "filename": "nassnd.u36",
+      "type": "sound"
+    },
+    "nassnd.u7": {
+      "filename": "nassnd.u7",
+      "type": "sound"
+    },
+    "nassnd.u37": {
+      "filename": "nassnd.u37",
+      "type": "sound"
+    },
+    "nassnd.u17": {
+      "filename": "nassnd.u17",
+      "type": "sound"
+    },
+    "daledisp.500": {
+      "filename": "daledisp.500",
+      "type": "dmd"
+    },
+    "nassnd.u21": {
+      "filename": "nassnd.u21",
+      "type": "sound"
+    },
+    "dalecpu.500": {
+      "filename": "dalecpu.500",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "nas301": {
+    "nassnd.u36": {
+      "filename": "nassnd.u36",
+      "type": "sound"
+    },
+    "nassnd.u7": {
+      "filename": "nassnd.u7",
+      "type": "sound"
+    },
+    "nassnd.u37": {
+      "filename": "nassnd.u37",
+      "type": "sound"
+    },
+    "nassnd.u17": {
+      "filename": "nassnd.u17",
+      "type": "sound"
+    },
+    "nasdspa.301": {
+      "filename": "nasdspa.301",
+      "type": "dmd"
+    },
+    "nassnd.u21": {
+      "filename": "nassnd.u21",
+      "type": "sound"
+    },
+    "nascpua.301": {
+      "filename": "nascpua.301",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "nas350": {
+    "nassnd.u36": {
+      "filename": "nassnd.u36",
+      "type": "sound"
+    },
+    "nassnd.u7": {
+      "filename": "nassnd.u7",
+      "type": "sound"
+    },
+    "nassnd.u37": {
+      "filename": "nassnd.u37",
+      "type": "sound"
+    },
+    "nassnd.u17": {
+      "filename": "nassnd.u17",
+      "type": "sound"
+    },
+    "nassnd.u21": {
+      "filename": "nassnd.u21",
+      "type": "sound"
+    },
+    "nasdspa.303": {
+      "filename": "nasdspa.303",
+      "type": "dmd"
+    },
+    "nascpua.350": {
+      "filename": "nascpua.350",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "nas352": {
+    "nassnd.u36": {
+      "filename": "nassnd.u36",
+      "type": "sound"
+    },
+    "nassnd.u7": {
+      "filename": "nassnd.u7",
+      "type": "sound"
+    },
+    "nassnd.u37": {
+      "filename": "nassnd.u37",
+      "type": "sound"
+    },
+    "nassnd.u17": {
+      "filename": "nassnd.u17",
+      "type": "sound"
+    },
+    "nascpua.352": {
+      "filename": "nascpua.352",
+      "type": "main",
+      "romType": "se"
+    },
+    "nassnd.u21": {
+      "filename": "nassnd.u21",
+      "type": "sound"
+    },
+    "nasdspa.303": {
+      "filename": "nasdspa.303",
+      "type": "dmd"
+    }
+  },
+  "nas400": {
+    "nassnd.u36": {
+      "filename": "nassnd.u36",
+      "type": "sound"
+    },
+    "nascpua.400": {
+      "filename": "nascpua.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "nasdspa.400": {
+      "filename": "nasdspa.400",
+      "type": "dmd"
+    },
+    "nassnd.u7": {
+      "filename": "nassnd.u7",
+      "type": "sound"
+    },
+    "nassnd.u37": {
+      "filename": "nassnd.u37",
+      "type": "sound"
+    },
+    "nassnd.u17": {
+      "filename": "nassnd.u17",
+      "type": "sound"
+    },
+    "nassnd.u21": {
+      "filename": "nassnd.u21",
+      "type": "sound"
+    }
+  },
+  "nascar": {
+    "nassnd.u36": {
+      "filename": "nassnd.u36",
+      "type": "sound"
+    },
+    "nasdspa.400": {
+      "filename": "nasdspa.400",
+      "type": "dmd"
+    },
+    "nassnd.u7": {
+      "filename": "nassnd.u7",
+      "type": "sound"
+    },
+    "nassnd.u37": {
+      "filename": "nassnd.u37",
+      "type": "sound"
+    },
+    "nassnd.u17": {
+      "filename": "nassnd.u17",
+      "type": "sound"
+    },
+    "nassnd.u21": {
+      "filename": "nassnd.u21",
+      "type": "sound"
+    },
+    "nascpua.450": {
+      "filename": "nascpua.450",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "meteort": {
+    "meteo_s1.bin": {
+      "filename": "meteo_s1.bin",
+      "type": "sound"
+    },
+    "meteor1.bin": {
+      "filename": "meteor1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "meteor2.bin": {
+      "filename": "meteor2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "meteor3.bin": {
+      "filename": "meteor3.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "sockgfp": {
+    "sk-de4.g": {
+      "filename": "sk-de4.g",
+      "type": "sound"
+    },
+    "sk-de3.f": {
+      "filename": "sk-de3.f",
+      "type": "sound"
+    },
+    "sk-de1.c": {
+      "filename": "sk-de1.c",
+      "type": "sound"
+    },
+    "socfp.ic1": {
+      "filename": "socfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sk-de2.e": {
+      "filename": "sk-de2.e",
+      "type": "sound"
+    },
+    "sk-de5.h": {
+      "filename": "sk-de5.h",
+      "type": "sound"
+    },
+    "socfp.ic2": {
+      "filename": "socfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "alienstr": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "689.cpu": {
+      "filename": "689.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "689-s.snd": {
+      "filename": "689-s.snd",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "amazonh": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "684-s2.snd": {
+      "filename": "684-s2.snd",
+      "type": "sound"
+    },
+    "684-s1.snd": {
+      "filename": "684-s1.snd",
+      "type": "sound"
+    },
+    "684-2.cpu": {
+      "filename": "684-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "amazonha": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "684-s2.snd": {
+      "filename": "684-s2.snd",
+      "type": "sound"
+    },
+    "684-1.cpu": {
+      "filename": "684-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "684-s1.snd": {
+      "filename": "684-s1.snd",
+      "type": "sound"
+    }
+  },
+  "cavemana": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "v810-u5.bin": {
+      "filename": "v810-u5.bin",
+      "type": "dmd"
+    },
+    "v810-u6.bin": {
+      "filename": "v810-u6.bin",
+      "type": "dmd"
+    },
+    "v810-u4a.bin": {
+      "filename": "v810-u4a.bin",
+      "type": "dmd"
+    },
+    "v810-u8.bin": {
+      "filename": "v810-u8.bin",
+      "type": "dmd"
+    },
+    "v810-u3a.bin": {
+      "filename": "v810-u3a.bin",
+      "type": "dmd"
+    },
+    "v810-u7.bin": {
+      "filename": "v810-u7.bin",
+      "type": "dmd"
+    },
+    "v810-u1a.bin": {
+      "filename": "v810-u1a.bin",
+      "type": "dmd"
+    },
+    "pv810-s1.snd": {
+      "filename": "pv810-s1.snd",
+      "type": "sound"
+    },
+    "v810-u2a.bin": {
+      "filename": "v810-u2a.bin",
+      "type": "dmd"
+    },
+    "pv810-s2.snd": {
+      "filename": "pv810-s2.snd",
+      "type": "sound"
+    },
+    "pv810-1.cpu": {
+      "filename": "pv810-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "dvlsdre": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "670-s1.snd": {
+      "filename": "670-s1.snd",
+      "type": "sound"
+    },
+    "670-1.cpu": {
+      "filename": "670-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "670-s2.snd": {
+      "filename": "670-s2.snd",
+      "type": "sound"
+    }
+  },
+  "dvlsdre2": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "670-a.cpu": {
+      "filename": "670-a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "670-a-s.snd": {
+      "filename": "670-a-s.snd",
+      "type": "sound"
+    }
+  },
+  "eldorado": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "692-2.cpu": {
+      "filename": "692-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "692-s.dat": {
+      "filename": "692-s.dat",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "goinnuts": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "682-s2.snd": {
+      "filename": "682-s2.snd",
+      "type": "sound"
+    },
+    "682.cpu": {
+      "filename": "682.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "682-s1.snd": {
+      "filename": "682-s1.snd",
+      "type": "sound"
+    }
+  },
+  "icefever": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "695.cpu": {
+      "filename": "695.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "695-s.snd": {
+      "filename": "695-s.snd",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "qbquest": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "677-s2.snd": {
+      "filename": "677-s2.snd",
+      "type": "sound"
+    },
+    "677-s1.snd": {
+      "filename": "677-s1.snd",
+      "type": "sound"
+    },
+    "677.cpu": {
+      "filename": "677.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "rackemup": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "685.cpu": {
+      "filename": "685.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "685-s.snd": {
+      "filename": "685-s.snd",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "sorbit": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "680-s2.snd": {
+      "filename": "680-s2.snd",
+      "type": "sound"
+    },
+    "680.cpu": {
+      "filename": "680.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "680-s1.snd": {
+      "filename": "680-s1.snd",
+      "type": "sound"
+    }
+  },
+  "spirit": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "673-s2.snd": {
+      "filename": "673-s2.snd",
+      "type": "sound"
+    },
+    "673-2.cpu": {
+      "filename": "673-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "673-s1.snd": {
+      "filename": "673-s1.snd",
+      "type": "sound"
+    }
+  },
+  "thegames": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "691.cpu": {
+      "filename": "691.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "691-s.snd": {
+      "filename": "691-s.snd",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "touchdn": {
+    "u2_80a.bin": {
+      "filename": "u2_80a.bin",
+      "type": "main"
+    },
+    "u3_80a.bin": {
+      "filename": "u3_80a.bin",
+      "type": "main"
+    },
+    "688-s.snd": {
+      "filename": "688-s.snd",
+      "type": "main",
+      "romType": "gts"
+    },
+    "688.cpu": {
+      "filename": "688.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "wwfr_103": {
+    "wfsndu21.400": {
+      "filename": "wfsndu21.400",
+      "type": "sound"
+    },
+    "wfsndu36.400": {
+      "filename": "wfsndu36.400",
+      "type": "sound"
+    },
+    "wfsndu17.400": {
+      "filename": "wfsndu17.400",
+      "type": "sound"
+    },
+    "wfcpuc5.512": {
+      "filename": "wfcpuc5.512",
+      "type": "main",
+      "romType": "de"
+    },
+    "wfdisp0.400": {
+      "filename": "wfdisp0.400",
+      "type": "dmd"
+    },
+    "wfsndu7.512": {
+      "filename": "wfsndu7.512",
+      "type": "sound"
+    }
+  },
+  "wwfr_106": {
+    "wfsndu21.400": {
+      "filename": "wfsndu21.400",
+      "type": "sound"
+    },
+    "wfsndu36.400": {
+      "filename": "wfsndu36.400",
+      "type": "sound"
+    },
+    "wwfdispa.102": {
+      "filename": "wwfdispa.102",
+      "type": "dmd"
+    },
+    "wwfcpua.106": {
+      "filename": "wwfcpua.106",
+      "type": "main",
+      "romType": "de"
+    },
+    "wfsndu17.400": {
+      "filename": "wfsndu17.400",
+      "type": "sound"
+    },
+    "wfsndu7.512": {
+      "filename": "wfsndu7.512",
+      "type": "sound"
+    }
+  },
+  "pmv112r": {
+    "u31_v19i.bin": {
+      "filename": "u31_v19i.bin",
+      "type": "sound"
+    },
+    "u1lv112i.bin": {
+      "filename": "u1lv112i.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_v10.bin": {
+      "filename": "u28_v10.bin",
+      "type": "sound"
+    },
+    "u29_v10.bin": {
+      "filename": "u29_v10.bin",
+      "type": "sound"
+    },
+    "u2h_v10.bin": {
+      "filename": "u2h_v10.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u30_v16.bin": {
+      "filename": "u30_v16.bin",
+      "type": "sound"
+    },
+    "u2l_v10.bin": {
+      "filename": "u2l_v10.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u1hv112i.bin": {
+      "filename": "u1hv112i.bin",
+      "type": "main",
+      "romType": "capcom"
+    }
+  },
+  "escape": {
+    "snd.bin": {
+      "filename": "SND.bin",
+      "type": "main"
+    },
+    "cpu_ic7.bin": {
+      "filename": "CPU_IC7.bin",
+      "type": "main"
+    },
+    "cpu_ic1.bin": {
+      "filename": "CPU_IC1.bin",
+      "type": "main"
+    }
+  },
+  "movmastr": {
+    "snd.bin": {
+      "filename": "SND.bin",
+      "type": "main"
+    },
+    "mm_ic7.764": {
+      "filename": "mm_ic7.764",
+      "type": "main"
+    },
+    "mm_ic1.764": {
+      "filename": "mm_ic1.764",
+      "type": "main"
+    }
+  },
+  "monop301": {
+    "moncpu.301": {
+      "filename": "moncpu.301",
+      "type": "main",
+      "romType": "se"
+    },
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "mondsp-a.301": {
+      "filename": "mondsp-a.301",
+      "type": "dmd"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "bttf_a27": {
+    "bttfb5.2-7": {
+      "filename": "bttfb5.2-7",
+      "type": "main",
+      "romType": "de"
+    },
+    "bttfsf5.rom": {
+      "filename": "bttfsf5.rom",
+      "type": "sound"
+    },
+    "bttfsf6.rom": {
+      "filename": "bttfsf6.rom",
+      "type": "sound"
+    },
+    "bttfsf7.rom": {
+      "filename": "bttfsf7.rom",
+      "type": "sound"
+    },
+    "bttfc5.2-7": {
+      "filename": "bttfc5.2-7",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "pinc7fp": {
+    "pchmp_gb.1e": {
+      "filename": "pchmp_gb.1e",
+      "type": "sound"
+    },
+    "pchmp_gb.1g": {
+      "filename": "pchmp_gb.1g",
+      "type": "sound"
+    },
+    "pinc7fp.ic2": {
+      "filename": "pinc7fp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pinc7fp.ic1": {
+      "filename": "pinc7fp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_gb.1f": {
+      "filename": "pchmp_gb.1f",
+      "type": "sound"
+    },
+    "pchmp_gb.1c": {
+      "filename": "pchmp_gb.1c",
+      "type": "sound"
+    }
+  },
+  "pinc7ifp": {
+    "pchmp_gb.1e": {
+      "filename": "pchmp_gb.1e",
+      "type": "sound"
+    },
+    "pchmp_it.1g": {
+      "filename": "pchmp_it.1g",
+      "type": "sound"
+    },
+    "pchmp_it.1f": {
+      "filename": "pchmp_it.1f",
+      "type": "sound"
+    },
+    "pinc7fp.ic2": {
+      "filename": "pinc7fp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pinc7fp.ic1": {
+      "filename": "pinc7fp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_it.1c": {
+      "filename": "pchmp_it.1c",
+      "type": "sound"
+    }
+  },
+  "pincha7i": {
+    "pchmp_gb.1e": {
+      "filename": "pchmp_gb.1e",
+      "type": "sound"
+    },
+    "pchmp_it.1g": {
+      "filename": "pchmp_it.1g",
+      "type": "sound"
+    },
+    "pblchmp7.ic3": {
+      "filename": "pblchmp7.ic3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_it.1f": {
+      "filename": "pchmp_it.1f",
+      "type": "sound"
+    },
+    "pchmp_it.1c": {
+      "filename": "pchmp_it.1c",
+      "type": "sound"
+    },
+    "pblchmp7.ic2": {
+      "filename": "pblchmp7.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pblchmp7.ic1": {
+      "filename": "pblchmp7.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "pincham7": {
+    "pchmp_gb.1e": {
+      "filename": "pchmp_gb.1e",
+      "type": "sound"
+    },
+    "pchmp_gb.1g": {
+      "filename": "pchmp_gb.1g",
+      "type": "sound"
+    },
+    "pblchmp7.ic3": {
+      "filename": "pblchmp7.ic3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pblchmp7.ic2": {
+      "filename": "pblchmp7.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_gb.1f": {
+      "filename": "pchmp_gb.1f",
+      "type": "sound"
+    },
+    "pblchmp7.ic1": {
+      "filename": "pblchmp7.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_gb.1c": {
+      "filename": "pchmp_gb.1c",
+      "type": "sound"
+    }
+  },
+  "eatpm_l4": {
+    "elvi_u26.l4": {
+      "filename": "elvi_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u27.l4": {
+      "filename": "elvi_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u20.l1": {
+      "filename": "elvi_u20.l1",
+      "type": "sound"
+    },
+    "elvi_u21.l1": {
+      "filename": "elvi_u21.l1",
+      "type": "sound"
+    },
+    "elvi_u19.l1": {
+      "filename": "elvi_u19.l1",
+      "type": "sound"
+    },
+    "elvi_u4.l1": {
+      "filename": "elvi_u4.l1",
+      "type": "sound"
+    },
+    "elvi_u22.l1": {
+      "filename": "elvi_u22.l1",
+      "type": "sound"
+    }
+  },
+  "teedoff1": {
+    "dsprom1.bin": {
+      "filename": "dsprom1.bin",
+      "type": "dmd"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "gprom1.bin": {
+      "filename": "gprom1.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "teedoff3": {
+    "dsprom1.bin": {
+      "filename": "dsprom1.bin",
+      "type": "dmd"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom3.bin": {
+      "filename": "gprom3.bin",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "rock2500": {
+    "r2500snd.rom": {
+      "filename": "R2500SND.ROM",
+      "type": "sound"
+    },
+    "r2500cpu.rom": {
+      "filename": "r2500cpu.rom",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "ww_p8": {
+    "ww_p8.u6": {
+      "filename": "ww_p8.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u18.p2": {
+      "filename": "ww_u18.p2",
+      "type": "sound"
+    },
+    "ww_u15.p2": {
+      "filename": "ww_u15.p2",
+      "type": "sound"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    }
+  },
+  "fg_700al": {
+    "fg700al.bin": {
+      "filename": "fg700al.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bigtown": {
+    "bigtowna.bin": {
+      "filename": "bigtowna.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "bigtownb.bin": {
+      "filename": "bigtownb.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "lastlap": {
+    "lastlapa.bin": {
+      "filename": "lastlapa.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "lastlapb.bin": {
+      "filename": "lastlapb.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "party": {
+    "party_a.bin": {
+      "filename": "party_a.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "party_b.bin": {
+      "filename": "party_b.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "wpt_111f": {
+    "wpt0111f.bin": {
+      "filename": "wpt0111f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mundial": {
+    "snd22.bin": {
+      "filename": "snd22.bin",
+      "type": "sound"
+    },
+    "snd23.bin": {
+      "filename": "snd23.bin",
+      "type": "sound"
+    },
+    "snd11.bin": {
+      "filename": "snd11.bin",
+      "type": "sound"
+    },
+    "snd24.bin": {
+      "filename": "snd24.bin",
+      "type": "sound"
+    },
+    "snd21.bin": {
+      "filename": "snd21.bin",
+      "type": "sound"
+    },
+    "mundial.cpu": {
+      "filename": "mundial.cpu",
+      "type": "main",
+      "romType": "inder"
+    }
+  },
+  "ss_01": {
+    "sssnd_s4.21": {
+      "filename": "sssnd_s4.21",
+      "type": "sound"
+    },
+    "ss_s2.rom": {
+      "filename": "ss_s2.rom",
+      "type": "sound"
+    },
+    "ss_g11.rom": {
+      "filename": "ss_g11.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sssnd_s3.21": {
+      "filename": "sssnd_s3.21",
+      "type": "sound"
+    }
+  },
+  "ss_01b": {
+    "sssnd_s4.21": {
+      "filename": "sssnd_s4.21",
+      "type": "sound"
+    },
+    "ss_g11b.rom": {
+      "filename": "ss_g11b.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ss_s2.rom": {
+      "filename": "ss_s2.rom",
+      "type": "sound"
+    },
+    "sssnd_s3.21": {
+      "filename": "sssnd_s3.21",
+      "type": "sound"
+    }
+  },
+  "diner_l1": {
+    "u26-lu1.rom": {
+      "filename": "u26-lu1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dinr_u19.l1": {
+      "filename": "dinr_u19.l1",
+      "type": "sound"
+    },
+    "u27-lu1.rom": {
+      "filename": "u27-lu1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dinr_u4.l1": {
+      "filename": "dinr_u4.l1",
+      "type": "sound"
+    },
+    "dinr_u20.l1": {
+      "filename": "dinr_u20.l1",
+      "type": "sound"
+    }
+  },
+  "canasta": {
+    "c861.bin": {
+      "filename": "c861.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "c860.bin": {
+      "filename": "c860.bin",
+      "type": "main",
+      "romType": "inder"
+    }
+  },
+  "hod": {
+    "hod_4.bin": {
+      "filename": "hod_4.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "hod_5.bin": {
+      "filename": "hod_5.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "hod_3.bin": {
+      "filename": "hod_3.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "hod_2.bin": {
+      "filename": "hod_2.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "hod_1.bin": {
+      "filename": "hod_1.bin",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "dd_p6": {
+    "u27-pa6.11c": {
+      "filename": "u27-pa6.11c",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dude_u4.l1": {
+      "filename": "dude_u4.l1",
+      "type": "sound"
+    },
+    "u26-pa6.11c": {
+      "filename": "u26-pa6.11c",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dude_u20.l1": {
+      "filename": "dude_u20.l1",
+      "type": "sound"
+    },
+    "dude_u19.l1": {
+      "filename": "dude_u19.l1",
+      "type": "sound"
+    }
+  },
+  "lotr4": {
+    "lotrdspa.403": {
+      "filename": "lotrdspa.403",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrcpu.401": {
+      "filename": "lotrcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "mm_10u": {
+    "mmu_g11.1_0": {
+      "filename": "mmu_g11.1_0",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mm_sav6.rom": {
+      "filename": "mm_sav6.rom",
+      "type": "sound"
+    },
+    "mm_sav5.rom": {
+      "filename": "mm_sav5.rom",
+      "type": "sound"
+    },
+    "mm_sav4.rom": {
+      "filename": "mm_sav4.rom",
+      "type": "sound"
+    },
+    "mm_s2.1_0": {
+      "filename": "mm_s2.1_0",
+      "type": "sound"
+    },
+    "mm_sav3.rom": {
+      "filename": "mm_sav3.rom",
+      "type": "sound"
+    }
+  },
+  "poolchai": {
+    "poolcham.ic2": {
+      "filename": "poolcham.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "poolc_it.1e": {
+      "filename": "poolc_it.1e",
+      "type": "sound"
+    },
+    "poolcham.ic1": {
+      "filename": "poolcham.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "poolcham": {
+    "poolcham.ic2": {
+      "filename": "poolcham.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "poolcham.1f": {
+      "filename": "poolcham.1f",
+      "type": "sound"
+    },
+    "poolcham.ic1": {
+      "filename": "poolcham.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "poolchap": {
+    "poolcham.ic2": {
+      "filename": "poolcham.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound1.f": {
+      "filename": "sound1.f",
+      "type": "sound"
+    },
+    "poolcham.ic1": {
+      "filename": "poolcham.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "slbmanib": {
+    "silv2732.u2": {
+      "filename": "silv2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "786-11_4.716": {
+      "filename": "786-11_4.716",
+      "type": "sound"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "hangon": {
+    "hangon3.bin": {
+      "filename": "hangon3.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "hangon2.bin": {
+      "filename": "hangon2.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "hangon1.bin": {
+      "filename": "hangon1.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "bnzai_g3": {
+    "banz_u20.l1": {
+      "filename": "banz_u20.l1",
+      "type": "sound"
+    },
+    "banz_u26.l3g": {
+      "filename": "banz_u26.l3g",
+      "type": "main",
+      "romType": "s11"
+    },
+    "banz_u4.l1": {
+      "filename": "banz_u4.l1",
+      "type": "sound"
+    },
+    "banz_u19.l1": {
+      "filename": "banz_u19.l1",
+      "type": "sound"
+    },
+    "banz_u27.l3": {
+      "filename": "banz_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "banz_u21.l1": {
+      "filename": "banz_u21.l1",
+      "type": "sound"
+    },
+    "banz_u22.l1": {
+      "filename": "banz_u22.l1",
+      "type": "sound"
+    }
+  },
+  "bnzai_l1": {
+    "banz_u20.l1": {
+      "filename": "banz_u20.l1",
+      "type": "sound"
+    },
+    "u26-l1.rom": {
+      "filename": "u26-l1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "u27-l1.rom": {
+      "filename": "u27-l1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "banz_u4.l1": {
+      "filename": "banz_u4.l1",
+      "type": "sound"
+    },
+    "banz_u19.l1": {
+      "filename": "banz_u19.l1",
+      "type": "sound"
+    },
+    "banz_u21.l1": {
+      "filename": "banz_u21.l1",
+      "type": "sound"
+    },
+    "banz_u22.l1": {
+      "filename": "banz_u22.l1",
+      "type": "sound"
+    }
+  },
+  "bnzai_l3": {
+    "banz_u20.l1": {
+      "filename": "banz_u20.l1",
+      "type": "sound"
+    },
+    "banz_u4.l1": {
+      "filename": "banz_u4.l1",
+      "type": "sound"
+    },
+    "banz_u19.l1": {
+      "filename": "banz_u19.l1",
+      "type": "sound"
+    },
+    "banz_u27.l3": {
+      "filename": "banz_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "banz_u26.l3": {
+      "filename": "banz_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "banz_u21.l1": {
+      "filename": "banz_u21.l1",
+      "type": "sound"
+    },
+    "banz_u22.l1": {
+      "filename": "banz_u22.l1",
+      "type": "sound"
+    }
+  },
+  "bnzai_pa": {
+    "banz_u20.l1": {
+      "filename": "banz_u20.l1",
+      "type": "sound"
+    },
+    "u4-p7.rom": {
+      "filename": "u4-p7.rom",
+      "type": "sound"
+    },
+    "u26-pa.rom": {
+      "filename": "u26-pa.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "banz_u19.l1": {
+      "filename": "banz_u19.l1",
+      "type": "sound"
+    },
+    "u27-pa.rom": {
+      "filename": "u27-pa.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "banz_u21.l1": {
+      "filename": "banz_u21.l1",
+      "type": "sound"
+    },
+    "banz_u22.l1": {
+      "filename": "banz_u22.l1",
+      "type": "sound"
+    }
+  },
+  "lancelot": {
+    "lancelot.bin": {
+      "filename": "lancelot.bin",
+      "type": "main"
+    },
+    "snd_u4.bin": {
+      "filename": "snd_u4.bin",
+      "type": "main"
+    },
+    "snd_u5.bin": {
+      "filename": "snd_u5.bin",
+      "type": "main"
+    },
+    "snd_u3.bin": {
+      "filename": "snd_u3.bin",
+      "type": "main"
+    }
+  },
+  "brooks": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "sfight2b": {
+    "gprom2.bin": {
+      "filename": "gprom2.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "dsprom2.bin": {
+      "filename": "dsprom2.bin",
+      "type": "dmd"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "nfl": {
+    "nfl_v100.u36": {
+      "filename": "nfl_v100.u36",
+      "type": "sound"
+    },
+    "nfl_v100.u37": {
+      "filename": "nfl_v100.u37",
+      "type": "sound"
+    },
+    "nfl_v100.u7": {
+      "filename": "nfl_v100.u7",
+      "type": "sound"
+    },
+    "nfl_v101.cpu": {
+      "filename": "nfl_v101.cpu",
+      "type": "main",
+      "romType": "se"
+    },
+    "nfl_v100.u17": {
+      "filename": "nfl_v100.u17",
+      "type": "sound"
+    },
+    "nfl_v100.u21": {
+      "filename": "nfl_v100.u21",
+      "type": "sound"
+    },
+    "nfl_v102.dmd": {
+      "filename": "nfl_v102.dmd",
+      "type": "dmd"
+    }
+  },
+  "hshot_p8": {
+    "hshot_p8.u6": {
+      "filename": "hshot_p8.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "hshot_l1.u18": {
+      "filename": "hshot_l1.u18",
+      "type": "sound"
+    },
+    "hshot_l1.u14": {
+      "filename": "hshot_l1.u14",
+      "type": "sound"
+    }
+  },
+  "torp_a16": {
+    "torpef7.rom": {
+      "filename": "torpef7.rom",
+      "type": "sound"
+    },
+    "c5.256": {
+      "filename": "c5.256",
+      "type": "main",
+      "romType": "de"
+    },
+    "torpef4.rom": {
+      "filename": "torpef4.rom",
+      "type": "sound"
+    },
+    "b5.256": {
+      "filename": "b5.256",
+      "type": "main",
+      "romType": "de"
+    },
+    "torpef6.rom": {
+      "filename": "torpef6.rom",
+      "type": "sound"
+    }
+  },
+  "torp_e21": {
+    "torpef7.rom": {
+      "filename": "torpef7.rom",
+      "type": "sound"
+    },
+    "torpef4.rom": {
+      "filename": "torpef4.rom",
+      "type": "sound"
+    },
+    "torpe2-1.c5": {
+      "filename": "torpe2-1.c5",
+      "type": "main",
+      "romType": "de"
+    },
+    "torpe2-1.b5": {
+      "filename": "torpe2-1.b5",
+      "type": "main",
+      "romType": "de"
+    },
+    "torpef6.rom": {
+      "filename": "torpef6.rom",
+      "type": "sound"
+    }
+  },
+  "rapidfia": {
+    "869-04_2.732": {
+      "filename": "869-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "869-02_5.532": {
+      "filename": "869-02_5.532",
+      "type": "sound"
+    },
+    "rapidfun.u6": {
+      "filename": "rapidfun.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "rapidfir": {
+    "869-04_2.732": {
+      "filename": "869-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "869-02_5.532": {
+      "filename": "869-02_5.532",
+      "type": "sound"
+    },
+    "869-03_6.732": {
+      "filename": "869-03_6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "starrac7": {
+    "657-1.cpu": {
+      "filename": "657-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "657.snd": {
+      "filename": "657.snd",
+      "type": "sound"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "657-2.cpu": {
+      "filename": "657-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "blkshpsq": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "swrds_l1": {
+    "swrd_u4.l1": {
+      "filename": "swrd_u4.l1",
+      "type": "sound"
+    },
+    "swrd_u22.l1": {
+      "filename": "swrd_u22.l1",
+      "type": "sound"
+    },
+    "swrd_u27.l1": {
+      "filename": "swrd_u27.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "swrd_u19.l1": {
+      "filename": "swrd_u19.l1",
+      "type": "sound"
+    },
+    "swrd_u26.l1": {
+      "filename": "swrd_u26.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "swrd_u21.l1": {
+      "filename": "swrd_u21.l1",
+      "type": "sound"
+    }
+  },
+  "swrds_l2": {
+    "swrd_u4.l1": {
+      "filename": "swrd_u4.l1",
+      "type": "sound"
+    },
+    "swrd_u27.l2": {
+      "filename": "swrd_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "swrd_u22.l1": {
+      "filename": "swrd_u22.l1",
+      "type": "sound"
+    },
+    "swrd_u19.l1": {
+      "filename": "swrd_u19.l1",
+      "type": "sound"
+    },
+    "swrd_u26.l2": {
+      "filename": "swrd_u26.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "swrd_u21.l1": {
+      "filename": "swrd_u21.l1",
+      "type": "sound"
+    }
+  },
+  "fourx4": {
+    "8000ce65.bin": {
+      "filename": "8000ce65.bin",
+      "type": "main",
+      "romType": "atari"
+    },
+    "a0004c37.bin": {
+      "filename": "a0004c37.bin",
+      "type": "main",
+      "romType": "atari"
+    },
+    "c000a70c.bin": {
+      "filename": "c000a70c.bin",
+      "type": "main",
+      "romType": "atari"
+    },
+    "82s130.bin": {
+      "filename": "82s130.bin",
+      "type": "sound"
+    }
+  },
+  "ww_l2": {
+    "ww_l2.u6": {
+      "filename": "ww_l2.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u18.l1": {
+      "filename": "ww_u18.l1",
+      "type": "sound"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    },
+    "ww_u15.l1": {
+      "filename": "ww_u15.l1",
+      "type": "sound"
+    }
+  },
+  "ww_p1": {
+    "ww_l2.u6": {
+      "filename": "ww_l2.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u15.p1": {
+      "filename": "ww_u15.p1",
+      "type": "sound"
+    },
+    "ww_u18.p1": {
+      "filename": "ww_u18.p1",
+      "type": "sound"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    }
+  },
+  "ww_p2": {
+    "ww_l2.u6": {
+      "filename": "ww_l2.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u18.p2": {
+      "filename": "ww_u18.p2",
+      "type": "sound"
+    },
+    "ww_u15.p2": {
+      "filename": "ww_u15.p2",
+      "type": "sound"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    }
+  },
+  "mach2": {
+    "m2cpu0.19": {
+      "filename": "m2cpu0.19",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "m2musa.01": {
+      "filename": "m2musa.01",
+      "type": "sound"
+    },
+    "m2musb.01": {
+      "filename": "m2musb.01",
+      "type": "sound"
+    },
+    "m2musc.01": {
+      "filename": "m2musc.01",
+      "type": "sound"
+    },
+    "m2cpu1.19": {
+      "filename": "m2cpu1.19",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "m2dmdf.01": {
+      "filename": "m2dmdf.01",
+      "type": "dmd"
+    },
+    "m2sndd.01": {
+      "filename": "m2sndd.01",
+      "type": "sound"
+    },
+    "m2snde.01": {
+      "filename": "m2snde.01",
+      "type": "sound"
+    }
+  },
+  "mrblack": {
+    "mrb_s3.bin": {
+      "filename": "mrb_s3.bin",
+      "type": "sound"
+    },
+    "mrb_s2.bin": {
+      "filename": "mrb_s2.bin",
+      "type": "sound"
+    },
+    "mrb4.bin": {
+      "filename": "mrb4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb5.bin": {
+      "filename": "mrb5.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb1.bin": {
+      "filename": "mrb1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb2.bin": {
+      "filename": "mrb2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb3.bin": {
+      "filename": "mrb3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb_s1.bin": {
+      "filename": "mrb_s1.bin",
+      "type": "sound"
+    }
+  },
+  "mrblkz80": {
+    "mrb_s3.bin": {
+      "filename": "mrb_s3.bin",
+      "type": "sound"
+    },
+    "mrb_s2.bin": {
+      "filename": "mrb_s2.bin",
+      "type": "sound"
+    },
+    "mb03z80.dat": {
+      "filename": "mb03z80.dat",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mb02z80.dat": {
+      "filename": "mb02z80.dat",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mb01z80.dat": {
+      "filename": "mb01z80.dat",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mb04z80.dat": {
+      "filename": "mb04z80.dat",
+      "type": "main",
+      "romType": "taito"
+    },
+    "mrb_s1.bin": {
+      "filename": "mrb_s1.bin",
+      "type": "sound"
+    }
+  },
+  "sst": {
+    "741-08_2.716": {
+      "filename": "741-08_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-30_6.716": {
+      "filename": "720-30_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "741-10_1.716": {
+      "filename": "741-10_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "diner_l3": {
+    "dinr_u19.l1": {
+      "filename": "dinr_u19.l1",
+      "type": "sound"
+    },
+    "dinr_u4.l1": {
+      "filename": "dinr_u4.l1",
+      "type": "sound"
+    },
+    "u27-la3.rom": {
+      "filename": "u27-la3.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dinr_u20.l1": {
+      "filename": "dinr_u20.l1",
+      "type": "sound"
+    },
+    "u26-la3.rom": {
+      "filename": "u26-la3.rom",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "diner_l4": {
+    "dinr_u19.l1": {
+      "filename": "dinr_u19.l1",
+      "type": "sound"
+    },
+    "dinr_u4.l1": {
+      "filename": "dinr_u4.l1",
+      "type": "sound"
+    },
+    "dinr_u20.l1": {
+      "filename": "dinr_u20.l1",
+      "type": "sound"
+    },
+    "dinr_u26.l4": {
+      "filename": "dinr_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dinr_u27.l4": {
+      "filename": "dinr_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "alcapone": {
+    "alcapo_h.bin": {
+      "filename": "alcapo_h.bin",
+      "type": "main",
+      "romType": "ltd"
+    },
+    "alcapo_l.bin": {
+      "filename": "alcapo_l.bin",
+      "type": "main",
+      "romType": "ltd"
+    }
+  },
+  "dh_lx2": {
+    "dh_snd.u3": {
+      "filename": "dh_snd.u3",
+      "type": "sound"
+    },
+    "dh_snd.u6": {
+      "filename": "dh_snd.u6",
+      "type": "sound"
+    },
+    "dh_snd.u4": {
+      "filename": "dh_snd.u4",
+      "type": "sound"
+    },
+    "dh_snd.u5": {
+      "filename": "dh_snd.u5",
+      "type": "sound"
+    },
+    "harr_lx2.rom": {
+      "filename": "harr_lx2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dh_snd.u2": {
+      "filename": "dh_snd.u2",
+      "type": "sound"
+    }
+  },
+  "fg_1000af": {
+    "fg1000af.bin": {
+      "filename": "fg1000af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "robo_a30": {
+    "robof4.rom": {
+      "filename": "robof4.rom",
+      "type": "sound"
+    },
+    "b5.256": {
+      "filename": "b5.256",
+      "type": "main",
+      "romType": "de"
+    },
+    "robof6.rom": {
+      "filename": "robof6.rom",
+      "type": "sound"
+    },
+    "c5.256": {
+      "filename": "c5.256",
+      "type": "main",
+      "romType": "de"
+    },
+    "robof7.rom": {
+      "filename": "robof7.rom",
+      "type": "sound"
+    }
+  },
+  "robo_a34": {
+    "robof4.rom": {
+      "filename": "robof4.rom",
+      "type": "sound"
+    },
+    "robob5.a34": {
+      "filename": "robob5.a34",
+      "type": "main",
+      "romType": "de"
+    },
+    "robof6.rom": {
+      "filename": "robof6.rom",
+      "type": "sound"
+    },
+    "roboc5.a34": {
+      "filename": "roboc5.a34",
+      "type": "main",
+      "romType": "de"
+    },
+    "robof7.rom": {
+      "filename": "robof7.rom",
+      "type": "sound"
+    }
+  },
+  "princefp": {
+    "fpcosp_6.716": {
+      "filename": "fpcosp_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fpcosp_2.716": {
+      "filename": "fpcosp_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "eballd14": {
+    "838-14_2.732": {
+      "filename": "838-14_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-52_6.732": {
+      "filename": "720-52_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-10_5.532": {
+      "filename": "838-10_5.532",
+      "type": "sound"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    }
+  },
+  "gpr400g": {
+    "gpsndg.u17": {
+      "filename": "gpsndg.u17",
+      "type": "sound"
+    },
+    "gpsndg.u36": {
+      "filename": "gpsndg.u36",
+      "type": "sound"
+    },
+    "gpsndg.u21": {
+      "filename": "gpsndg.u21",
+      "type": "sound"
+    },
+    "gpsndg.u7": {
+      "filename": "gpsndg.u7",
+      "type": "sound"
+    },
+    "gpcpug.400": {
+      "filename": "gpcpug.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpdspg.400": {
+      "filename": "gpdspg.400",
+      "type": "dmd"
+    },
+    "gpsndg.u37": {
+      "filename": "gpsndg.u37",
+      "type": "sound"
+    }
+  },
+  "gprixg": {
+    "gpsndg.u17": {
+      "filename": "gpsndg.u17",
+      "type": "sound"
+    },
+    "gpsndg.u36": {
+      "filename": "gpsndg.u36",
+      "type": "sound"
+    },
+    "gpsndg.u21": {
+      "filename": "gpsndg.u21",
+      "type": "sound"
+    },
+    "gpsndg.u7": {
+      "filename": "gpsndg.u7",
+      "type": "sound"
+    },
+    "gpdspg.400": {
+      "filename": "gpdspg.400",
+      "type": "dmd"
+    },
+    "gpcpug.450": {
+      "filename": "gpcpug.450",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndg.u37": {
+      "filename": "gpsndg.u37",
+      "type": "sound"
+    }
+  },
+  "wof_500i": {
+    "wof0500i.bin": {
+      "filename": "wof0500i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "apollo13": {
+    "apollo13.u21": {
+      "filename": "apollo13.u21",
+      "type": "sound"
+    },
+    "apollo13.u17": {
+      "filename": "apollo13.u17",
+      "type": "sound"
+    },
+    "apolcpu.501": {
+      "filename": "apolcpu.501",
+      "type": "main",
+      "romType": "se"
+    },
+    "a13dspa.500": {
+      "filename": "a13dspa.500",
+      "type": "dmd"
+    },
+    "apollo13.u36": {
+      "filename": "apollo13.u36",
+      "type": "sound"
+    },
+    "apollo13.u7": {
+      "filename": "apollo13.u7",
+      "type": "sound"
+    }
+  },
+  "apollo14": {
+    "apollo13.u21": {
+      "filename": "apollo13.u21",
+      "type": "sound"
+    },
+    "apollo13.u17": {
+      "filename": "apollo13.u17",
+      "type": "sound"
+    },
+    "apolcpu.501": {
+      "filename": "apolcpu.501",
+      "type": "main",
+      "romType": "se"
+    },
+    "a13dspa.401": {
+      "filename": "a13dspa.401",
+      "type": "dmd"
+    },
+    "apollo13.u36": {
+      "filename": "apollo13.u36",
+      "type": "sound"
+    },
+    "apollo13.u7": {
+      "filename": "apollo13.u7",
+      "type": "sound"
+    }
+  },
+  "apollo2": {
+    "apollo13.u21": {
+      "filename": "apollo13.u21",
+      "type": "sound"
+    },
+    "a13cpu.203": {
+      "filename": "a13cpu.203",
+      "type": "main",
+      "romType": "se"
+    },
+    "apollo13.u17": {
+      "filename": "apollo13.u17",
+      "type": "sound"
+    },
+    "a13dps.201": {
+      "filename": "a13dps.201",
+      "type": "dmd"
+    },
+    "apollo13.u36": {
+      "filename": "apollo13.u36",
+      "type": "sound"
+    },
+    "apollo13.u7": {
+      "filename": "apollo13.u7",
+      "type": "sound"
+    }
+  },
+  "timelin7": {
+    "659.snd": {
+      "filename": "659.snd",
+      "type": "sound"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "659.cpu": {
+      "filename": "659.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "sman_130gf": {
+    "spd_1_30_gf.bin": {
+      "filename": "spd_1_30_gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "midearth": {
+    "608.bin": {
+      "filename": "608.bin",
+      "type": "main",
+      "romType": "atari"
+    },
+    "609.bin": {
+      "filename": "609.bin",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "robot": {
+    "robot_2.lgc": {
+      "filename": "robot_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_e.snd": {
+      "filename": "robot_e.snd",
+      "type": "sound"
+    },
+    "robot_1.lgc": {
+      "filename": "robot_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_g.snd": {
+      "filename": "robot_g.snd",
+      "type": "sound"
+    },
+    "robot_d.snd": {
+      "filename": "robot_d.snd",
+      "type": "sound"
+    }
+  },
+  "robotf": {
+    "robot_2.lgc": {
+      "filename": "robot_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_1.lgc": {
+      "filename": "robot_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_fr.1d": {
+      "filename": "robot_fr.1d",
+      "type": "sound"
+    },
+    "robot_fr.1g": {
+      "filename": "robot_fr.1g",
+      "type": "sound"
+    },
+    "robot_fr.1e": {
+      "filename": "robot_fr.1e",
+      "type": "sound"
+    }
+  },
+  "robotg": {
+    "robot_2.lgc": {
+      "filename": "robot_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_1.lgc": {
+      "filename": "robot_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_gg.snd": {
+      "filename": "robot_gg.snd",
+      "type": "sound"
+    },
+    "robot_dg.snd": {
+      "filename": "robot_dg.snd",
+      "type": "sound"
+    },
+    "robot_eg.snd": {
+      "filename": "robot_eg.snd",
+      "type": "sound"
+    }
+  },
+  "roboti": {
+    "robot_2.lgc": {
+      "filename": "robot_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_it.1e": {
+      "filename": "robot_it.1e",
+      "type": "sound"
+    },
+    "robot_1.lgc": {
+      "filename": "robot_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_it.1g": {
+      "filename": "robot_it.1g",
+      "type": "sound"
+    },
+    "robot_it.1d": {
+      "filename": "robot_it.1d",
+      "type": "sound"
+    }
+  },
+  "goldcue": {
+    "gc_sound.u17": {
+      "filename": "gc_sound.u17",
+      "type": "sound"
+    },
+    "gc_sound.u36": {
+      "filename": "gc_sound.u36",
+      "type": "sound"
+    },
+    "gc_cpu.210": {
+      "filename": "gc_cpu.210",
+      "type": "main",
+      "romType": "se"
+    },
+    "gc_disp.u12": {
+      "filename": "gc_disp.u12",
+      "type": "dmd"
+    },
+    "gc_sound.u7": {
+      "filename": "gc_sound.u7",
+      "type": "sound"
+    },
+    "gc_sound.u21": {
+      "filename": "gc_sound.u21",
+      "type": "sound"
+    }
+  },
+  "rollstob": {
+    "roll2732.u2": {
+      "filename": "roll2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    },
+    "796-19_4.716": {
+      "filename": "796-19_4.716",
+      "type": "sound"
+    }
+  },
+  "cycln_l1": {
+    "cycl_u22.l1": {
+      "filename": "cycl_u22.l1",
+      "type": "sound"
+    },
+    "cycl_u27.l1": {
+      "filename": "cycl_u27.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cycl_u19.l1": {
+      "filename": "cycl_u19.l1",
+      "type": "sound"
+    },
+    "cycl_u26.l1": {
+      "filename": "cycl_u26.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cycl_u4.l5": {
+      "filename": "cycl_u4.l5",
+      "type": "sound"
+    },
+    "cycl_u21.l1": {
+      "filename": "cycl_u21.l1",
+      "type": "sound"
+    }
+  },
+  "cycln_l4": {
+    "cycl_u22.l1": {
+      "filename": "cycl_u22.l1",
+      "type": "sound"
+    },
+    "cycl_u26.l4": {
+      "filename": "cycl_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cycl_u27.l4": {
+      "filename": "cycl_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cycl_u19.l1": {
+      "filename": "cycl_u19.l1",
+      "type": "sound"
+    },
+    "cycl_u4.l5": {
+      "filename": "cycl_u4.l5",
+      "type": "sound"
+    },
+    "cycl_u21.l1": {
+      "filename": "cycl_u21.l1",
+      "type": "sound"
+    }
+  },
+  "cycln_l5": {
+    "cycl_u22.l1": {
+      "filename": "cycl_u22.l1",
+      "type": "sound"
+    },
+    "cycl_u26.l5": {
+      "filename": "cycl_u26.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cycl_u19.l1": {
+      "filename": "cycl_u19.l1",
+      "type": "sound"
+    },
+    "cycl_u27.l5": {
+      "filename": "cycl_u27.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "cycl_u4.l5": {
+      "filename": "cycl_u4.l5",
+      "type": "sound"
+    },
+    "cycl_u21.l1": {
+      "filename": "cycl_u21.l1",
+      "type": "sound"
+    }
+  },
+  "cyclopes": {
+    "800.snd": {
+      "filename": "800.snd",
+      "type": "sound"
+    },
+    "800.a": {
+      "filename": "800.a",
+      "type": "main",
+      "romType": "gp"
+    },
+    "800.b": {
+      "filename": "800.b",
+      "type": "main",
+      "romType": "gp"
+    },
+    "800.c": {
+      "filename": "800.c",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "wrlok_l3": {
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "strlt_l1": {
+    "ic14.532": {
+      "filename": "ic14.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "ic20.532": {
+      "filename": "ic20.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "stargzrb": {
+    "cpu_u5b.716": {
+      "filename": "cpu_u5b.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2b.716": {
+      "filename": "cpu_u2b.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6b.716": {
+      "filename": "cpu_u6b.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "lapbylap": {
+    "lblr0.bin": {
+      "filename": "lblr0.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "lblr1.bin": {
+      "filename": "lblr1.bin",
+      "type": "main",
+      "romType": "inder"
+    }
+  },
+  "lotr_sp5": {
+    "lotrcpul.500": {
+      "filename": "lotrcpul.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrlu36.100": {
+      "filename": "lotrlu36.100",
+      "type": "sound"
+    },
+    "lotrlu37.100": {
+      "filename": "lotrlu37.100",
+      "type": "sound"
+    },
+    "lotrlu7.100": {
+      "filename": "lotrlu7.100",
+      "type": "sound"
+    },
+    "lotrdspl.500": {
+      "filename": "lotrdspl.500",
+      "type": "dmd"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrlu17.100": {
+      "filename": "lotrlu17.100",
+      "type": "sound"
+    },
+    "lotrlu21.100": {
+      "filename": "lotrlu21.100",
+      "type": "sound"
+    }
+  },
+  "sman_210gf": {
+    "spd_v2-1_gf.bin": {
+      "filename": "spd_v2-1_gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sfight2": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "odisea": {
+    "odiseaa.bin": {
+      "filename": "odiseaa.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "odiseac.bin": {
+      "filename": "odiseac.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "odiseab.bin": {
+      "filename": "odiseab.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "starfira": {
+    "starfira.rom": {
+      "filename": "starfira.rom",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "starfu3.rom": {
+      "filename": "starfu3.rom",
+      "type": "sound"
+    },
+    "starfu4.rom": {
+      "filename": "starfu4.rom",
+      "type": "sound"
+    }
+  },
+  "twenty4_144": {
+    "24_v1-44_e.bin": {
+      "filename": "24_v1-44_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "motrdome": {
+    "modm_u7.snd": {
+      "filename": "modm_u7.snd",
+      "type": "sound"
+    },
+    "modm_u2.dat": {
+      "filename": "modm_u2.dat",
+      "type": "main",
+      "romType": "by"
+    },
+    "modm_u3.dat": {
+      "filename": "modm_u3.dat",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "vrnwrld": {
+    "vwdmd2.rom": {
+      "filename": "vwdmd2.rom",
+      "type": "dmd"
+    },
+    "vwdmd0.rom": {
+      "filename": "vwdmd0.rom",
+      "type": "dmd"
+    },
+    "vws5ic25.rom": {
+      "filename": "vws5ic25.rom",
+      "type": "sound"
+    },
+    "vws7ic27.rom": {
+      "filename": "vws7ic27.rom",
+      "type": "sound"
+    },
+    "vwcpu0.rom": {
+      "filename": "vwcpu0.rom",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "vwcpu1.rom": {
+      "filename": "vwcpu1.rom",
+      "type": "main",
+      "romType": "spinball"
+    },
+    "vws2ic9.rom": {
+      "filename": "vws2ic9.rom",
+      "type": "sound"
+    },
+    "vws6ic26.rom": {
+      "filename": "vws6ic26.rom",
+      "type": "sound"
+    },
+    "vws3ic15.rom": {
+      "filename": "vws3ic15.rom",
+      "type": "sound"
+    },
+    "vwdmd1.rom": {
+      "filename": "vwdmd1.rom",
+      "type": "dmd"
+    },
+    "vws4ic30.rom": {
+      "filename": "vws4ic30.rom",
+      "type": "sound"
+    }
+  },
+  "barra_l1": {
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound4.716": {
+      "filename": "sound4.716",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "congo_11": {
+    "cgs4v1_0.rom": {
+      "filename": "cgs4v1_0.rom",
+      "type": "sound"
+    },
+    "cgs2v1_1.rom": {
+      "filename": "cgs2v1_1.rom",
+      "type": "sound"
+    },
+    "cgs3v1_0.rom": {
+      "filename": "cgs3v1_0.rom",
+      "type": "sound"
+    },
+    "cong1_10.rom": {
+      "filename": "Cong1_10.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "congo_13": {
+    "cgs4v1_0.rom": {
+      "filename": "cgs4v1_0.rom",
+      "type": "sound"
+    },
+    "cgs2v1_1.rom": {
+      "filename": "cgs2v1_1.rom",
+      "type": "sound"
+    },
+    "cgs3v1_0.rom": {
+      "filename": "cgs3v1_0.rom",
+      "type": "sound"
+    },
+    "cong1_30.rom": {
+      "filename": "cong1_30.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "congo_20": {
+    "cgs4v1_0.rom": {
+      "filename": "cgs4v1_0.rom",
+      "type": "sound"
+    },
+    "cgs2v1_1.rom": {
+      "filename": "cgs2v1_1.rom",
+      "type": "sound"
+    },
+    "cgs3v1_0.rom": {
+      "filename": "cgs3v1_0.rom",
+      "type": "sound"
+    },
+    "cong2_00.rom": {
+      "filename": "cong2_00.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "congo_21": {
+    "cgs4v1_0.rom": {
+      "filename": "cgs4v1_0.rom",
+      "type": "sound"
+    },
+    "cgs2v1_1.rom": {
+      "filename": "cgs2v1_1.rom",
+      "type": "sound"
+    },
+    "cg_g11.2_1": {
+      "filename": "cg_g11.2_1",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "cgs3v1_0.rom": {
+      "filename": "cgs3v1_0.rom",
+      "type": "sound"
+    }
+  },
+  "slbmania": {
+    "786-11_4.716": {
+      "filename": "786-11_4.716",
+      "type": "sound"
+    },
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "786-17_2.716": {
+      "filename": "786-17_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "786-16_1.716": {
+      "filename": "786-16_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "eballdlx": {
+    "720-52_6.732": {
+      "filename": "720-52_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-15_2.732": {
+      "filename": "838-15_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-10_5.532": {
+      "filename": "838-10_5.532",
+      "type": "sound"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    }
+  },
+  "embryon": {
+    "720-52_6.732": {
+      "filename": "720-52_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "841-06_2.732": {
+      "filename": "841-06_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "841-02_5.532": {
+      "filename": "841-02_5.532",
+      "type": "sound"
+    },
+    "841-01_4.716": {
+      "filename": "841-01_4.716",
+      "type": "sound"
+    }
+  },
+  "fball_ii": {
+    "720-52_6.732": {
+      "filename": "720-52_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "839-12_2.732": {
+      "filename": "839-12_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "839-01_2.532": {
+      "filename": "839-01_2.532",
+      "type": "sound"
+    },
+    "839-02_5.532": {
+      "filename": "839-02_5.532",
+      "type": "sound"
+    }
+  },
+  "sopr107i": {
+    "sopdspi.100": {
+      "filename": "sopdspi.100",
+      "type": "dmd"
+    },
+    "sopsndi.u21": {
+      "filename": "sopsndi.u21",
+      "type": "sound"
+    },
+    "sopsndi.u36": {
+      "filename": "sopsndi.u36",
+      "type": "sound"
+    },
+    "sopsndi1.u17": {
+      "filename": "Sopsndi1.u17",
+      "type": "sound"
+    },
+    "sopsndi.u7": {
+      "filename": "sopsndi.u7",
+      "type": "sound"
+    },
+    "sopsndi.u37": {
+      "filename": "sopsndi.u37",
+      "type": "sound"
+    },
+    "sopcpui.107": {
+      "filename": "sopcpui.107",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "waterwl2": {
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "gprom2.bin": {
+      "filename": "gprom2.bin",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "waterwld": {
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "lotr8": {
+    "lotrdspa.800": {
+      "filename": "LOTRDSPA.800",
+      "type": "dmd"
+    },
+    "lotrcpu.800": {
+      "filename": "LOTRCPU.800",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "mephist1": {
+    "ic15_02": {
+      "filename": "ic15_02",
+      "type": "main"
+    },
+    "ic13_s1": {
+      "filename": "ic13_s1",
+      "type": "main"
+    },
+    "ic16_c": {
+      "filename": "ic16_c",
+      "type": "main"
+    },
+    "ic14_s0": {
+      "filename": "ic14_s0",
+      "type": "main"
+    },
+    "ic11_s3": {
+      "filename": "ic11_s3",
+      "type": "main"
+    },
+    "ic12_s2": {
+      "filename": "ic12_s2",
+      "type": "main"
+    },
+    "ic19_f": {
+      "filename": "ic19_f",
+      "type": "main"
+    },
+    "cpu_ver1.1": {
+      "filename": "cpu_ver1.1",
+      "type": "main"
+    },
+    "ic17_d": {
+      "filename": "ic17_d",
+      "type": "main"
+    },
+    "ic18_e": {
+      "filename": "ic18_e",
+      "type": "main"
+    }
+  },
+  "mephisto": {
+    "ic15_02": {
+      "filename": "ic15_02",
+      "type": "main"
+    },
+    "ic13_s1": {
+      "filename": "ic13_s1",
+      "type": "main"
+    },
+    "ic16_c": {
+      "filename": "ic16_c",
+      "type": "main"
+    },
+    "ic14_s0": {
+      "filename": "ic14_s0",
+      "type": "main"
+    },
+    "cpu_ver1.2": {
+      "filename": "cpu_ver1.2",
+      "type": "main"
+    },
+    "ic11_s3": {
+      "filename": "ic11_s3",
+      "type": "main"
+    },
+    "ic12_s2": {
+      "filename": "ic12_s2",
+      "type": "main"
+    },
+    "ic19_f": {
+      "filename": "ic19_f",
+      "type": "main"
+    },
+    "ic17_d": {
+      "filename": "ic17_d",
+      "type": "main"
+    },
+    "ic18_e": {
+      "filename": "ic18_e",
+      "type": "main"
+    }
+  },
+  "meteorc": {
+    "fp10met6.716": {
+      "filename": "fp10met6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fp10met1.716": {
+      "filename": "fp10met1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fp10met2.716": {
+      "filename": "fp10met2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fp10met5.716": {
+      "filename": "fp10met5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "meteord": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "pharo_l2": {
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech4.532": {
+      "filename": "speech4.532",
+      "type": "sound"
+    },
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech6.532": {
+      "filename": "speech6.532",
+      "type": "sound"
+    },
+    "speech5.532": {
+      "filename": "speech5.532",
+      "type": "sound"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech7.532": {
+      "filename": "speech7.532",
+      "type": "sound"
+    }
+  },
+  "lotr9": {
+    "lotrdspa.900": {
+      "filename": "lotrdspa.900",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.900": {
+      "filename": "lotrcpu.900",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "taxi_l3": {
+    "taxi_u21.l1": {
+      "filename": "taxi_u21.l1",
+      "type": "sound"
+    },
+    "taxi_u4.l1": {
+      "filename": "taxi_u4.l1",
+      "type": "sound"
+    },
+    "taxi_u19.l1": {
+      "filename": "taxi_u19.l1",
+      "type": "sound"
+    },
+    "taxi_u26.l4": {
+      "filename": "taxi_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "taxi_u22.l1": {
+      "filename": "taxi_u22.l1",
+      "type": "sound"
+    },
+    "taxi_u27.l3": {
+      "filename": "taxi_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "taxi_l4": {
+    "taxi_u21.l1": {
+      "filename": "taxi_u21.l1",
+      "type": "sound"
+    },
+    "taxi_u4.l1": {
+      "filename": "taxi_u4.l1",
+      "type": "sound"
+    },
+    "taxi_u19.l1": {
+      "filename": "taxi_u19.l1",
+      "type": "sound"
+    },
+    "taxi_u26.l4": {
+      "filename": "taxi_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "taxi_u22.l1": {
+      "filename": "taxi_u22.l1",
+      "type": "sound"
+    },
+    "taxi_u27.l4": {
+      "filename": "taxi_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "taxi_lg1": {
+    "taxi_u21.l1": {
+      "filename": "taxi_u21.l1",
+      "type": "sound"
+    },
+    "u26-lg1m.rom": {
+      "filename": "u26-lg1m.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "taxi_u4.l1": {
+      "filename": "taxi_u4.l1",
+      "type": "sound"
+    },
+    "taxi_u19.l1": {
+      "filename": "taxi_u19.l1",
+      "type": "sound"
+    },
+    "u27-lg1m.rom": {
+      "filename": "u27-lg1m.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "taxi_u22.l1": {
+      "filename": "taxi_u22.l1",
+      "type": "sound"
+    }
+  },
+  "taxi_p5": {
+    "taxi_u21.l1": {
+      "filename": "taxi_u21.l1",
+      "type": "sound"
+    },
+    "taxi_u4.l1": {
+      "filename": "taxi_u4.l1",
+      "type": "sound"
+    },
+    "taxi_u19.l1": {
+      "filename": "taxi_u19.l1",
+      "type": "sound"
+    },
+    "taxi_u26.p5": {
+      "filename": "taxi_u26.p5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "taxi_u22.l1": {
+      "filename": "taxi_u22.l1",
+      "type": "sound"
+    },
+    "taxi_u27.p5": {
+      "filename": "taxi_u27.p5",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "catacofp": {
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "fpcat_u5.716": {
+      "filename": "fpcat_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "catacomb": {
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "dm_la1": {
+    "dm_u3_s.l2": {
+      "filename": "dm_u3_s.l2",
+      "type": "sound"
+    },
+    "dm_u6_s.l2": {
+      "filename": "dm_u6_s.l2",
+      "type": "sound"
+    },
+    "dm_u7_s.l2": {
+      "filename": "dm_u7_s.l2",
+      "type": "sound"
+    },
+    "dm_u4_s.l2": {
+      "filename": "dm_u4_s.l2",
+      "type": "sound"
+    },
+    "dm_u5_s.l2": {
+      "filename": "dm_u5_s.l2",
+      "type": "sound"
+    },
+    "dman_la1.rom": {
+      "filename": "dman_la1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm_u2_s.l1": {
+      "filename": "dm_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "dm_lx3": {
+    "dm_u3_s.l2": {
+      "filename": "dm_u3_s.l2",
+      "type": "sound"
+    },
+    "dm_u6_s.l2": {
+      "filename": "dm_u6_s.l2",
+      "type": "sound"
+    },
+    "dman_lx3.rom": {
+      "filename": "dman_lx3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm_u7_s.l2": {
+      "filename": "dm_u7_s.l2",
+      "type": "sound"
+    },
+    "dm_u2_s.l2": {
+      "filename": "dm_u2_s.l2",
+      "type": "sound"
+    },
+    "dm_u4_s.l2": {
+      "filename": "dm_u4_s.l2",
+      "type": "sound"
+    },
+    "dm_u5_s.l2": {
+      "filename": "dm_u5_s.l2",
+      "type": "sound"
+    }
+  },
+  "dm_lx4": {
+    "dm_u3_s.l2": {
+      "filename": "dm_u3_s.l2",
+      "type": "sound"
+    },
+    "dm_u6_s.l2": {
+      "filename": "dm_u6_s.l2",
+      "type": "sound"
+    },
+    "dm_u7_s.l2": {
+      "filename": "dm_u7_s.l2",
+      "type": "sound"
+    },
+    "dm_u2_s.l2": {
+      "filename": "dm_u2_s.l2",
+      "type": "sound"
+    },
+    "dm_u4_s.l2": {
+      "filename": "dm_u4_s.l2",
+      "type": "sound"
+    },
+    "dm_u5_s.l2": {
+      "filename": "dm_u5_s.l2",
+      "type": "sound"
+    },
+    "dman_lx4.rom": {
+      "filename": "dman_lx4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "dm_pa2": {
+    "dm_u3_s.l2": {
+      "filename": "dm_u3_s.l2",
+      "type": "sound"
+    },
+    "dm_u6_s.l2": {
+      "filename": "dm_u6_s.l2",
+      "type": "sound"
+    },
+    "dm_u7_s.l2": {
+      "filename": "dm_u7_s.l2",
+      "type": "sound"
+    },
+    "dm_u2_s.l2": {
+      "filename": "dm_u2_s.l2",
+      "type": "sound"
+    },
+    "u6-pa2.rom": {
+      "filename": "u6-pa2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm_u4_s.l2": {
+      "filename": "dm_u4_s.l2",
+      "type": "sound"
+    },
+    "dm_u5_s.l2": {
+      "filename": "dm_u5_s.l2",
+      "type": "sound"
+    }
+  },
+  "dm_px5": {
+    "dm_u3_s.l2": {
+      "filename": "dm_u3_s.l2",
+      "type": "sound"
+    },
+    "dm_u6_s.l2": {
+      "filename": "dm_u6_s.l2",
+      "type": "sound"
+    },
+    "dman_px5.rom": {
+      "filename": "dman_px5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dm_u7_s.l2": {
+      "filename": "dm_u7_s.l2",
+      "type": "sound"
+    },
+    "dm_u2_s.l2": {
+      "filename": "dm_u2_s.l2",
+      "type": "sound"
+    },
+    "dm_u4_s.l2": {
+      "filename": "dm_u4_s.l2",
+      "type": "sound"
+    },
+    "dm_u5_s.l2": {
+      "filename": "dm_u5_s.l2",
+      "type": "sound"
+    }
+  },
+  "spstn_l5": {
+    "sstn_u22.l1": {
+      "filename": "sstn_u22.l1",
+      "type": "sound"
+    },
+    "sstn_u27.l5": {
+      "filename": "sstn_u27.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "sstn_u26.l5": {
+      "filename": "sstn_u26.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "sstn_u21.l1": {
+      "filename": "sstn_u21.l1",
+      "type": "sound"
+    },
+    "sstn_u4.l1": {
+      "filename": "sstn_u4.l1",
+      "type": "sound"
+    }
+  },
+  "ij4_116g": {
+    "indy0116g.bin": {
+      "filename": "indy0116g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "barbwire": {
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "orbitofp": {
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpo1_u2.716": {
+      "filename": "fpo1_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "fpo1_u5.716": {
+      "filename": "fpo1_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "orbitor1": {
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "orbitora": {
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "o1v3_u1.716": {
+      "filename": "o1v3_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "o1v3_u5.716": {
+      "filename": "o1v3_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "orbitorb": {
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "o1v4u5.716": {
+      "filename": "o1v4u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "o1v4u2.716": {
+      "filename": "o1v4u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "o1v4u1.716": {
+      "filename": "o1v4u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "bbb109": {
+    "u1h_b19.bin": {
+      "filename": "u1h_b19.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u31_b17.bin": {
+      "filename": "u31_b17.bin",
+      "type": "sound"
+    },
+    "u1l_b19.bin": {
+      "filename": "u1l_b19.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u2l_b17.bin": {
+      "filename": "u2l_b17.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_b17.bin": {
+      "filename": "u28_b17.bin",
+      "type": "sound"
+    },
+    "u2h_b17.bin": {
+      "filename": "u2h_b17.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u30_b17.bin": {
+      "filename": "u30_b17.bin",
+      "type": "sound"
+    },
+    "u29_b17.bin": {
+      "filename": "u29_b17.bin",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    }
+  },
+  "iomoon": {
+    "v1_3_02.bin": {
+      "filename": "v1_3_02.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "v1_3_03.bin": {
+      "filename": "v1_3_03.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "v1_3_05.bin": {
+      "filename": "v1_3_05.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "v1_3_01.bin": {
+      "filename": "v1_3_01.bin",
+      "type": "main",
+      "romType": "sleic"
+    },
+    "v1_3_04.bin": {
+      "filename": "v1_3_04.bin",
+      "type": "main",
+      "romType": "sleic"
+    }
+  },
+  "gw_pc": {
+    "u6-p-c.rom": {
+      "filename": "u6-p-c.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "u18-sp1.rom": {
+      "filename": "u18-sp1.rom",
+      "type": "sound"
+    }
+  },
+  "csi_240": {
+    "csi_v2-4_a.bin": {
+      "filename": "CSI_V2-4_A.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bsv102": {
+    "u1h_v12.bin": {
+      "filename": "u1h_v12.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u1l_v12.bin": {
+      "filename": "u1l_v12.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_v11.bin": {
+      "filename": "u28_v11.bin",
+      "type": "sound"
+    },
+    "u29_v11.bin": {
+      "filename": "u29_v11.bin",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    }
+  },
+  "vegasgp": {
+    "140a.12": {
+      "filename": "140a.12",
+      "type": "main",
+      "romType": "gp"
+    },
+    "140b.13": {
+      "filename": "140b.13",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "wpt_112al": {
+    "wpt0112al.bin": {
+      "filename": "wpt0112al.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "godz_100": {
+    "gdzu37.100": {
+      "filename": "gdzu37.100",
+      "type": "sound"
+    },
+    "gdzcpu.100": {
+      "filename": "gdzcpu.100",
+      "type": "main",
+      "romType": "se"
+    },
+    "gdzu17.100": {
+      "filename": "gdzu17.100",
+      "type": "sound"
+    },
+    "gdzdspa.100": {
+      "filename": "gdzdspa.100",
+      "type": "dmd"
+    },
+    "gdzu7.100": {
+      "filename": "gdzu7.100",
+      "type": "sound"
+    },
+    "gdzu21.100": {
+      "filename": "gdzu21.100",
+      "type": "sound"
+    },
+    "gdzu36.100": {
+      "filename": "gdzu36.100",
+      "type": "sound"
+    }
+  },
+  "memlanfp": {
+    "fpmeml_6.716": {
+      "filename": "fpmeml_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fpmeml_2.716": {
+      "filename": "fpmeml_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "eballdp1": {
+    "ebd68701.1": {
+      "filename": "ebd68701.1",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-16_5.532": {
+      "filename": "838-16_5.532",
+      "type": "sound"
+    },
+    "720-61.u10": {
+      "filename": "720-61.U10",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-62.u14": {
+      "filename": "720-62.U14",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    },
+    "838-19.u12": {
+      "filename": "838-19.U12",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-63.u13": {
+      "filename": "720-63.U13",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "potc_113as": {
+    "potc0113as.bin": {
+      "filename": "potc0113as.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "antar": {
+    "antar09.bin": {
+      "filename": "antar09.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "antar11.bin": {
+      "filename": "antar11.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "antar10.bin": {
+      "filename": "antar10.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "antar08.bin": {
+      "filename": "antar08.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "trek_120": {
+    "trekcpu.120": {
+      "filename": "trekcpu.120",
+      "type": "main",
+      "romType": "de"
+    },
+    "trek.u17": {
+      "filename": "trek.u17",
+      "type": "sound"
+    },
+    "trek.u21": {
+      "filename": "trek.u21",
+      "type": "sound"
+    },
+    "trekdsp.106": {
+      "filename": "trekdsp.106",
+      "type": "dmd"
+    },
+    "trek.u7": {
+      "filename": "trek.u7",
+      "type": "sound"
+    }
+  },
+  "toppin": {
+    "snd_u8.bin": {
+      "filename": "snd_u8.BIN",
+      "type": "main"
+    },
+    "cpu_256.bin": {
+      "filename": "cpu_256.BIN",
+      "type": "main"
+    },
+    "snd_u9.bin": {
+      "filename": "snd_u9.BIN",
+      "type": "main"
+    },
+    "snd_u10.bin": {
+      "filename": "snd_u10.BIN",
+      "type": "main"
+    }
+  },
+  "avg_110": {
+    "avg_110.bin": {
+      "filename": "avg_110.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "evlfight": {
+    "evfg08.bin": {
+      "filename": "evfg08.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "evfg09.bin": {
+      "filename": "evfg09.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "evfg11.bin": {
+      "filename": "evfg11.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "evfg10.bin": {
+      "filename": "evfg10.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "torch": {
+    "438.cpu": {
+      "filename": "438.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "438.snd": {
+      "filename": "438.snd",
+      "type": "sound"
+    },
+    "6530sys1.bin": {
+      "filename": "6530sys1.bin",
+      "type": "sound"
+    }
+  },
+  "mbossy": {
+    "mb.u10": {
+      "filename": "mb.u10",
+      "type": "sound"
+    },
+    "mb.u9": {
+      "filename": "mb.u9",
+      "type": "sound"
+    }
+  },
+  "potc_300ai": {
+    "potc0300ai.bin": {
+      "filename": "potc0300ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "id4_201": {
+    "id4dspa.200": {
+      "filename": "id4dspa.200",
+      "type": "dmd"
+    },
+    "id4sdu17.400": {
+      "filename": "id4sdu17.400",
+      "type": "sound"
+    },
+    "id4cpu.201": {
+      "filename": "id4cpu.201",
+      "type": "main",
+      "romType": "se"
+    },
+    "id4sndu7.512": {
+      "filename": "id4sndu7.512",
+      "type": "sound"
+    },
+    "id4sdu21.400": {
+      "filename": "id4sdu21.400",
+      "type": "sound"
+    }
+  },
+  "tsptr_l3": {
+    "tran_u26.l3": {
+      "filename": "tran_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "tran_u22.l2": {
+      "filename": "tran_u22.l2",
+      "type": "sound"
+    },
+    "tran_u19.l2": {
+      "filename": "tran_u19.l2",
+      "type": "sound"
+    },
+    "tran_u27.l3": {
+      "filename": "tran_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "tran_u4.l2": {
+      "filename": "tran_u4.l2",
+      "type": "sound"
+    },
+    "tran_u21.l2": {
+      "filename": "tran_u21.l2",
+      "type": "sound"
+    },
+    "tran_u20.l2": {
+      "filename": "tran_u20.l2",
+      "type": "sound"
+    }
+  },
+  "lotr51": {
+    "lotrdspa.501": {
+      "filename": "lotrdspa.501",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.501": {
+      "filename": "lotrcpu.501",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "potc_600ai": {
+    "potc0600ai.bin": {
+      "filename": "potc0600ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "goldbalb": {
+    "gb_u4.532": {
+      "filename": "gb_u4.532",
+      "type": "sound"
+    },
+    "gold2732.u2": {
+      "filename": "gold2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "goldd7u6.bin": {
+      "filename": "goldd7u6.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "goldball": {
+    "gb_u4.532": {
+      "filename": "gb_u4.532",
+      "type": "sound"
+    },
+    "gold2732.u2": {
+      "filename": "gold2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "goldball.u6": {
+      "filename": "goldball.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "goldbaln": {
+    "gb_u4.532": {
+      "filename": "gb_u4.532",
+      "type": "sound"
+    },
+    "goldball.u6": {
+      "filename": "goldball.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "u2.532": {
+      "filename": "u2.532",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "jm_12b": {
+    "jm_u4_s.1_0": {
+      "filename": "jm_u4_s.1_0",
+      "type": "sound"
+    },
+    "jm_u2_s.1_0": {
+      "filename": "jm_u2_s.1_0",
+      "type": "sound"
+    },
+    "jm_u5_s.1_0": {
+      "filename": "jm_u5_s.1_0",
+      "type": "sound"
+    },
+    "jm_u3_s.1_0": {
+      "filename": "jm_u3_s.1_0",
+      "type": "sound"
+    },
+    "jm_u7_s.1_0": {
+      "filename": "jm_u7_s.1_0",
+      "type": "sound"
+    },
+    "john1_2b.rom": {
+      "filename": "JOHN1_2B.ROM",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jm_u6_s.1_0": {
+      "filename": "jm_u6_s.1_0",
+      "type": "sound"
+    },
+    "jm_u8_s.1_0": {
+      "filename": "jm_u8_s.1_0",
+      "type": "sound"
+    }
+  },
+  "jm_12r": {
+    "jm_u4_s.1_0": {
+      "filename": "jm_u4_s.1_0",
+      "type": "sound"
+    },
+    "jm_u2_s.1_0": {
+      "filename": "jm_u2_s.1_0",
+      "type": "sound"
+    },
+    "jm_u5_s.1_0": {
+      "filename": "jm_u5_s.1_0",
+      "type": "sound"
+    },
+    "jm_u3_s.1_0": {
+      "filename": "jm_u3_s.1_0",
+      "type": "sound"
+    },
+    "jm_u7_s.1_0": {
+      "filename": "jm_u7_s.1_0",
+      "type": "sound"
+    },
+    "jm_u6_s.1_0": {
+      "filename": "jm_u6_s.1_0",
+      "type": "sound"
+    },
+    "jm_u8_s.1_0": {
+      "filename": "jm_u8_s.1_0",
+      "type": "sound"
+    },
+    "john1_2r.rom": {
+      "filename": "john1_2r.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "term3l": {
+    "t3displ.400": {
+      "filename": "t3displ.400",
+      "type": "dmd"
+    },
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3cpu.400": {
+      "filename": "t3cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "hirol210": {
+    "hrccpu.210": {
+      "filename": "hrccpu.210",
+      "type": "main",
+      "romType": "se"
+    },
+    "hrsndu36.100": {
+      "filename": "hrsndu36.100",
+      "type": "sound"
+    },
+    "hrsndu17.100": {
+      "filename": "hrsndu17.100",
+      "type": "sound"
+    },
+    "hrcdispa.200": {
+      "filename": "hrcdispa.200",
+      "type": "dmd"
+    },
+    "hrsndu7.100": {
+      "filename": "hrsndu7.100",
+      "type": "sound"
+    },
+    "hrsndu21.100": {
+      "filename": "hrsndu21.100",
+      "type": "sound"
+    },
+    "hrsndu37.100": {
+      "filename": "hrsndu37.100",
+      "type": "sound"
+    }
+  },
+  "hirol_gr": {
+    "hrccpu.210": {
+      "filename": "hrccpu.210",
+      "type": "main",
+      "romType": "se"
+    },
+    "hrsndu36.100": {
+      "filename": "hrsndu36.100",
+      "type": "sound"
+    },
+    "hrcdispg.201": {
+      "filename": "hrcdispg.201",
+      "type": "dmd"
+    },
+    "hrsndu17.100": {
+      "filename": "hrsndu17.100",
+      "type": "sound"
+    },
+    "hrsndu7.100": {
+      "filename": "hrsndu7.100",
+      "type": "sound"
+    },
+    "hrsndu21.100": {
+      "filename": "hrsndu21.100",
+      "type": "sound"
+    },
+    "hrsndu37.100": {
+      "filename": "hrsndu37.100",
+      "type": "sound"
+    }
+  },
+  "wof_200": {
+    "wof0200a.bin": {
+      "filename": "wof0200a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "poto_a29": {
+    "potof7.rom": {
+      "filename": "potof7.rom",
+      "type": "sound"
+    },
+    "potof5.rom": {
+      "filename": "potof5.rom",
+      "type": "sound"
+    },
+    "potof6.rom": {
+      "filename": "potof6.rom",
+      "type": "sound"
+    },
+    "potoc5.2-9": {
+      "filename": "potoc5.2-9",
+      "type": "main",
+      "romType": "de"
+    },
+    "potob5.2-9": {
+      "filename": "potob5.2-9",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "poto_a32": {
+    "potof7.rom": {
+      "filename": "potof7.rom",
+      "type": "sound"
+    },
+    "potof5.rom": {
+      "filename": "potof5.rom",
+      "type": "sound"
+    },
+    "potof6.rom": {
+      "filename": "potof6.rom",
+      "type": "sound"
+    },
+    "potob5.3-2": {
+      "filename": "potob5.3-2",
+      "type": "main",
+      "romType": "de"
+    },
+    "potoc5.3-2": {
+      "filename": "potoc5.3-2",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "sman_210af": {
+    "spd_v2-1_ef.bin": {
+      "filename": "spd_v2-1_ef.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_125": {
+    "twd_125.bin": {
+      "filename": "twd_125.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "simp_a20": {
+    "simpf6.rom": {
+      "filename": "simpf6.rom",
+      "type": "sound"
+    },
+    "simpa2-0.c5": {
+      "filename": "simpa2-0.c5",
+      "type": "main",
+      "romType": "de"
+    },
+    "simpf7.rom": {
+      "filename": "simpf7.rom",
+      "type": "sound"
+    },
+    "simpf5.rom": {
+      "filename": "simpf5.rom",
+      "type": "sound"
+    },
+    "simpa2-0.b5": {
+      "filename": "simpa2-0.b5",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "simp_a27": {
+    "simpf6.rom": {
+      "filename": "simpf6.rom",
+      "type": "sound"
+    },
+    "simpc5.2-7": {
+      "filename": "simpc5.2-7",
+      "type": "main",
+      "romType": "de"
+    },
+    "simpb5.2-7": {
+      "filename": "simpb5.2-7",
+      "type": "main",
+      "romType": "de"
+    },
+    "simpf7.rom": {
+      "filename": "simpf7.rom",
+      "type": "sound"
+    },
+    "simpf5.rom": {
+      "filename": "simpf5.rom",
+      "type": "sound"
+    }
+  },
+  "amazonh3": {
+    "684d-cpu.rom": {
+      "filename": "684d-cpu.rom",
+      "type": "main",
+      "romType": "gts"
+    },
+    "684d-snd.rom": {
+      "filename": "684d-snd.rom",
+      "type": "sound"
+    }
+  },
+  "wpt_140al": {
+    "wpt1400al.bin": {
+      "filename": "wpt1400al.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "robotfp": {
+    "robot_e.snd": {
+      "filename": "robot_e.snd",
+      "type": "sound"
+    },
+    "robot_g.snd": {
+      "filename": "robot_g.snd",
+      "type": "sound"
+    },
+    "robotfp.ic2": {
+      "filename": "robotfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_d.snd": {
+      "filename": "robot_d.snd",
+      "type": "sound"
+    },
+    "robotfp.ic1": {
+      "filename": "robotfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "robotifp": {
+    "robot_it.1e": {
+      "filename": "robot_it.1e",
+      "type": "sound"
+    },
+    "robot_it.1g": {
+      "filename": "robot_it.1g",
+      "type": "sound"
+    },
+    "robotfp.ic2": {
+      "filename": "robotfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_it.1d": {
+      "filename": "robot_it.1d",
+      "type": "sound"
+    },
+    "robotfp.ic1": {
+      "filename": "robotfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "jokrz_l3": {
+    "jokeru22.l1": {
+      "filename": "jokeru22.l1",
+      "type": "sound"
+    },
+    "u27-l3.rom": {
+      "filename": "u27-l3.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "u26-l3.rom": {
+      "filename": "u26-l3.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "jokeru21.l1": {
+      "filename": "jokeru21.l1",
+      "type": "sound"
+    },
+    "jokeru5.l2": {
+      "filename": "jokeru5.l2",
+      "type": "sound"
+    }
+  },
+  "jokrz_l6": {
+    "jokeru22.l1": {
+      "filename": "jokeru22.l1",
+      "type": "sound"
+    },
+    "jokeru27.l6": {
+      "filename": "jokeru27.l6",
+      "type": "main",
+      "romType": "s11"
+    },
+    "jokeru21.l1": {
+      "filename": "jokeru21.l1",
+      "type": "sound"
+    },
+    "jokeru26.l6": {
+      "filename": "jokeru26.l6",
+      "type": "main",
+      "romType": "s11"
+    },
+    "jokeru5.l2": {
+      "filename": "jokeru5.l2",
+      "type": "sound"
+    }
+  },
+  "cosflash": {
+    "834-20_2.532": {
+      "filename": "834-20_2.532",
+      "type": "sound"
+    },
+    "cf6d.532": {
+      "filename": "cf6d.532",
+      "type": "main",
+      "romType": "by"
+    },
+    "834-18_5.532": {
+      "filename": "834-18_5.532",
+      "type": "sound"
+    },
+    "cf2d.532": {
+      "filename": "cf2d.532",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "flashgdp": {
+    "834-20_2.532": {
+      "filename": "834-20_2.532",
+      "type": "sound"
+    },
+    "xxx-xx.u12": {
+      "filename": "xxx-xx.U12",
+      "type": "main"
+    },
+    "834-18_5.532": {
+      "filename": "834-18_5.532",
+      "type": "sound"
+    },
+    "xxx-xx.u11": {
+      "filename": "xxx-xx.U11",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "fireactd": {
+    "fired1.bin": {
+      "filename": "fired1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "fired2.bin": {
+      "filename": "fired2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "fired_s1.bin": {
+      "filename": "fired_s1.bin",
+      "type": "sound"
+    },
+    "fired_s2.bin": {
+      "filename": "fired_s2.bin",
+      "type": "sound"
+    },
+    "fired4.bin": {
+      "filename": "fired4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "fired_s3.bin": {
+      "filename": "fired_s3.bin",
+      "type": "sound"
+    },
+    "fired3.bin": {
+      "filename": "fired3.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "wpt_112g": {
+    "wpt0112g.bin": {
+      "filename": "wpt0112g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "roadrunr": {
+    "3000.716": {
+      "filename": "3000.716",
+      "type": "main",
+      "romType": "atari"
+    },
+    "0000.716": {
+      "filename": "0000.716",
+      "type": "main",
+      "romType": "atari"
+    },
+    "3800.716": {
+      "filename": "3800.716",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "strngsci": {
+    "cpu_u2.128": {
+      "filename": "cpu_u2.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u3.128": {
+      "filename": "cpu_u3.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "sound_u7.256": {
+      "filename": "sound_u7.256",
+      "type": "sound"
+    }
+  },
+  "bbb108": {
+    "u31_b17.bin": {
+      "filename": "u31_b17.bin",
+      "type": "sound"
+    },
+    "u1l_b18.bin": {
+      "filename": "u1l_b18.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u1h_b18.bin": {
+      "filename": "u1h_b18.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u2l_b17.bin": {
+      "filename": "u2l_b17.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_b17.bin": {
+      "filename": "u28_b17.bin",
+      "type": "sound"
+    },
+    "u2h_b17.bin": {
+      "filename": "u2h_b17.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u30_b17.bin": {
+      "filename": "u30_b17.bin",
+      "type": "sound"
+    },
+    "u29_b17.bin": {
+      "filename": "u29_b17.bin",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    }
+  },
+  "mexico": {
+    "mex86_f.snd": {
+      "filename": "mex86_f.snd",
+      "type": "sound"
+    },
+    "mex86_2.lgc": {
+      "filename": "mex86_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mex86_1.lgc": {
+      "filename": "mex86_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "mex86_e.snd": {
+      "filename": "mex86_e.snd",
+      "type": "sound"
+    }
+  },
+  "gwarfare": {
+    "240a.716": {
+      "filename": "240a.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "240c.716": {
+      "filename": "240c.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "240b.716": {
+      "filename": "240b.716",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "bbh_140": {
+    "bbh140.bin": {
+      "filename": "bbh140.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bsv100r": {
+    "u1l_v10i.bin": {
+      "filename": "u1l_v10i.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u30_v10i.bin": {
+      "filename": "u30_v10i.bin",
+      "type": "sound"
+    },
+    "u28_v11.bin": {
+      "filename": "u28_v11.bin",
+      "type": "sound"
+    },
+    "u29_v11.bin": {
+      "filename": "u29_v11.bin",
+      "type": "sound"
+    },
+    "u1h_v10i.bin": {
+      "filename": "u1h_v10i.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    }
+  },
+  "spyhunta": {
+    "858-06_5.532": {
+      "filename": "858-06_5.532",
+      "type": "sound"
+    },
+    "858-11_2.732": {
+      "filename": "858-11_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "858-03_4.532": {
+      "filename": "858-03_4.532",
+      "type": "sound"
+    },
+    "858-01_2.532": {
+      "filename": "858-01_2.532",
+      "type": "sound"
+    },
+    "858-02_3.532": {
+      "filename": "858-02_3.532",
+      "type": "sound"
+    }
+  },
+  "vector": {
+    "858-06_5.532": {
+      "filename": "858-06_5.532",
+      "type": "sound"
+    },
+    "858-11_2.732": {
+      "filename": "858-11_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "858-03_4.532": {
+      "filename": "858-03_4.532",
+      "type": "sound"
+    },
+    "858-01_2.532": {
+      "filename": "858-01_2.532",
+      "type": "sound"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "858-02_3.532": {
+      "filename": "858-02_3.532",
+      "type": "sound"
+    }
+  },
+  "vectora": {
+    "858-06_5.532": {
+      "filename": "858-06_5.532",
+      "type": "sound"
+    },
+    "858-11_2.732": {
+      "filename": "858-11_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "858-03_4.532": {
+      "filename": "858-03_4.532",
+      "type": "sound"
+    },
+    "858-01_2.532": {
+      "filename": "858-01_2.532",
+      "type": "sound"
+    },
+    "858-02_3.532": {
+      "filename": "858-02_3.532",
+      "type": "sound"
+    }
+  },
+  "vectorb": {
+    "858-06_5.532": {
+      "filename": "858-06_5.532",
+      "type": "sound"
+    },
+    "vectoru2.732": {
+      "filename": "vectoru2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "858-03_4.532": {
+      "filename": "858-03_4.532",
+      "type": "sound"
+    },
+    "858-01_2.532": {
+      "filename": "858-01_2.532",
+      "type": "sound"
+    },
+    "858-02_3.532": {
+      "filename": "858-02_3.532",
+      "type": "sound"
+    },
+    "vectoru6.732": {
+      "filename": "vectoru6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "sman_142": {
+    "spd_1_42_e-beta.bin": {
+      "filename": "spd_1_42_e-beta.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_113g": {
+    "indy0113g.bin": {
+      "filename": "indy0113g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_1100af": {
+    "fg110af.bin": {
+      "filename": "fg110af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "im2_110": {
+    "im2_110.bin": {
+      "filename": "im2_110.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "futurspa": {
+    "781-09_2.716": {
+      "filename": "781-09_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "781-02_4.716": {
+      "filename": "781-02_4.716",
+      "type": "sound"
+    },
+    "781-07_1.716": {
+      "filename": "781-07_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "ironmafp": {
+    "fp_imu5.716": {
+      "filename": "fp_imu5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "hardbody": {
+    "cpu_u3.128": {
+      "filename": "cpu_u3.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u2.128": {
+      "filename": "cpu_u2.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "sound_u7.512": {
+      "filename": "sound_u7.512",
+      "type": "sound"
+    }
+  },
+  "bttf_g27": {
+    "bttfc5g.2-7": {
+      "filename": "bttfc5g.2-7",
+      "type": "main",
+      "romType": "de"
+    },
+    "bttfsf5.rom": {
+      "filename": "bttfsf5.rom",
+      "type": "sound"
+    },
+    "bttfsf6.rom": {
+      "filename": "bttfsf6.rom",
+      "type": "sound"
+    },
+    "bttfb5g.2-7": {
+      "filename": "bttfb5g.2-7",
+      "type": "main",
+      "romType": "de"
+    },
+    "bttfsf7.rom": {
+      "filename": "bttfsf7.rom",
+      "type": "sound"
+    }
+  },
+  "medusa": {
+    "845-01_3.532": {
+      "filename": "845-01_3.532",
+      "type": "sound"
+    },
+    "845-05_5.716": {
+      "filename": "845-05_5.716",
+      "type": "sound"
+    },
+    "845-02_4.532": {
+      "filename": "845-02_4.532",
+      "type": "sound"
+    },
+    "845-16_2.732": {
+      "filename": "845-16_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "medusaa": {
+    "845-01_3.532": {
+      "filename": "845-01_3.532",
+      "type": "sound"
+    },
+    "845-05_5.716": {
+      "filename": "845-05_5.716",
+      "type": "sound"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "845-02_4.532": {
+      "filename": "845-02_4.532",
+      "type": "sound"
+    },
+    "845-16_2.732": {
+      "filename": "845-16_2.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "medusaf": {
+    "845-01_3.532": {
+      "filename": "845-01_3.532",
+      "type": "sound"
+    },
+    "845-05_5.716": {
+      "filename": "845-05_5.716",
+      "type": "sound"
+    },
+    "845-02_4.532": {
+      "filename": "845-02_4.532",
+      "type": "sound"
+    },
+    "845-16_2.732": {
+      "filename": "845-16_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "orbit1": {
+    "o1_ic14.snd": {
+      "filename": "o1_ic14.snd",
+      "type": "sound"
+    },
+    "o1_ic2.mpu": {
+      "filename": "o1_ic2.mpu",
+      "type": "main",
+      "romType": "hnk"
+    },
+    "o1_ic3.snd": {
+      "filename": "o1_ic3.snd",
+      "type": "sound"
+    },
+    "o1_ic3.mpu": {
+      "filename": "o1_ic3.mpu",
+      "type": "main",
+      "romType": "hnk"
+    }
+  },
+  "sman_192gf": {
+    "spd_1-92_gf.bin": {
+      "filename": "spd_1-92_gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_130al": {
+    "spd_1_30_es.bin": {
+      "filename": "spd_1_30_es.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "rotation": {
+    "rot-c117.dat": {
+      "filename": "rot-c117.dat",
+      "type": "main"
+    },
+    "rot-b117.dat": {
+      "filename": "rot-b117.dat",
+      "type": "main"
+    },
+    "rot-a117.dat": {
+      "filename": "rot-a117.dat",
+      "type": "main"
+    }
+  },
+  "shrky207": {
+    "ssdispa.201": {
+      "filename": "ssdispa.201",
+      "type": "dmd"
+    },
+    "sscpu.207": {
+      "filename": "sscpu.207",
+      "type": "main",
+      "romType": "se"
+    },
+    "sssndu36.100": {
+      "filename": "sssndu36.100",
+      "type": "sound"
+    },
+    "sssndu17.100": {
+      "filename": "sssndu17.100",
+      "type": "sound"
+    },
+    "sssndu21.100": {
+      "filename": "sssndu21.100",
+      "type": "sound"
+    },
+    "sssndu7.101": {
+      "filename": "sssndu7.101",
+      "type": "sound"
+    }
+  },
+  "shrkysht": {
+    "ssdispa.201": {
+      "filename": "ssdispa.201",
+      "type": "dmd"
+    },
+    "sscpu.211": {
+      "filename": "sscpu.211",
+      "type": "main",
+      "romType": "se"
+    },
+    "sssndu36.100": {
+      "filename": "sssndu36.100",
+      "type": "sound"
+    },
+    "sssndu17.100": {
+      "filename": "sssndu17.100",
+      "type": "sound"
+    },
+    "sssndu21.100": {
+      "filename": "sssndu21.100",
+      "type": "sound"
+    },
+    "sssndu7.101": {
+      "filename": "sssndu7.101",
+      "type": "sound"
+    }
+  },
+  "mtl_113h": {
+    "mtl113le.bin": {
+      "filename": "MTL113LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "pentacp2": {
+    "micro_2.bin": {
+      "filename": "Micro_2.bin",
+      "type": "main"
+    },
+    "micro_1.bin": {
+      "filename": "Micro_1.bin",
+      "type": "main"
+    },
+    "micro_3.bin": {
+      "filename": "Micro_3.bin",
+      "type": "main"
+    },
+    "micro_4.bin": {
+      "filename": "Micro_4.bin",
+      "type": "main"
+    }
+  },
+  "jokrpokr": {
+    "417.cpu": {
+      "filename": "417.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "smman": {
+    "742-20_1.716": {
+      "filename": "742-20_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-30_6.716": {
+      "filename": "720-30_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "742-18_2.716": {
+      "filename": "742-18_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "gs_l3": {
+    "gshw_u26.l3": {
+      "filename": "gshw_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gshw_u27.l3": {
+      "filename": "gshw_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gshw_u20.l1": {
+      "filename": "gshw_u20.l1",
+      "type": "sound"
+    },
+    "gshw_u19.l1": {
+      "filename": "gshw_u19.l1",
+      "type": "sound"
+    },
+    "gshw_u4.l2": {
+      "filename": "gshw_u4.l2",
+      "type": "sound"
+    }
+  },
+  "gs_l4": {
+    "gshw_u26.l3": {
+      "filename": "gshw_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gshw_u20.l1": {
+      "filename": "gshw_u20.l1",
+      "type": "sound"
+    },
+    "gshw_u19.l1": {
+      "filename": "gshw_u19.l1",
+      "type": "sound"
+    },
+    "u27-lu4.rom": {
+      "filename": "u27-lu4.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "gshw_u4.l2": {
+      "filename": "gshw_u4.l2",
+      "type": "sound"
+    }
+  },
+  "esha_la1": {
+    "u27-la1.rom": {
+      "filename": "u27-la1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u4.l1": {
+      "filename": "eshk_u4.l1",
+      "type": "sound"
+    },
+    "eshk_u22.l1": {
+      "filename": "eshk_u22.l1",
+      "type": "sound"
+    },
+    "u26-la1.rom": {
+      "filename": "u26-la1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u19.l1": {
+      "filename": "eshk_u19.l1",
+      "type": "sound"
+    },
+    "eshk_u21.l1": {
+      "filename": "eshk_u21.l1",
+      "type": "sound"
+    }
+  },
+  "speakesa": {
+    "877-03_2.732": {
+      "filename": "877-03_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "877-01_4.716": {
+      "filename": "877-01_4.716",
+      "type": "sound"
+    }
+  },
+  "speakesy": {
+    "877-03_2.732": {
+      "filename": "877-03_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "877-01_4.716": {
+      "filename": "877-01_4.716",
+      "type": "sound"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "ratfink": {
+    "star2732.u2": {
+      "filename": "star2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "3032d7.bin": {
+      "filename": "3032d7.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "startreb": {
+    "star2732.u2": {
+      "filename": "star2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "3032d7.bin": {
+      "filename": "3032d7.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wof_400i": {
+    "wof0400i.bin": {
+      "filename": "wof0400i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cntct_l1": {
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white2.716": {
+      "filename": "white2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white1.716": {
+      "filename": "white1.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "clas1812": {
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    }
+  },
+  "heavymtl": {
+    "hvymtl_b.bin": {
+      "filename": "hvymtl_b.bin",
+      "type": "main"
+    },
+    "hvymtl_c.bin": {
+      "filename": "hvymtl_c.bin",
+      "type": "main"
+    },
+    "hvymtl_s.bin": {
+      "filename": "hvymtl_s.bin",
+      "type": "main"
+    }
+  },
+  "mav_401": {
+    "mavdsar0.401": {
+      "filename": "mavdsar0.401",
+      "type": "dmd"
+    },
+    "mavu7.dat": {
+      "filename": "mavu7.dat",
+      "type": "sound"
+    },
+    "mavcpua.404": {
+      "filename": "mavcpua.404",
+      "type": "main",
+      "romType": "de"
+    },
+    "mavu21.dat": {
+      "filename": "mavu21.dat",
+      "type": "sound"
+    },
+    "mavdsar3.401": {
+      "filename": "mavdsar3.401",
+      "type": "dmd"
+    },
+    "mavu17.dat": {
+      "filename": "mavu17.dat",
+      "type": "sound"
+    }
+  },
+  "gpr340i": {
+    "gpcpui.340": {
+      "filename": "gpcpui.340",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpdspi.303": {
+      "filename": "gpdspi.303",
+      "type": "dmd"
+    },
+    "gpsndi.u7": {
+      "filename": "gpsndi.u7",
+      "type": "sound"
+    },
+    "gpsndi.u17": {
+      "filename": "gpsndi.u17",
+      "type": "sound"
+    },
+    "gpsndi.u37": {
+      "filename": "gpsndi.u37",
+      "type": "sound"
+    },
+    "gpsndi.u21": {
+      "filename": "gpsndi.u21",
+      "type": "sound"
+    },
+    "gpsndi.u36": {
+      "filename": "gpsndi.u36",
+      "type": "sound"
+    }
+  },
+  "xmen_122h": {
+    "xmen_122h.bin": {
+      "filename": "xmen_122h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "leking": {
+    "jeutel2-sound-v.bin": {
+      "filename": "Jeutel2-Sound-V.bin",
+      "type": "main"
+    },
+    "jeutel2-game-m.bin": {
+      "filename": "Jeutel2-Game-M.bin",
+      "type": "main"
+    },
+    "jeutel2-sound-par.bin": {
+      "filename": "Jeutel2-Sound-PAR.bin",
+      "type": "main"
+    },
+    "jeutel2-game-v.bin": {
+      "filename": "Jeutel2-Game-V.bin",
+      "type": "main"
+    }
+  },
+  "eatpm_4g": {
+    "elvi_u27.l4": {
+      "filename": "elvi_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u20.l1": {
+      "filename": "elvi_u20.l1",
+      "type": "sound"
+    },
+    "u26-lg4.rom": {
+      "filename": "u26-lg4.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u21.l1": {
+      "filename": "elvi_u21.l1",
+      "type": "sound"
+    },
+    "elvi_u19.l1": {
+      "filename": "elvi_u19.l1",
+      "type": "sound"
+    },
+    "elvi_u4.l1": {
+      "filename": "elvi_u4.l1",
+      "type": "sound"
+    },
+    "elvi_u22.l1": {
+      "filename": "elvi_u22.l1",
+      "type": "sound"
+    }
+  },
+  "eatpm_4u": {
+    "elvi_u27.l4": {
+      "filename": "elvi_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u20.l1": {
+      "filename": "elvi_u20.l1",
+      "type": "sound"
+    },
+    "u26-lu4.rom": {
+      "filename": "u26-lu4.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u21.l1": {
+      "filename": "elvi_u21.l1",
+      "type": "sound"
+    },
+    "elvi_u19.l1": {
+      "filename": "elvi_u19.l1",
+      "type": "sound"
+    },
+    "elvi_u4.l1": {
+      "filename": "elvi_u4.l1",
+      "type": "sound"
+    },
+    "elvi_u22.l1": {
+      "filename": "elvi_u22.l1",
+      "type": "sound"
+    }
+  },
+  "comet_l4": {
+    "cpu_u20.128": {
+      "filename": "cpu_u20.128",
+      "type": "main",
+      "romType": "s9"
+    },
+    "spch_u7.732": {
+      "filename": "spch_u7.732",
+      "type": "sound"
+    },
+    "spch_u6.732": {
+      "filename": "spch_u6.732",
+      "type": "sound"
+    },
+    "spch_u5.732": {
+      "filename": "spch_u5.732",
+      "type": "sound"
+    },
+    "spch_u4.732": {
+      "filename": "spch_u4.732",
+      "type": "sound"
+    },
+    "cpu_u49.128": {
+      "filename": "cpu_u49.128",
+      "type": "sound"
+    }
+  },
+  "gpr350i": {
+    "gpdspi.303": {
+      "filename": "gpdspi.303",
+      "type": "dmd"
+    },
+    "gpsndi.u7": {
+      "filename": "gpsndi.u7",
+      "type": "sound"
+    },
+    "gpcpui.350": {
+      "filename": "gpcpui.350",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndi.u17": {
+      "filename": "gpsndi.u17",
+      "type": "sound"
+    },
+    "gpsndi.u37": {
+      "filename": "gpsndi.u37",
+      "type": "sound"
+    },
+    "gpsndi.u21": {
+      "filename": "gpsndi.u21",
+      "type": "sound"
+    },
+    "gpsndi.u36": {
+      "filename": "gpsndi.u36",
+      "type": "sound"
+    }
+  },
+  "gpr352i": {
+    "gpdspi.303": {
+      "filename": "gpdspi.303",
+      "type": "dmd"
+    },
+    "gpsndi.u7": {
+      "filename": "gpsndi.u7",
+      "type": "sound"
+    },
+    "gpsndi.u17": {
+      "filename": "gpsndi.u17",
+      "type": "sound"
+    },
+    "gpcpui.352": {
+      "filename": "gpcpui.352",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndi.u37": {
+      "filename": "gpsndi.u37",
+      "type": "sound"
+    },
+    "gpsndi.u21": {
+      "filename": "gpsndi.u21",
+      "type": "sound"
+    },
+    "gpsndi.u36": {
+      "filename": "gpsndi.u36",
+      "type": "sound"
+    }
+  },
+  "futurspb": {
+    "781-02_4.716": {
+      "filename": "781-02_4.716",
+      "type": "sound"
+    },
+    "fspa2732.u2": {
+      "filename": "fspa2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "comet_l5": {
+    "spch_u7.732": {
+      "filename": "spch_u7.732",
+      "type": "sound"
+    },
+    "spch_u6.732": {
+      "filename": "spch_u6.732",
+      "type": "sound"
+    },
+    "spch_u5.732": {
+      "filename": "spch_u5.732",
+      "type": "sound"
+    },
+    "spch_u4.732": {
+      "filename": "spch_u4.732",
+      "type": "sound"
+    },
+    "cpu_u20.l5": {
+      "filename": "cpu_u20.l5",
+      "type": "main",
+      "romType": "s9"
+    },
+    "cpu_u49.128": {
+      "filename": "cpu_u49.128",
+      "type": "sound"
+    }
+  },
+  "nmoves": {
+    "nmovsp1.764": {
+      "filename": "nmovsp1.764",
+      "type": "sound"
+    },
+    "nmovdrom.256": {
+      "filename": "nmovdrom.256",
+      "type": "sound"
+    },
+    "nmovsp2.732": {
+      "filename": "nmovsp2.732",
+      "type": "sound"
+    },
+    "nmovyrom.256": {
+      "filename": "nmovyrom.256",
+      "type": "sound"
+    }
+  },
+  "sttng_x7": {
+    "ngs_u3.rom": {
+      "filename": "ngs_u3.rom",
+      "type": "sound"
+    },
+    "ngs_u5.rom": {
+      "filename": "ngs_u5.rom",
+      "type": "sound"
+    },
+    "trek_x7.rom": {
+      "filename": "trek_x7.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ngs_u4.rom": {
+      "filename": "ngs_u4.rom",
+      "type": "sound"
+    },
+    "ng_u8_s.l1": {
+      "filename": "ng_u8_s.l1",
+      "type": "sound"
+    },
+    "ngs_u7.rom": {
+      "filename": "ngs_u7.rom",
+      "type": "sound"
+    },
+    "ngs_u6.rom": {
+      "filename": "ngs_u6.rom",
+      "type": "sound"
+    },
+    "ngs_u2.rom": {
+      "filename": "ngs_u2.rom",
+      "type": "sound"
+    }
+  },
+  "chance": {
+    "chance_c.bin": {
+      "filename": "chance_c.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "chance_a.bin": {
+      "filename": "chance_a.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "chance_b.bin": {
+      "filename": "chance_b.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "titan": {
+    "titan_s1.bin": {
+      "filename": "titan_s1.bin",
+      "type": "sound"
+    },
+    "titan_s2.bin": {
+      "filename": "titan_s2.bin",
+      "type": "sound"
+    },
+    "titan1.bin": {
+      "filename": "titan1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "titan3.bin": {
+      "filename": "titan3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "titan2.bin": {
+      "filename": "titan2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "titan4.bin": {
+      "filename": "titan4.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "cv_11": {
+    "s6v0_4.rom": {
+      "filename": "s6v0_4.rom",
+      "type": "sound"
+    },
+    "s2v1_0.rom": {
+      "filename": "s2v1_0.rom",
+      "type": "sound"
+    },
+    "s5v0_4.rom": {
+      "filename": "s5v0_4.rom",
+      "type": "sound"
+    },
+    "s3v0_4.rom": {
+      "filename": "s3v0_4.rom",
+      "type": "sound"
+    },
+    "s4v0_4.rom": {
+      "filename": "s4v0_4.rom",
+      "type": "sound"
+    },
+    "g11_110.rom": {
+      "filename": "g11_110.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "cv_13": {
+    "s6v0_4.rom": {
+      "filename": "s6v0_4.rom",
+      "type": "sound"
+    },
+    "cv_g11.1_3": {
+      "filename": "cv_g11.1_3",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "s2v1_0.rom": {
+      "filename": "s2v1_0.rom",
+      "type": "sound"
+    },
+    "s5v0_4.rom": {
+      "filename": "s5v0_4.rom",
+      "type": "sound"
+    },
+    "s3v0_4.rom": {
+      "filename": "s3v0_4.rom",
+      "type": "sound"
+    },
+    "s4v0_4.rom": {
+      "filename": "s4v0_4.rom",
+      "type": "sound"
+    }
+  },
+  "cv_14": {
+    "s6v0_4.rom": {
+      "filename": "s6v0_4.rom",
+      "type": "sound"
+    },
+    "s2v1_0.rom": {
+      "filename": "s2v1_0.rom",
+      "type": "sound"
+    },
+    "cirq_14.rom": {
+      "filename": "cirq_14.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "s5v0_4.rom": {
+      "filename": "s5v0_4.rom",
+      "type": "sound"
+    },
+    "s3v0_4.rom": {
+      "filename": "s3v0_4.rom",
+      "type": "sound"
+    },
+    "s4v0_4.rom": {
+      "filename": "s4v0_4.rom",
+      "type": "sound"
+    }
+  },
+  "cv_20hc": {
+    "s6v0_4.rom": {
+      "filename": "s6v0_4.rom",
+      "type": "sound"
+    },
+    "s2v1_0.rom": {
+      "filename": "s2v1_0.rom",
+      "type": "sound"
+    },
+    "s5v0_4.rom": {
+      "filename": "s5v0_4.rom",
+      "type": "sound"
+    },
+    "s3v0_4.rom": {
+      "filename": "s3v0_4.rom",
+      "type": "sound"
+    },
+    "cv200hc.rom": {
+      "filename": "cv200hc.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "s4v0_4.rom": {
+      "filename": "s4v0_4.rom",
+      "type": "sound"
+    }
+  },
+  "splitsec": {
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "ttt_10": {
+    "ttt_s3.rom": {
+      "filename": "ttt_s3.rom",
+      "type": "sound"
+    },
+    "tikt1_0.rom": {
+      "filename": "tikt1_0.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ttt_s2.rom": {
+      "filename": "ttt_s2.rom",
+      "type": "sound"
+    }
+  },
+  "csi_103": {
+    "csi103a.bin": {
+      "filename": "csi103a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "drac_l1": {
+    "dracsnd.u18": {
+      "filename": "dracsnd.u18",
+      "type": "sound"
+    },
+    "dracsnd.u14": {
+      "filename": "dracsnd.u14",
+      "type": "sound"
+    },
+    "dracsnd.u15": {
+      "filename": "dracsnd.u15",
+      "type": "sound"
+    },
+    "dracu_l1.rom": {
+      "filename": "dracu_l1.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "sopr400i": {
+    "sopsndi.u21": {
+      "filename": "sopsndi.u21",
+      "type": "sound"
+    },
+    "sopsndi.u36": {
+      "filename": "sopsndi.u36",
+      "type": "sound"
+    },
+    "sopdspi.400": {
+      "filename": "sopdspi.400",
+      "type": "dmd"
+    },
+    "sopcpui.400": {
+      "filename": "sopcpui.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "sopsndi.u7": {
+      "filename": "sopsndi.u7",
+      "type": "sound"
+    },
+    "sopsndi.u37": {
+      "filename": "sopsndi.u37",
+      "type": "sound"
+    },
+    "sopsndi.u17": {
+      "filename": "sopsndi.u17",
+      "type": "sound"
+    }
+  },
+  "spooky": {
+    "spook_1.lgc": {
+      "filename": "spook_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spook_4.snd": {
+      "filename": "spook_4.snd",
+      "type": "sound"
+    },
+    "spook_e.snd": {
+      "filename": "spook_e.snd",
+      "type": "sound"
+    },
+    "spook_2.lgc": {
+      "filename": "spook_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spook_f.snd": {
+      "filename": "spook_f.snd",
+      "type": "sound"
+    },
+    "spook_6.snd": {
+      "filename": "spook_6.snd",
+      "type": "sound"
+    }
+  },
+  "spookyi": {
+    "spook_1.lgc": {
+      "filename": "spook_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spook_4.snd": {
+      "filename": "spook_4.snd",
+      "type": "sound"
+    },
+    "spook_2.lgc": {
+      "filename": "spook_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spook_f.snd": {
+      "filename": "spook_f.snd",
+      "type": "sound"
+    },
+    "spook_it.1e": {
+      "filename": "spook_it.1e",
+      "type": "sound"
+    },
+    "spook_6.snd": {
+      "filename": "spook_6.snd",
+      "type": "sound"
+    }
+  },
+  "bttf_a20": {
+    "bttfsf5.rom": {
+      "filename": "bttfsf5.rom",
+      "type": "sound"
+    },
+    "bttfsf6.rom": {
+      "filename": "bttfsf6.rom",
+      "type": "sound"
+    },
+    "bttfsf7.rom": {
+      "filename": "bttfsf7.rom",
+      "type": "sound"
+    },
+    "bttfc5.2-0": {
+      "filename": "bttfc5.2-0",
+      "type": "main",
+      "romType": "de"
+    },
+    "bttfb5.2-0": {
+      "filename": "bttfb5.2-0",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "agsoccer": {
+    "agscpu1r.18u": {
+      "filename": "agscpu1r.18u",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "ags_snd.v21": {
+      "filename": "ags_snd.v21",
+      "type": "sound"
+    },
+    "ags_voic.v12": {
+      "filename": "ags_voic.v12",
+      "type": "sound"
+    }
+  },
+  "gw_l1": {
+    "u18snd": {
+      "filename": "u18snd",
+      "type": "sound"
+    },
+    "gw_l1.u6": {
+      "filename": "gw_l1.u6",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "gw_l2": {
+    "u18snd": {
+      "filename": "u18snd",
+      "type": "sound"
+    },
+    "get_l2.u6": {
+      "filename": "get_l2.u6",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "gw_l3": {
+    "u18snd": {
+      "filename": "u18snd",
+      "type": "sound"
+    },
+    "get_l3.u6": {
+      "filename": "get_l3.u6",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "gw_l5": {
+    "u18snd": {
+      "filename": "u18snd",
+      "type": "sound"
+    },
+    "getaw_l5.rom": {
+      "filename": "getaw_l5.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "gpr400i": {
+    "gpsndi.u7": {
+      "filename": "gpsndi.u7",
+      "type": "sound"
+    },
+    "gpcpui.400": {
+      "filename": "gpcpui.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndi.u17": {
+      "filename": "gpsndi.u17",
+      "type": "sound"
+    },
+    "gpdspi.400": {
+      "filename": "gpdspi.400",
+      "type": "dmd"
+    },
+    "gpsndi.u37": {
+      "filename": "gpsndi.u37",
+      "type": "sound"
+    },
+    "gpsndi.u21": {
+      "filename": "gpsndi.u21",
+      "type": "sound"
+    },
+    "gpsndi.u36": {
+      "filename": "gpsndi.u36",
+      "type": "sound"
+    }
+  },
+  "gprixi": {
+    "gpsndi.u7": {
+      "filename": "gpsndi.u7",
+      "type": "sound"
+    },
+    "gpsndi.u17": {
+      "filename": "gpsndi.u17",
+      "type": "sound"
+    },
+    "gpdspi.400": {
+      "filename": "gpdspi.400",
+      "type": "dmd"
+    },
+    "gpsndi.u37": {
+      "filename": "gpsndi.u37",
+      "type": "sound"
+    },
+    "gpsndi.u21": {
+      "filename": "gpsndi.u21",
+      "type": "sound"
+    },
+    "gpcpui.450": {
+      "filename": "gpcpui.450",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsndi.u36": {
+      "filename": "gpsndi.u36",
+      "type": "sound"
+    }
+  },
+  "pinbalfp": {
+    "fppinb_2.716": {
+      "filename": "fppinb_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fppinb_6.716": {
+      "filename": "fppinb_6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "stingrfp": {
+    "fpstry_2.716": {
+      "filename": "fpstry_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fpstry_6.716": {
+      "filename": "fpstry_6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "jupk_513": {
+    "jpu17.dat": {
+      "filename": "jpu17.dat",
+      "type": "sound"
+    },
+    "jpu21.dat": {
+      "filename": "jpu21.dat",
+      "type": "sound"
+    },
+    "jpdspa.510": {
+      "filename": "jpdspa.510",
+      "type": "dmd"
+    },
+    "jpcpua.513": {
+      "filename": "jpcpua.513",
+      "type": "main",
+      "romType": "de"
+    },
+    "jpu7.dat": {
+      "filename": "jpu7.dat",
+      "type": "sound"
+    }
+  },
+  "jupk_600": {
+    "jpu17.dat": {
+      "filename": "JPU17.DAT",
+      "type": "sound"
+    },
+    "jpu21.dat": {
+      "filename": "JPU21.DAT",
+      "type": "sound"
+    },
+    "jpcpua.600": {
+      "filename": "JPCPUA.600",
+      "type": "main",
+      "romType": "de"
+    },
+    "jpdspa.600": {
+      "filename": "JPDSPA.600",
+      "type": "dmd"
+    },
+    "jpu7.dat": {
+      "filename": "JPU7.DAT",
+      "type": "sound"
+    }
+  },
+  "jupk_g51": {
+    "jpu17.dat": {
+      "filename": "jpu17.dat",
+      "type": "sound"
+    },
+    "jpdspg.501": {
+      "filename": "jpdspg.501",
+      "type": "dmd"
+    },
+    "jpu21.dat": {
+      "filename": "jpu21.dat",
+      "type": "sound"
+    },
+    "jpcpua.501": {
+      "filename": "jpcpua.501",
+      "type": "main",
+      "romType": "de"
+    },
+    "jpu7.dat": {
+      "filename": "jpu7.dat",
+      "type": "sound"
+    }
+  },
+  "ft_p4": {
+    "ft_p4.u6": {
+      "filename": "ft_p4.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ft_u18.l1": {
+      "filename": "ft_u18.l1",
+      "type": "sound"
+    }
+  },
+  "tftc_302": {
+    "tftcdspa.301": {
+      "filename": "tftcdspa.301",
+      "type": "dmd"
+    },
+    "sndu17.dat": {
+      "filename": "sndu17.dat",
+      "type": "sound"
+    },
+    "sndu7.dat": {
+      "filename": "sndu7.dat",
+      "type": "sound"
+    },
+    "sndu21.dat": {
+      "filename": "sndu21.dat",
+      "type": "sound"
+    },
+    "tftccpua.302": {
+      "filename": "tftccpua.302",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "tftc_303": {
+    "tftcdspa.301": {
+      "filename": "tftcdspa.301",
+      "type": "dmd"
+    },
+    "sndu17.dat": {
+      "filename": "sndu17.dat",
+      "type": "sound"
+    },
+    "sndu7.dat": {
+      "filename": "sndu7.dat",
+      "type": "sound"
+    },
+    "sndu21.dat": {
+      "filename": "sndu21.dat",
+      "type": "sound"
+    },
+    "tftccpua.303": {
+      "filename": "tftccpua.303",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "tz_92": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    },
+    "tzone9_2.rom": {
+      "filename": "tzone9_2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "tz_94ch": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    },
+    "tz_94ch.rom": {
+      "filename": "tz_94ch.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "tz_94h": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tz_94h.rom": {
+      "filename": "tz_94h.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    }
+  },
+  "tz_f19": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "ftz0_19.rom": {
+      "filename": "ftz0_19.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    }
+  },
+  "tz_f50": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    },
+    "ftz0_50.rom": {
+      "filename": "ftz0_50.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "tz_f86": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "ftz0_86.rom": {
+      "filename": "ftz0_86.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    }
+  },
+  "tz_h7": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    },
+    "u6-h7.040": {
+      "filename": "u6-h7.040",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "tz_h8": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    },
+    "tz_h8.u6": {
+      "filename": "tz_h8.u6",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "tz_ifpa": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "u6-ifpa.040": {
+      "filename": "u6-ifpa.040",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    }
+  },
+  "tz_l1": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "u6-l1.040": {
+      "filename": "u6-l1.040",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu18_l1.rom": {
+      "filename": "tzu18_l1.rom",
+      "type": "sound"
+    }
+  },
+  "tz_l3": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    },
+    "tz_l3.u6": {
+      "filename": "tz_l3.u6",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "tz_l4": {
+    "tzu15_l2.rom": {
+      "filename": "tzu15_l2.rom",
+      "type": "sound"
+    },
+    "tz_l4.u6": {
+      "filename": "tz_l4.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "tzu14_l2.rom": {
+      "filename": "tzu14_l2.rom",
+      "type": "sound"
+    },
+    "tzu18_l2.rom": {
+      "filename": "tzu18_l2.rom",
+      "type": "sound"
+    }
+  },
+  "kissp": {
+    "kissprot.u5": {
+      "filename": "KISSPROT.U5",
+      "type": "main"
+    },
+    "kiss8755.bin": {
+      "filename": "kiss8755.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "kissprot.u6": {
+      "filename": "KISSPROT.U6",
+      "type": "main",
+      "romType": "by"
+    },
+    "kissprot.u7": {
+      "filename": "KISSPROT.U7",
+      "type": "main"
+    }
+  },
+  "kissp2": {
+    "kissprot.u5": {
+      "filename": "kissprot.u5",
+      "type": "main"
+    },
+    "kissprot.u6": {
+      "filename": "kissprot.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "8755u8.dat": {
+      "filename": "8755u8.dat",
+      "type": "main",
+      "romType": "by"
+    },
+    "u7.dat": {
+      "filename": "u7.dat",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "flight2k": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "trn_160": {
+    "trn160.bin": {
+      "filename": "trn160.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "blackjcb": {
+    "blkj2732.u2": {
+      "filename": "blkj2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "72132fn.u6": {
+      "filename": "72132fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "lotr_gr5": {
+    "lotrdspg.500": {
+      "filename": "lotrdspg.500",
+      "type": "dmd"
+    },
+    "lotrcpu.500": {
+      "filename": "lotrcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "potc_600af": {
+    "potc0600af.bin": {
+      "filename": "potc0600af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bmf_at": {
+    "bfdrom0g.401": {
+      "filename": "bfdrom0g.401",
+      "type": "dmd"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3g.401": {
+      "filename": "bfdrom3g.401",
+      "type": "dmd"
+    },
+    "batnovh.401": {
+      "filename": "batnovh.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "bmf_ch": {
+    "bfdrom0g.401": {
+      "filename": "bfdrom0g.401",
+      "type": "dmd"
+    },
+    "batnovs.401": {
+      "filename": "batnovs.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3g.401": {
+      "filename": "bfdrom3g.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "bmf_de": {
+    "bfdrom0g.401": {
+      "filename": "bfdrom0g.401",
+      "type": "dmd"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3g.401": {
+      "filename": "bfdrom3g.401",
+      "type": "dmd"
+    },
+    "batnovg.401": {
+      "filename": "batnovg.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "sprk_103": {
+    "spku21.100": {
+      "filename": "spku21.100",
+      "type": "sound"
+    },
+    "spku7.101": {
+      "filename": "spku7.101",
+      "type": "sound"
+    },
+    "spdspa.101": {
+      "filename": "spdspa.101",
+      "type": "dmd"
+    },
+    "spkcpu.103": {
+      "filename": "spkcpu.103",
+      "type": "main",
+      "romType": "se"
+    },
+    "spku37.100": {
+      "filename": "spku37.100",
+      "type": "sound"
+    },
+    "spku17.100": {
+      "filename": "spku17.100",
+      "type": "sound"
+    },
+    "spku36.100": {
+      "filename": "spku36.100",
+      "type": "sound"
+    }
+  },
+  "mtl_116h": {
+    "mtl_116h.bin": {
+      "filename": "mtl_116h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "scram_tp": {
+    "scram_5.snd": {
+      "filename": "scram_5.snd",
+      "type": "sound"
+    },
+    "scram_2.lgc": {
+      "filename": "scram_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "scram_4.snd": {
+      "filename": "scram_4.snd",
+      "type": "sound"
+    },
+    "scram_2.snd": {
+      "filename": "scram_2.snd",
+      "type": "sound"
+    },
+    "scram_1.lgc": {
+      "filename": "scram_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "scram_3.snd": {
+      "filename": "scram_3.snd",
+      "type": "sound"
+    },
+    "scram_1.snd": {
+      "filename": "scram_1.snd",
+      "type": "sound"
+    }
+  },
+  "sockfp": {
+    "sound1.c": {
+      "filename": "sound1.c",
+      "type": "sound"
+    },
+    "sound3.f": {
+      "filename": "sound3.f",
+      "type": "sound"
+    },
+    "sound4.g": {
+      "filename": "sound4.g",
+      "type": "sound"
+    },
+    "socfp.ic1": {
+      "filename": "socfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "socfp.ic2": {
+      "filename": "socfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    }
+  },
+  "spookifp": {
+    "spook_4.snd": {
+      "filename": "spook_4.snd",
+      "type": "sound"
+    },
+    "spookyfp.ic2": {
+      "filename": "spookyfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spookyfp.ic1": {
+      "filename": "spookyfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spook_f.snd": {
+      "filename": "spook_f.snd",
+      "type": "sound"
+    },
+    "spook_it.1e": {
+      "filename": "spook_it.1e",
+      "type": "sound"
+    },
+    "spook_6.snd": {
+      "filename": "spook_6.snd",
+      "type": "sound"
+    }
+  },
+  "spookyfp": {
+    "spook_4.snd": {
+      "filename": "spook_4.snd",
+      "type": "sound"
+    },
+    "spook_e.snd": {
+      "filename": "spook_e.snd",
+      "type": "sound"
+    },
+    "spookyfp.ic2": {
+      "filename": "spookyfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spookyfp.ic1": {
+      "filename": "spookyfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "spook_f.snd": {
+      "filename": "spook_f.snd",
+      "type": "sound"
+    },
+    "spook_6.snd": {
+      "filename": "spook_6.snd",
+      "type": "sound"
+    }
+  },
+  "phnix_l1": {
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white2.716": {
+      "filename": "white2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white1.716": {
+      "filename": "white1.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "wof_500f": {
+    "wof0500f.bin": {
+      "filename": "wof0500f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_200": {
+    "spd_2-00_e.bin": {
+      "filename": "spd_2-00_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "jm_05r": {
+    "jm_u2_s.038": {
+      "filename": "jm_u2_s.038",
+      "type": "sound"
+    },
+    "jm_u6_s.038": {
+      "filename": "jm_u6_s.038",
+      "type": "sound"
+    },
+    "john0_5r.rom": {
+      "filename": "john0_5r.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "jm_u5_s.038": {
+      "filename": "jm_u5_s.038",
+      "type": "sound"
+    },
+    "jm_u3_s.038": {
+      "filename": "jm_u3_s.038",
+      "type": "sound"
+    },
+    "jm_u7_s.038": {
+      "filename": "jm_u7_s.038",
+      "type": "sound"
+    },
+    "jm_u4_s.038": {
+      "filename": "jm_u4_s.038",
+      "type": "sound"
+    },
+    "jm_u8_s.038": {
+      "filename": "jm_u8_s.038",
+      "type": "sound"
+    }
+  },
+  "fg_400ag": {
+    "fg400ag.bin": {
+      "filename": "fg400ag.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "spcgambl": {
+    "spcgamba.bin": {
+      "filename": "spcgamba.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "spcgambb.bin": {
+      "filename": "spcgambb.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "ngndshkb": {
+    "nitr2732.u2": {
+      "filename": "nitr2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "776-15_4.716": {
+      "filename": "776-15_4.716",
+      "type": "sound"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "gnr_300": {
+    "gnru7.snd": {
+      "filename": "gnru7.snd",
+      "type": "sound"
+    },
+    "gnru17.snd": {
+      "filename": "gnru17.snd",
+      "type": "sound"
+    },
+    "gnru37.snd": {
+      "filename": "gnru37.snd",
+      "type": "sound"
+    },
+    "gnrdispa.300": {
+      "filename": "gnrdispa.300",
+      "type": "dmd"
+    },
+    "gnru36.snd": {
+      "filename": "gnru36.snd",
+      "type": "sound"
+    },
+    "gnru21.snd": {
+      "filename": "gnru21.snd",
+      "type": "sound"
+    },
+    "gnrcpua.300": {
+      "filename": "gnrcpua.300",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "gnr_300f": {
+    "gnru7.snd": {
+      "filename": "gnru7.snd",
+      "type": "sound"
+    },
+    "gnru17.snd": {
+      "filename": "gnru17.snd",
+      "type": "sound"
+    },
+    "gnru37.snd": {
+      "filename": "gnru37.snd",
+      "type": "sound"
+    },
+    "gnru36.snd": {
+      "filename": "gnru36.snd",
+      "type": "sound"
+    },
+    "gnrdispf.300": {
+      "filename": "gnrdispf.300",
+      "type": "dmd"
+    },
+    "gnrcpuf.300": {
+      "filename": "gnrcpuf.300",
+      "type": "main",
+      "romType": "de"
+    },
+    "gnru21.snd": {
+      "filename": "gnru21.snd",
+      "type": "sound"
+    }
+  },
+  "vrkon_l1": {
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "jst_l2": {
+    "sound12.532": {
+      "filename": "sound12.532",
+      "type": "sound"
+    },
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "magicfp": {
+    "fpmagic6.716": {
+      "filename": "fpmagic6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fpmagic2.716": {
+      "filename": "fpmagic2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "lotr_sp7": {
+    "lotrdspl.700": {
+      "filename": "lotrdspl.700",
+      "type": "dmd"
+    },
+    "lotrlu36.100": {
+      "filename": "lotrlu36.100",
+      "type": "sound"
+    },
+    "lotrcpul.700": {
+      "filename": "lotrcpul.700",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrlu37.100": {
+      "filename": "lotrlu37.100",
+      "type": "sound"
+    },
+    "lotrlu7.100": {
+      "filename": "lotrlu7.100",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrlu17.100": {
+      "filename": "lotrlu17.100",
+      "type": "sound"
+    },
+    "lotrlu21.100": {
+      "filename": "lotrlu21.100",
+      "type": "sound"
+    }
+  },
+  "tmacfzac": {
+    "timemach.ic2": {
+      "filename": "timemach.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    },
+    "tmach_fr.1g": {
+      "filename": "tmach_fr.1g",
+      "type": "sound"
+    },
+    "tmach_fr.1d": {
+      "filename": "tmach_fr.1d",
+      "type": "sound"
+    },
+    "timemach.ic1": {
+      "filename": "timemach.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "tmachzac": {
+    "timemach.ic2": {
+      "filename": "timemach.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    },
+    "sound3.g": {
+      "filename": "sound3.g",
+      "type": "sound"
+    },
+    "timemach.ic1": {
+      "filename": "timemach.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound1.d": {
+      "filename": "sound1.d",
+      "type": "sound"
+    }
+  },
+  "lunelle": {
+    "lunel_s2.bin": {
+      "filename": "lunel_s2.bin",
+      "type": "sound"
+    },
+    "lunelle4.bin": {
+      "filename": "lunelle4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "lunelle3.bin": {
+      "filename": "lunelle3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "lunelle2.bin": {
+      "filename": "lunelle2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "lunel_s1.bin": {
+      "filename": "lunel_s1.bin",
+      "type": "sound"
+    },
+    "lunelle1.bin": {
+      "filename": "lunelle1.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "hglbtrtr": {
+    "750-08_2.716": {
+      "filename": "750-08_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    },
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "750-07_1.716": {
+      "filename": "750-07_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wpt_140f": {
+    "wpt1400f.bin": {
+      "filename": "wpt1400f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "break": {
+    "break3.cpu": {
+      "filename": "break3.cpu",
+      "type": "main"
+    },
+    "break1.cpu": {
+      "filename": "break1.cpu",
+      "type": "main"
+    },
+    "break2.cpu": {
+      "filename": "break2.cpu",
+      "type": "main"
+    }
+  },
+  "spcrider": {
+    "spacer.bin": {
+      "filename": "spacer.bin",
+      "type": "main",
+      "romType": "atari"
+    },
+    "spacel.bin": {
+      "filename": "spacel.bin",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "cpthook": {
+    "780.b": {
+      "filename": "780.b",
+      "type": "main",
+      "romType": "gp"
+    },
+    "780.a": {
+      "filename": "780.a",
+      "type": "main",
+      "romType": "gp"
+    },
+    "780.snd": {
+      "filename": "780.snd",
+      "type": "sound"
+    },
+    "780.c": {
+      "filename": "780.c",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "spaceinb": {
+    "inva2732.u2": {
+      "filename": "inva2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "792-07_4.716": {
+      "filename": "792-07_4.716",
+      "type": "sound"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "futrquen": {
+    "snd_u8.bin": {
+      "filename": "snd_u8.bin",
+      "type": "main"
+    },
+    "snd_u10.bin": {
+      "filename": "snd_u10.bin",
+      "type": "main"
+    },
+    "snd_u11.bin": {
+      "filename": "snd_u11.bin",
+      "type": "main"
+    },
+    "snd_u9.bin": {
+      "filename": "snd_u9.bin",
+      "type": "main"
+    },
+    "mpu_u2.bin": {
+      "filename": "mpu_u2.bin",
+      "type": "main"
+    }
+  },
+  "tftc_300": {
+    "tftccpua.300": {
+      "filename": "tftccpua.300",
+      "type": "main",
+      "romType": "de"
+    },
+    "sndu17.dat": {
+      "filename": "sndu17.dat",
+      "type": "sound"
+    },
+    "sndu7.dat": {
+      "filename": "sndu7.dat",
+      "type": "sound"
+    },
+    "sndu21.dat": {
+      "filename": "sndu21.dat",
+      "type": "sound"
+    },
+    "tftcdspa.300": {
+      "filename": "tftcdspa.300",
+      "type": "dmd"
+    }
+  },
+  "bonebstf": {
+    "prom1f.cpu": {
+      "filename": "prom1f.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom2f.cpu": {
+      "filename": "prom2f.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "drom2.snd": {
+      "filename": "drom2.snd",
+      "type": "sound"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    }
+  },
+  "eatpm_l1": {
+    "elvi_u20.l1": {
+      "filename": "elvi_u20.l1",
+      "type": "sound"
+    },
+    "elvi_u21.l1": {
+      "filename": "elvi_u21.l1",
+      "type": "sound"
+    },
+    "u26-la1.rom": {
+      "filename": "u26-la1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u19.l1": {
+      "filename": "elvi_u19.l1",
+      "type": "sound"
+    },
+    "elvi_u4.l1": {
+      "filename": "elvi_u4.l1",
+      "type": "sound"
+    },
+    "u27-la1.rom": {
+      "filename": "u27-la1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "elvi_u22.l1": {
+      "filename": "elvi_u22.l1",
+      "type": "sound"
+    }
+  },
+  "nudgeit": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "rab_130": {
+    "rab.u21": {
+      "filename": "rab.u21",
+      "type": "sound"
+    },
+    "rab.u17": {
+      "filename": "rab.u17",
+      "type": "sound"
+    },
+    "rab.u7": {
+      "filename": "rab.u7",
+      "type": "sound"
+    },
+    "rbdspa.130": {
+      "filename": "rbdspa.130",
+      "type": "dmd"
+    },
+    "rabcpua.130": {
+      "filename": "rabcpua.130",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "memlane": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wof_200i": {
+    "wof0200i.bin": {
+      "filename": "wof0200i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "gprix": {
+    "gpcpua.450": {
+      "filename": "gpcpua.450",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsnda.u17": {
+      "filename": "gpsnda.u17",
+      "type": "sound"
+    },
+    "gpsnda.u36": {
+      "filename": "gpsnda.u36",
+      "type": "sound"
+    },
+    "gpsnda.u21": {
+      "filename": "gpsnda.u21",
+      "type": "sound"
+    },
+    "gpsnda.u37": {
+      "filename": "gpsnda.u37",
+      "type": "sound"
+    },
+    "gpdspa.400": {
+      "filename": "gpdspa.400",
+      "type": "dmd"
+    },
+    "gpsnda.u7": {
+      "filename": "gpsnda.u7",
+      "type": "sound"
+    }
+  },
+  "pb_l3": {
+    "pbot_u21.l1": {
+      "filename": "pbot_u21.l1",
+      "type": "sound"
+    },
+    "pbot_u19.l1": {
+      "filename": "pbot_u19.l1",
+      "type": "sound"
+    },
+    "u27-l3.rom": {
+      "filename": "u27-l3.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pbot_u22.l1": {
+      "filename": "pbot_u22.l1",
+      "type": "sound"
+    },
+    "pbot_u4.l1": {
+      "filename": "pbot_u4.l1",
+      "type": "sound"
+    },
+    "u26-l2.rom": {
+      "filename": "u26-l2.rom",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "pb_l5": {
+    "pbot_u21.l1": {
+      "filename": "pbot_u21.l1",
+      "type": "sound"
+    },
+    "pbot_u19.l1": {
+      "filename": "pbot_u19.l1",
+      "type": "sound"
+    },
+    "pbot_u22.l1": {
+      "filename": "pbot_u22.l1",
+      "type": "sound"
+    },
+    "pbot_u26.l5": {
+      "filename": "pbot_u26.l5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pbot_u4.l1": {
+      "filename": "pbot_u4.l1",
+      "type": "sound"
+    },
+    "pbot_u27.l5": {
+      "filename": "pbot_u27.l5",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "pb_p4": {
+    "pbot_u21.l1": {
+      "filename": "pbot_u21.l1",
+      "type": "sound"
+    },
+    "pbot_u19.l1": {
+      "filename": "pbot_u19.l1",
+      "type": "sound"
+    },
+    "pbot_u22.l1": {
+      "filename": "pbot_u22.l1",
+      "type": "sound"
+    },
+    "pbot_u4.l1": {
+      "filename": "pbot_u4.l1",
+      "type": "sound"
+    },
+    "u26-l2.rom": {
+      "filename": "u26-l2.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "u27-p4.bin": {
+      "filename": "u27-p4.bin",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "specforc": {
+    "u13_snd.512": {
+      "filename": "u13_snd.512",
+      "type": "sound"
+    },
+    "u12_snd.512": {
+      "filename": "u12_snd.512",
+      "type": "sound"
+    },
+    "u14_snd.512": {
+      "filename": "u14_snd.512",
+      "type": "sound"
+    },
+    "u11_snd.512": {
+      "filename": "u11_snd.512",
+      "type": "sound"
+    },
+    "u2_revc.128": {
+      "filename": "u2_revc.128",
+      "type": "sound"
+    },
+    "u3_revc.128": {
+      "filename": "u3_revc.128",
+      "type": "sound"
+    }
+  },
+  "dd_l2": {
+    "dude_u4.l1": {
+      "filename": "dude_u4.l1",
+      "type": "sound"
+    },
+    "dude_u27.l2": {
+      "filename": "dude_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dude_u20.l1": {
+      "filename": "dude_u20.l1",
+      "type": "sound"
+    },
+    "dude_u26.l2": {
+      "filename": "dude_u26.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dude_u19.l1": {
+      "filename": "dude_u19.l1",
+      "type": "sound"
+    }
+  },
+  "dd_p06": {
+    "dude_u4.l1": {
+      "filename": "dude_u4.l1",
+      "type": "sound"
+    },
+    "dude_u20.l1": {
+      "filename": "dude_u20.l1",
+      "type": "sound"
+    },
+    "dude_u19.l1": {
+      "filename": "dude_u19.l1",
+      "type": "sound"
+    },
+    "u6-pa6.wpc": {
+      "filename": "u6-pa6.wpc",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "dd_p7": {
+    "dude_u4.l1": {
+      "filename": "dude_u4.l1",
+      "type": "sound"
+    },
+    "dude_u20.l1": {
+      "filename": "dude_u20.l1",
+      "type": "sound"
+    },
+    "dude_u6.p7": {
+      "filename": "dude_u6.p7",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "dude_u19.l1": {
+      "filename": "dude_u19.l1",
+      "type": "sound"
+    }
+  },
+  "term3": {
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3dispa.400": {
+      "filename": "t3dispa.400",
+      "type": "dmd"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3cpu.400": {
+      "filename": "t3cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "term3i": {
+    "t3100.u37": {
+      "filename": "t3100.u37",
+      "type": "sound"
+    },
+    "t3100.u21": {
+      "filename": "t3100.u21",
+      "type": "sound"
+    },
+    "t3100.u7": {
+      "filename": "t3100.u7",
+      "type": "sound"
+    },
+    "t3cpu.400": {
+      "filename": "t3cpu.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "t3100.u36": {
+      "filename": "t3100.u36",
+      "type": "sound"
+    },
+    "t3dispi.400": {
+      "filename": "t3dispi.400",
+      "type": "dmd"
+    },
+    "t3100.u17": {
+      "filename": "t3100.u17",
+      "type": "sound"
+    }
+  },
+  "black100": {
+    "u11.bin": {
+      "filename": "u11.bin",
+      "type": "sound"
+    },
+    "u2.cpu": {
+      "filename": "u2.cpu",
+      "type": "main",
+      "romType": "by"
+    },
+    "u12.bin": {
+      "filename": "u12.bin",
+      "type": "sound"
+    },
+    "u14.bin": {
+      "filename": "u14.bin",
+      "type": "sound"
+    },
+    "u3.cpu": {
+      "filename": "u3.cpu",
+      "type": "main",
+      "romType": "by"
+    },
+    "u13.bin": {
+      "filename": "u13.bin",
+      "type": "sound"
+    }
+  },
+  "black10s": {
+    "u11.bin": {
+      "filename": "u11.bin",
+      "type": "sound"
+    },
+    "u12.bin": {
+      "filename": "u12.bin",
+      "type": "sound"
+    },
+    "sb3.cpu": {
+      "filename": "sb3.cpu",
+      "type": "main",
+      "romType": "by"
+    },
+    "u14.bin": {
+      "filename": "u14.bin",
+      "type": "sound"
+    },
+    "sb2.cpu": {
+      "filename": "sb2.cpu",
+      "type": "main",
+      "romType": "by"
+    },
+    "u13.bin": {
+      "filename": "u13.bin",
+      "type": "sound"
+    }
+  },
+  "bay_d300": {
+    "bayrom0d.300": {
+      "filename": "bayrom0d.300",
+      "type": "dmd"
+    },
+    "bayw.u7": {
+      "filename": "bayw.u7",
+      "type": "sound"
+    },
+    "bayrom3d.300": {
+      "filename": "bayrom3d.300",
+      "type": "dmd"
+    },
+    "bayw.u17": {
+      "filename": "bayw.u17",
+      "type": "sound"
+    },
+    "bayw.u21": {
+      "filename": "bayw.u21",
+      "type": "sound"
+    },
+    "baycpud.300": {
+      "filename": "baycpud.300",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "bay_d400": {
+    "bayrom0d.300": {
+      "filename": "bayrom0d.300",
+      "type": "dmd"
+    },
+    "baycpud.400": {
+      "filename": "baycpud.400",
+      "type": "main",
+      "romType": "de"
+    },
+    "bayw.u7": {
+      "filename": "bayw.u7",
+      "type": "sound"
+    },
+    "bayrom3d.300": {
+      "filename": "bayrom3d.300",
+      "type": "dmd"
+    },
+    "bayw.u17": {
+      "filename": "bayw.u17",
+      "type": "sound"
+    },
+    "bayw.u21": {
+      "filename": "bayw.u21",
+      "type": "sound"
+    }
+  },
+  "monop233": {
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "mondsp-a.203": {
+      "filename": "mondsp-a.203",
+      "type": "dmd"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "moncpu.233": {
+      "filename": "moncpu.233",
+      "type": "main",
+      "romType": "se"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "monopole": {
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "moncpu.303": {
+      "filename": "moncpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "mondsp-a.301": {
+      "filename": "mondsp-a.301",
+      "type": "dmd"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "monopolf": {
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "moncpu.303": {
+      "filename": "moncpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "monopolg": {
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "moncpu.303": {
+      "filename": "moncpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "monopoli": {
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "moncpu.303": {
+      "filename": "moncpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "monopoll": {
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "moncpu.303": {
+      "filename": "moncpu.303",
+      "type": "main",
+      "romType": "se"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "monopoly": {
+    "mnsndu7.100": {
+      "filename": "mnsndu7.100",
+      "type": "sound"
+    },
+    "moncpu.320": {
+      "filename": "moncpu.320",
+      "type": "main",
+      "romType": "se"
+    },
+    "mondsp-a.301": {
+      "filename": "mondsp-a.301",
+      "type": "dmd"
+    },
+    "mnsndu36.100": {
+      "filename": "mnsndu36.100",
+      "type": "sound"
+    },
+    "mnsndu21.100": {
+      "filename": "mnsndu21.100",
+      "type": "sound"
+    },
+    "mnsndu17.100": {
+      "filename": "mnsndu17.100",
+      "type": "sound"
+    }
+  },
+  "esha_la3": {
+    "eshk_u4.l1": {
+      "filename": "eshk_u4.l1",
+      "type": "sound"
+    },
+    "eshk_u22.l1": {
+      "filename": "eshk_u22.l1",
+      "type": "sound"
+    },
+    "eshk_u26.l3": {
+      "filename": "eshk_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u27.l3": {
+      "filename": "eshk_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u19.l1": {
+      "filename": "eshk_u19.l1",
+      "type": "sound"
+    },
+    "eshk_u21.l1": {
+      "filename": "eshk_u21.l1",
+      "type": "sound"
+    }
+  },
+  "esha_lg1": {
+    "eshk_u4.l1": {
+      "filename": "eshk_u4.l1",
+      "type": "sound"
+    },
+    "eshk_u22.l1": {
+      "filename": "eshk_u22.l1",
+      "type": "sound"
+    },
+    "u26-lg1.rom": {
+      "filename": "u26-lg1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "u27-lg1.rom": {
+      "filename": "u27-lg1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u19.l1": {
+      "filename": "eshk_u19.l1",
+      "type": "sound"
+    },
+    "eshk_u21.l1": {
+      "filename": "eshk_u21.l1",
+      "type": "sound"
+    }
+  },
+  "esha_lg2": {
+    "eshk_u4.l1": {
+      "filename": "eshk_u4.l1",
+      "type": "sound"
+    },
+    "eshk_u22.l1": {
+      "filename": "eshk_u22.l1",
+      "type": "sound"
+    },
+    "u27-lg1.rom": {
+      "filename": "u27-lg1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "u26-lg2.rom": {
+      "filename": "u26-lg2.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u19.l1": {
+      "filename": "eshk_u19.l1",
+      "type": "sound"
+    },
+    "eshk_u21.l1": {
+      "filename": "eshk_u21.l1",
+      "type": "sound"
+    }
+  },
+  "esha_ma3": {
+    "eshk_u4.l1": {
+      "filename": "eshk_u4.l1",
+      "type": "sound"
+    },
+    "eshk_u22.l1": {
+      "filename": "eshk_u22.l1",
+      "type": "sound"
+    },
+    "eshk_u27.l3": {
+      "filename": "eshk_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u26.l3": {
+      "filename": "eshk_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "eshk_u19.l1": {
+      "filename": "eshk_u19.l1",
+      "type": "sound"
+    },
+    "eshk_u21.l1": {
+      "filename": "eshk_u21.l1",
+      "type": "sound"
+    }
+  },
+  "thndrman": {
+    "snd_1f.764": {
+      "filename": "snd_1f.764",
+      "type": "main"
+    },
+    "snd_1c.764": {
+      "filename": "snd_1c.764",
+      "type": "main"
+    },
+    "mpu_ic1.764": {
+      "filename": "mpu_ic1.764",
+      "type": "main"
+    },
+    "mpu_ic3.764": {
+      "filename": "mpu_ic3.764",
+      "type": "main"
+    }
+  },
+  "gladiatr": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    }
+  },
+  "viking": {
+    "802-06_2.716": {
+      "filename": "802-06_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "802-07-4.716": {
+      "filename": "802-07-4.716",
+      "type": "sound"
+    },
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "802-05_1.716": {
+      "filename": "802-05_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "strxt_it": {
+    "sxdispi.103": {
+      "filename": "sxdispi.103",
+      "type": "dmd"
+    },
+    "s00.u37": {
+      "filename": "s00.u37",
+      "type": "sound"
+    },
+    "s00.u36": {
+      "filename": "s00.u36",
+      "type": "sound"
+    },
+    "s00.u21": {
+      "filename": "s00.u21",
+      "type": "sound"
+    },
+    "s00.u17": {
+      "filename": "s00.u17",
+      "type": "sound"
+    },
+    "sxcpui.102": {
+      "filename": "sxcpui.102",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "polic_l2": {
+    "pfrc_u22.l1": {
+      "filename": "pfrc_u22.l1",
+      "type": "sound"
+    },
+    "pfrc_u27.l2": {
+      "filename": "pfrc_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pfrc_u26.l2": {
+      "filename": "pfrc_u26.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "pfrc_u21.l1": {
+      "filename": "pfrc_u21.l1",
+      "type": "sound"
+    },
+    "pfrc_u4.l2": {
+      "filename": "pfrc_u4.l2",
+      "type": "sound"
+    },
+    "pfrc_u19.l1": {
+      "filename": "pfrc_u19.l1",
+      "type": "sound"
+    }
+  },
+  "bk_l3": {
+    "speech5.532": {
+      "filename": "speech5.532",
+      "type": "sound"
+    },
+    "bkl3_26.bin": {
+      "filename": "bkl3_26.bin",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "bkl3_14.bin": {
+      "filename": "bkl3_14.bin",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech7.532": {
+      "filename": "speech7.532",
+      "type": "sound"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech4.532": {
+      "filename": "speech4.532",
+      "type": "sound"
+    },
+    "speech6.532": {
+      "filename": "speech6.532",
+      "type": "sound"
+    }
+  },
+  "kiko_a10": {
+    "kkvoi_f5.bin": {
+      "filename": "kkvoi_f5.bin",
+      "type": "sound"
+    },
+    "kkcpu_b5.bin": {
+      "filename": "kkcpu_b5.bin",
+      "type": "main",
+      "romType": "de"
+    },
+    "kkvoi_f4.bin": {
+      "filename": "kkvoi_f4.bin",
+      "type": "sound"
+    },
+    "kkcpu_c5.bin": {
+      "filename": "kkcpu_c5.bin",
+      "type": "main",
+      "romType": "de"
+    },
+    "kksnd_f7.bin": {
+      "filename": "kksnd_f7.bin",
+      "type": "sound"
+    }
+  },
+  "sonstwr2": {
+    "stw1i.bin": {
+      "filename": "stw1i.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "stw3i.bin": {
+      "filename": "stw3i.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "stw2i.bin": {
+      "filename": "stw2i.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "tmacffp": {
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    },
+    "timemfp.ic2": {
+      "filename": "timemfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "tmach_fr.1g": {
+      "filename": "tmach_fr.1g",
+      "type": "sound"
+    },
+    "tmach_fr.1d": {
+      "filename": "tmach_fr.1d",
+      "type": "sound"
+    },
+    "timemfp.ic1": {
+      "filename": "timemfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "tmachfp": {
+    "sound2.e": {
+      "filename": "sound2.e",
+      "type": "sound"
+    },
+    "timemfp.ic2": {
+      "filename": "timemfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "timemfp.ic1": {
+      "filename": "timemfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "sound3.g": {
+      "filename": "sound3.g",
+      "type": "sound"
+    },
+    "sound1.d": {
+      "filename": "sound1.d",
+      "type": "sound"
+    }
+  },
+  "baywatch": {
+    "bayrom3a.400": {
+      "filename": "bayrom3a.400",
+      "type": "dmd"
+    },
+    "bayrom0a.400": {
+      "filename": "bayrom0a.400",
+      "type": "dmd"
+    },
+    "baycpua.400": {
+      "filename": "baycpua.400",
+      "type": "main",
+      "romType": "de"
+    },
+    "bayw.u7": {
+      "filename": "bayw.u7",
+      "type": "sound"
+    },
+    "bayw.u17": {
+      "filename": "bayw.u17",
+      "type": "sound"
+    },
+    "bayw.u21": {
+      "filename": "bayw.u21",
+      "type": "sound"
+    }
+  },
+  "spacejmg": {
+    "jamdspg.300": {
+      "filename": "jamdspg.300",
+      "type": "dmd"
+    },
+    "spcjam.u36": {
+      "filename": "spcjam.u36",
+      "type": "sound"
+    },
+    "jamcpu.300": {
+      "filename": "jamcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "spcjam.u21": {
+      "filename": "spcjam.u21",
+      "type": "sound"
+    },
+    "spcjam.u7": {
+      "filename": "spcjam.u7",
+      "type": "sound"
+    },
+    "spcjam.u17": {
+      "filename": "spcjam.u17",
+      "type": "sound"
+    }
+  },
+  "rollr_e1": {
+    "rolr_u20.pe1": {
+      "filename": "rolr_u20.pe1",
+      "type": "sound"
+    },
+    "rolr_u26.pe1": {
+      "filename": "rolr_u26.pe1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rolr_u27.pe1": {
+      "filename": "rolr_u27.pe1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rolr_u4.pe1": {
+      "filename": "rolr_u4.pe1",
+      "type": "sound"
+    },
+    "rolr_u19.pe1": {
+      "filename": "rolr_u19.pe1",
+      "type": "sound"
+    }
+  },
+  "wpt_111a": {
+    "wpt0111a.bin": {
+      "filename": "wpt0111a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cp_15": {
+    "cp_g11.1_5": {
+      "filename": "cp_g11.1_5",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "cp_s4.bin": {
+      "filename": "cp_s4.bin",
+      "type": "sound"
+    },
+    "cp_s3.bin": {
+      "filename": "cp_s3.bin",
+      "type": "sound"
+    },
+    "cp_s5.bin": {
+      "filename": "cp_s5.bin",
+      "type": "sound"
+    },
+    "cp_s6.bin": {
+      "filename": "cp_s6.bin",
+      "type": "sound"
+    },
+    "cp_s7.bin": {
+      "filename": "cp_s7.bin",
+      "type": "sound"
+    },
+    "cp_s2.bin": {
+      "filename": "cp_s2.bin",
+      "type": "sound"
+    }
+  },
+  "mav_402": {
+    "mavu7.dat": {
+      "filename": "mavu7.dat",
+      "type": "sound"
+    },
+    "mavdisp0.402": {
+      "filename": "mavdisp0.402",
+      "type": "dmd"
+    },
+    "mavdisp3.402": {
+      "filename": "mavdisp3.402",
+      "type": "dmd"
+    },
+    "mavcpua.404": {
+      "filename": "mavcpua.404",
+      "type": "main",
+      "romType": "de"
+    },
+    "mavu21.dat": {
+      "filename": "mavu21.dat",
+      "type": "sound"
+    },
+    "mavu17.dat": {
+      "filename": "mavu17.dat",
+      "type": "sound"
+    }
+  },
+  "triplay": {
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "696-s.snd": {
+      "filename": "696-s.snd",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "btmn_103": {
+    "batman.u21": {
+      "filename": "batman.u21",
+      "type": "sound"
+    },
+    "batdsp.102": {
+      "filename": "batdsp.102",
+      "type": "dmd"
+    },
+    "batcpub5.103": {
+      "filename": "batcpub5.103",
+      "type": "main",
+      "romType": "de"
+    },
+    "batcpuc5.103": {
+      "filename": "batcpuc5.103",
+      "type": "main",
+      "romType": "de"
+    },
+    "batman.u7": {
+      "filename": "batman.u7",
+      "type": "sound"
+    },
+    "batman.u17": {
+      "filename": "batman.u17",
+      "type": "sound"
+    }
+  },
+  "btmn_106": {
+    "batman.u21": {
+      "filename": "batman.u21",
+      "type": "sound"
+    },
+    "batdsp.106": {
+      "filename": "batdsp.106",
+      "type": "dmd"
+    },
+    "b5_a106.128": {
+      "filename": "b5_a106.128",
+      "type": "main",
+      "romType": "de"
+    },
+    "c5_a106.256": {
+      "filename": "c5_a106.256",
+      "type": "main",
+      "romType": "de"
+    },
+    "batman.u7": {
+      "filename": "batman.u7",
+      "type": "sound"
+    },
+    "batman.u17": {
+      "filename": "batman.u17",
+      "type": "sound"
+    }
+  },
+  "twd_128": {
+    "twd128.bin": {
+      "filename": "TWD128.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "jplstw20": {
+    "jp2cpu.200": {
+      "filename": "jp2cpu.200",
+      "type": "main",
+      "romType": "se"
+    },
+    "jp2_u7.bin": {
+      "filename": "jp2_u7.bin",
+      "type": "sound"
+    },
+    "jp2_u17.bin": {
+      "filename": "jp2_u17.bin",
+      "type": "sound"
+    },
+    "jp2dspa.201": {
+      "filename": "jp2dspa.201",
+      "type": "dmd"
+    },
+    "jp2_u21.bin": {
+      "filename": "jp2_u21.bin",
+      "type": "sound"
+    }
+  },
+  "mtl_120": {
+    "mtl120.bin": {
+      "filename": "MTL120.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "rollr_g3": {
+    "rolr-u26.lg3": {
+      "filename": "rolr-u26.lg3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rolr_u19.l3": {
+      "filename": "rolr_u19.l3",
+      "type": "sound"
+    },
+    "rolr_u20.l3": {
+      "filename": "rolr_u20.l3",
+      "type": "sound"
+    },
+    "rolr_u4.l3": {
+      "filename": "rolr_u4.l3",
+      "type": "sound"
+    },
+    "rolr_u27.l2": {
+      "filename": "rolr_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "rdkng_l3": {
+    "road_u4.l1": {
+      "filename": "road_u4.l1",
+      "type": "sound"
+    },
+    "road_u27.l3": {
+      "filename": "road_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "road_u26.l3": {
+      "filename": "road_u26.l3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "road_u22.l1": {
+      "filename": "road_u22.l1",
+      "type": "sound"
+    },
+    "road_u21.l1": {
+      "filename": "road_u21.l1",
+      "type": "sound"
+    }
+  },
+  "rdkng_l4": {
+    "road_u4.l1": {
+      "filename": "road_u4.l1",
+      "type": "sound"
+    },
+    "road_u26.l4": {
+      "filename": "road_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "road_u27.l4": {
+      "filename": "road_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "road_u22.l1": {
+      "filename": "road_u22.l1",
+      "type": "sound"
+    },
+    "road_u21.l1": {
+      "filename": "road_u21.l1",
+      "type": "sound"
+    }
+  },
+  "mm_05": {
+    "mm_sav6.rom": {
+      "filename": "mm_sav6.rom",
+      "type": "sound"
+    },
+    "mm_sav5.rom": {
+      "filename": "mm_sav5.rom",
+      "type": "sound"
+    },
+    "mm_sav4.rom": {
+      "filename": "mm_sav4.rom",
+      "type": "sound"
+    },
+    "g11-050.rom": {
+      "filename": "g11-050.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mm_sav3.rom": {
+      "filename": "mm_sav3.rom",
+      "type": "sound"
+    },
+    "s2-020.rom": {
+      "filename": "s2-020.rom",
+      "type": "sound"
+    }
+  },
+  "mm_10": {
+    "mm_sav6.rom": {
+      "filename": "mm_sav6.rom",
+      "type": "sound"
+    },
+    "mm_sav5.rom": {
+      "filename": "mm_sav5.rom",
+      "type": "sound"
+    },
+    "mm_g11.1_0": {
+      "filename": "mm_g11.1_0",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mm_sav4.rom": {
+      "filename": "mm_sav4.rom",
+      "type": "sound"
+    },
+    "mm_s2.1_0": {
+      "filename": "mm_s2.1_0",
+      "type": "sound"
+    },
+    "mm_sav3.rom": {
+      "filename": "mm_sav3.rom",
+      "type": "sound"
+    }
+  },
+  "mm_109": {
+    "mm_sav6.rom": {
+      "filename": "mm_sav6.rom",
+      "type": "sound"
+    },
+    "mm_sav5.rom": {
+      "filename": "mm_sav5.rom",
+      "type": "sound"
+    },
+    "mm_1_09.bin": {
+      "filename": "mm_1_09.bin",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mm_sav4.rom": {
+      "filename": "mm_sav4.rom",
+      "type": "sound"
+    },
+    "mm_s2.1_0": {
+      "filename": "mm_s2.1_0",
+      "type": "sound"
+    },
+    "mm_sav3.rom": {
+      "filename": "mm_sav3.rom",
+      "type": "sound"
+    }
+  },
+  "mm_109b": {
+    "mm_sav6.rom": {
+      "filename": "mm_sav6.rom",
+      "type": "sound"
+    },
+    "mm_sav5.rom": {
+      "filename": "mm_sav5.rom",
+      "type": "sound"
+    },
+    "mm_109b.bin": {
+      "filename": "mm_109b.bin",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mm_sav4.rom": {
+      "filename": "mm_sav4.rom",
+      "type": "sound"
+    },
+    "mm_s2.1_0": {
+      "filename": "mm_s2.1_0",
+      "type": "sound"
+    },
+    "mm_sav3.rom": {
+      "filename": "mm_sav3.rom",
+      "type": "sound"
+    }
+  },
+  "mm_109c": {
+    "mm_sav6.rom": {
+      "filename": "mm_sav6.rom",
+      "type": "sound"
+    },
+    "mm_sav5.rom": {
+      "filename": "mm_sav5.rom",
+      "type": "sound"
+    },
+    "mm_sav4.rom": {
+      "filename": "mm_sav4.rom",
+      "type": "sound"
+    },
+    "mm_s2.1_0": {
+      "filename": "mm_s2.1_0",
+      "type": "sound"
+    },
+    "mm_1_09c.bin": {
+      "filename": "mm_1_09c.bin",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mm_sav3.rom": {
+      "filename": "mm_sav3.rom",
+      "type": "sound"
+    }
+  },
+  "frontiea": {
+    "7406fn.u6": {
+      "filename": "7406fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "819-09_4.716": {
+      "filename": "819-09_4.716",
+      "type": "sound"
+    },
+    "frnt2732.u2": {
+      "filename": "frnt2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "skatebla": {
+    "7406fn.u6": {
+      "filename": "7406fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "skat2732.u2": {
+      "filename": "skat2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "823-02_4.716": {
+      "filename": "823-02_4.716",
+      "type": "sound"
+    }
+  },
+  "tfight": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "acd_140": {
+    "acd14pro.bin": {
+      "filename": "ACD14PRO.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "gpr340": {
+    "gpsnda.u17": {
+      "filename": "gpsnda.u17",
+      "type": "sound"
+    },
+    "gpsnda.u36": {
+      "filename": "gpsnda.u36",
+      "type": "sound"
+    },
+    "gpsnda.u21": {
+      "filename": "gpsnda.u21",
+      "type": "sound"
+    },
+    "gpcpua.340": {
+      "filename": "gpcpua.340",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpdspa.303": {
+      "filename": "gpdspa.303",
+      "type": "dmd"
+    },
+    "gpsnda.u37": {
+      "filename": "gpsnda.u37",
+      "type": "sound"
+    },
+    "gpsnda.u7": {
+      "filename": "gpsnda.u7",
+      "type": "sound"
+    }
+  },
+  "gpr350": {
+    "gpsnda.u17": {
+      "filename": "gpsnda.u17",
+      "type": "sound"
+    },
+    "gpsnda.u36": {
+      "filename": "gpsnda.u36",
+      "type": "sound"
+    },
+    "gpsnda.u21": {
+      "filename": "gpsnda.u21",
+      "type": "sound"
+    },
+    "gpdspa.303": {
+      "filename": "gpdspa.303",
+      "type": "dmd"
+    },
+    "gpcpua.350": {
+      "filename": "gpcpua.350",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsnda.u37": {
+      "filename": "gpsnda.u37",
+      "type": "sound"
+    },
+    "gpsnda.u7": {
+      "filename": "gpsnda.u7",
+      "type": "sound"
+    }
+  },
+  "gpr352": {
+    "gpsnda.u17": {
+      "filename": "gpsnda.u17",
+      "type": "sound"
+    },
+    "gpsnda.u36": {
+      "filename": "gpsnda.u36",
+      "type": "sound"
+    },
+    "gpsnda.u21": {
+      "filename": "gpsnda.u21",
+      "type": "sound"
+    },
+    "gpdspa.303": {
+      "filename": "gpdspa.303",
+      "type": "dmd"
+    },
+    "gpsnda.u37": {
+      "filename": "gpsnda.u37",
+      "type": "sound"
+    },
+    "gpcpua.352": {
+      "filename": "gpcpua.352",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsnda.u7": {
+      "filename": "gpsnda.u7",
+      "type": "sound"
+    }
+  },
+  "gpr400": {
+    "gpsnda.u17": {
+      "filename": "gpsnda.u17",
+      "type": "sound"
+    },
+    "gpsnda.u36": {
+      "filename": "gpsnda.u36",
+      "type": "sound"
+    },
+    "gpsnda.u21": {
+      "filename": "gpsnda.u21",
+      "type": "sound"
+    },
+    "gpcpua.400": {
+      "filename": "gpcpua.400",
+      "type": "main",
+      "romType": "se"
+    },
+    "gpsnda.u37": {
+      "filename": "gpsnda.u37",
+      "type": "sound"
+    },
+    "gpdspa.400": {
+      "filename": "gpdspa.400",
+      "type": "dmd"
+    },
+    "gpsnda.u7": {
+      "filename": "gpsnda.u7",
+      "type": "sound"
+    }
+  },
+  "eballdp4": {
+    "838-17.u12": {
+      "filename": "838-17.U12",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-16_5.532": {
+      "filename": "838-16_5.532",
+      "type": "sound"
+    },
+    "720-55.u14": {
+      "filename": "720-55.U14",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-54.u10": {
+      "filename": "720-54.U10",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    },
+    "ebd68701.2": {
+      "filename": "ebd68701.2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "f14_l1": {
+    "f14_u4.l1": {
+      "filename": "f14_u4.l1",
+      "type": "sound"
+    },
+    "f14_u26.l1": {
+      "filename": "f14_u26.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "f14_u22.l1": {
+      "filename": "f14_u22.l1",
+      "type": "sound"
+    },
+    "f14_u19.l1": {
+      "filename": "f14_u19.l1",
+      "type": "sound"
+    },
+    "f14_u27.l1": {
+      "filename": "f14_u27.l1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "f14_u21.l1": {
+      "filename": "f14_u21.l1",
+      "type": "sound"
+    }
+  },
+  "f14_p3": {
+    "f14_u4.l1": {
+      "filename": "F14_U4.L1",
+      "type": "sound"
+    },
+    "f14_l3.u27": {
+      "filename": "f14_l3.u27",
+      "type": "main",
+      "romType": "s11"
+    },
+    "f14_u22.l1": {
+      "filename": "F14_U22.L1",
+      "type": "sound"
+    },
+    "f14_l3.u26": {
+      "filename": "f14_l3.u26",
+      "type": "main",
+      "romType": "s11"
+    },
+    "f14_u19.l1": {
+      "filename": "F14_U19.L1",
+      "type": "sound"
+    },
+    "f14_u21.l1": {
+      "filename": "F14_U21.L1",
+      "type": "sound"
+    }
+  },
+  "f14_p5": {
+    "f14_u4.l1": {
+      "filename": "F14_U4.L1",
+      "type": "sound"
+    },
+    "f14_u27.p5": {
+      "filename": "f14_u27.p5",
+      "type": "main",
+      "romType": "s11"
+    },
+    "f14_u22.l1": {
+      "filename": "F14_U22.L1",
+      "type": "sound"
+    },
+    "f14_u19.l1": {
+      "filename": "F14_U19.L1",
+      "type": "sound"
+    },
+    "f14_u21.l1": {
+      "filename": "F14_U21.L1",
+      "type": "sound"
+    },
+    "f14_u26.p5": {
+      "filename": "f14_u26.p5",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "hotdogga": {
+    "809-07_4.716": {
+      "filename": "809-07_4.716",
+      "type": "sound"
+    },
+    "hot2un.u6": {
+      "filename": "hot2un.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "hot2un.u2": {
+      "filename": "hot2un.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "hotdoggb": {
+    "809-07_4.716": {
+      "filename": "809-07_4.716",
+      "type": "sound"
+    },
+    "hotd2732.u2": {
+      "filename": "hotd2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "spacecty": {
+    "zsc1.dat": {
+      "filename": "zsc1.dat",
+      "type": "main"
+    },
+    "zsc4.dat": {
+      "filename": "zsc4.dat",
+      "type": "main"
+    },
+    "zsc2.dat": {
+      "filename": "zsc2.dat",
+      "type": "main"
+    },
+    "zsc3.dat": {
+      "filename": "zsc3.dat",
+      "type": "main"
+    }
+  },
+  "lotr_i51": {
+    "lotrdspi.501": {
+      "filename": "lotrdspi.501",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.501": {
+      "filename": "lotrcpu.501",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "ccruise": {
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "pinc7gfp": {
+    "pchmp_de.1g": {
+      "filename": "pchmp_de.1g",
+      "type": "sound"
+    },
+    "pinc7fp.ic2": {
+      "filename": "pinc7fp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_de.1c": {
+      "filename": "pchmp_de.1c",
+      "type": "sound"
+    },
+    "pchmp_de.1e": {
+      "filename": "pchmp_de.1e",
+      "type": "sound"
+    },
+    "pinc7fp.ic1": {
+      "filename": "pinc7fp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_de.1f": {
+      "filename": "pchmp_de.1f",
+      "type": "sound"
+    }
+  },
+  "pincha7g": {
+    "pchmp_de.1g": {
+      "filename": "pchmp_de.1g",
+      "type": "sound"
+    },
+    "pblchmp7.ic3": {
+      "filename": "pblchmp7.ic3",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_de.1c": {
+      "filename": "pchmp_de.1c",
+      "type": "sound"
+    },
+    "pchmp_de.1e": {
+      "filename": "pchmp_de.1e",
+      "type": "sound"
+    },
+    "pblchmp7.ic2": {
+      "filename": "pblchmp7.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pblchmp7.ic1": {
+      "filename": "pblchmp7.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "pchmp_de.1f": {
+      "filename": "pchmp_de.1f",
+      "type": "sound"
+    }
+  },
+  "potc_600gf": {
+    "potc0600gf.bin": {
+      "filename": "potc0600gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_220": {
+    "spd_v2-2_e.bin": {
+      "filename": "spd_v2-2_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_109f": {
+    "wpt0109f.bin": {
+      "filename": "wpt0109f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "starfire": {
+    "starfcpu.rom": {
+      "filename": "Starfcpu.rom",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "starfu3.rom": {
+      "filename": "STARFU3.ROM",
+      "type": "sound"
+    },
+    "starfu4.rom": {
+      "filename": "STARFU4.ROM",
+      "type": "sound"
+    }
+  },
+  "trek_200": {
+    "trekcpuu.200": {
+      "filename": "trekcpuu.200",
+      "type": "main",
+      "romType": "de"
+    },
+    "trek.u17": {
+      "filename": "trek.u17",
+      "type": "sound"
+    },
+    "trek.u21": {
+      "filename": "trek.u21",
+      "type": "sound"
+    },
+    "trekdspa.109": {
+      "filename": "trekdspa.109",
+      "type": "dmd"
+    },
+    "trek.u7": {
+      "filename": "trek.u7",
+      "type": "sound"
+    }
+  },
+  "badgirls": {
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    }
+  },
+  "cactjack": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "lotr_f41": {
+    "lotrcpu.410": {
+      "filename": "lotrcpu.410",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrdspf.404": {
+      "filename": "lotrdspf.404",
+      "type": "dmd"
+    }
+  },
+  "lotr_g41": {
+    "lotrcpu.410": {
+      "filename": "lotrcpu.410",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspg.404": {
+      "filename": "lotrdspg.404",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "twd_156h": {
+    "twd156le.bin": {
+      "filename": "TWD156LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "rollr_l2": {
+    "rolr_u19.l3": {
+      "filename": "rolr_u19.l3",
+      "type": "sound"
+    },
+    "rolr_u20.l3": {
+      "filename": "rolr_u20.l3",
+      "type": "sound"
+    },
+    "rolr_u26.l2": {
+      "filename": "rolr_u26.l2",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rolr_u4.l3": {
+      "filename": "rolr_u4.l3",
+      "type": "sound"
+    },
+    "rolr_u27.l2": {
+      "filename": "rolr_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "rollr_l3": {
+    "rolr_u19.l3": {
+      "filename": "rolr_u19.l3",
+      "type": "sound"
+    },
+    "rolr_u20.l3": {
+      "filename": "rolr_u20.l3",
+      "type": "sound"
+    },
+    "rolr-u26.lu3": {
+      "filename": "rolr-u26.lu3",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rolr_u4.l3": {
+      "filename": "rolr_u4.l3",
+      "type": "sound"
+    },
+    "rolr_u27.l2": {
+      "filename": "rolr_u27.l2",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "sman_170": {
+    "spd_1-7_e.bin": {
+      "filename": "spd_1-7_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "atarianb": {
+    "atarian.e0": {
+      "filename": "atarian.e0",
+      "type": "main",
+      "romType": "atari"
+    },
+    "atarianb.e00": {
+      "filename": "atarianb.e00",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "atarians": {
+    "atarian.e0": {
+      "filename": "atarian.e0",
+      "type": "main",
+      "romType": "atari"
+    },
+    "atarian.e00": {
+      "filename": "atarian.e00",
+      "type": "main",
+      "romType": "atari"
+    }
+  },
+  "poleposn": {
+    "3.bin": {
+      "filename": "3.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "2.bin": {
+      "filename": "2.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "1.bin": {
+      "filename": "1.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "hook_408": {
+    "hokcpua.408": {
+      "filename": "hokcpua.408",
+      "type": "main",
+      "romType": "de"
+    },
+    "hokdspa.401": {
+      "filename": "hokdspa.401",
+      "type": "dmd"
+    },
+    "hooksnd.u7": {
+      "filename": "hooksnd.u7",
+      "type": "sound"
+    },
+    "hook-voi.u17": {
+      "filename": "hook-voi.u17",
+      "type": "sound"
+    },
+    "hook-voi.u21": {
+      "filename": "hook-voi.u21",
+      "type": "sound"
+    }
+  },
+  "gransl4a": {
+    "grandfn.u6": {
+      "filename": "grandfn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "gr_slam.u2b": {
+      "filename": "gr_slam.u2b",
+      "type": "main",
+      "romType": "by"
+    },
+    "grndslam.u4": {
+      "filename": "grndslam.u4",
+      "type": "sound"
+    }
+  },
+  "granslaa": {
+    "grandfn.u6": {
+      "filename": "grandfn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "grndslam.u2": {
+      "filename": "grndslam.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "grndslam.u4": {
+      "filename": "grndslam.u4",
+      "type": "sound"
+    }
+  },
+  "odin": {
+    "odin_b.bin": {
+      "filename": "odin_b.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "odin_a.bin": {
+      "filename": "odin_a.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "odin_dlx": {
+    "2a.bin": {
+      "filename": "2a.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "1a.bin": {
+      "filename": "1a.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "tf_180h": {
+    "tf_180h.bin": {
+      "filename": "tf_180h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "nemesis": {
+    "memoriac.bin": {
+      "filename": "MEMORIAC.BIN",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "nemesisa.bin": {
+      "filename": "NEMESISA.BIN",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "nemesisb.bin": {
+      "filename": "NEMESISB.BIN",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "mtl_105": {
+    "mtl_105.bin": {
+      "filename": "mtl_105.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "txsector": {
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "tmnt_103": {
+    "tmntc5.103": {
+      "filename": "tmntc5.103",
+      "type": "main",
+      "romType": "de"
+    },
+    "tmntdsp.104": {
+      "filename": "tmntdsp.104",
+      "type": "dmd"
+    },
+    "tmntf6.rom": {
+      "filename": "tmntf6.rom",
+      "type": "sound"
+    },
+    "tmntf7.rom": {
+      "filename": "tmntf7.rom",
+      "type": "sound"
+    },
+    "tmntf4.rom": {
+      "filename": "tmntf4.rom",
+      "type": "sound"
+    },
+    "tmntb5.103": {
+      "filename": "tmntb5.103",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "sureshot": {
+    "ssh1.bin": {
+      "filename": "ssh1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ssh3.bin": {
+      "filename": "ssh3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ssh_s3.bin": {
+      "filename": "ssh_s3.bin",
+      "type": "sound"
+    },
+    "ssh2.bin": {
+      "filename": "ssh2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ssh_s1.bin": {
+      "filename": "ssh_s1.bin",
+      "type": "sound"
+    },
+    "ssh_s2.bin": {
+      "filename": "ssh_s2.bin",
+      "type": "sound"
+    },
+    "ssh4.bin": {
+      "filename": "ssh4.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "skatebll": {
+    "823-24_1.716": {
+      "filename": "823-24_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "823-25_2.716": {
+      "filename": "823-25_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "823-02_4.716": {
+      "filename": "823-02_4.716",
+      "type": "sound"
+    },
+    "720-40_6.732": {
+      "filename": "720-40_6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "vegas": {
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "dinoeggs": {
+    "dinoeggs.512": {
+      "filename": "dinoeggs.512",
+      "type": "main",
+      "romType": "alvin"
+    }
+  },
+  "jngld_l2": {
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound3.716": {
+      "filename": "sound3.716",
+      "type": "sound"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech5.532": {
+      "filename": "speech5.532",
+      "type": "sound"
+    },
+    "speech7.532": {
+      "filename": "speech7.532",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "speech6.532": {
+      "filename": "speech6.532",
+      "type": "sound"
+    }
+  },
+  "pentacup": {
+    "ic6.bin": {
+      "filename": "ic6.bin",
+      "type": "main"
+    },
+    "ic4.bin": {
+      "filename": "ic4.bin",
+      "type": "main"
+    },
+    "ic3.bin": {
+      "filename": "ic3.bin",
+      "type": "main"
+    },
+    "ic8.bin": {
+      "filename": "ic8.bin",
+      "type": "main"
+    },
+    "ic5.bin": {
+      "filename": "ic5.bin",
+      "type": "main"
+    },
+    "ic7.bin": {
+      "filename": "ic7.bin",
+      "type": "main"
+    },
+    "ic2.bin": {
+      "filename": "ic2.bin",
+      "type": "main"
+    }
+  },
+  "rota_115": {
+    "v115-a.bin": {
+      "filename": "v115-a.bin",
+      "type": "main"
+    },
+    "v115-c.bin": {
+      "filename": "v115-c.bin",
+      "type": "main"
+    },
+    "v115-b.bin": {
+      "filename": "v115-b.bin",
+      "type": "main"
+    }
+  },
+  "arena": {
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    }
+  },
+  "mt_140": {
+    "mt_140.bin": {
+      "filename": "mt_140.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "vegast": {
+    "lluck2.bin": {
+      "filename": "lluck2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "vegas4.bin": {
+      "filename": "vegas4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "lluck_s1.bin": {
+      "filename": "lluck_s1.bin",
+      "type": "sound"
+    },
+    "lluck_s2.bin": {
+      "filename": "lluck_s2.bin",
+      "type": "sound"
+    },
+    "vegas3.bin": {
+      "filename": "vegas3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "lluck1.bin": {
+      "filename": "lluck1.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "raven": {
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    }
+  },
+  "sman_140": {
+    "spd_1_4_e.bin": {
+      "filename": "spd_1_4_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ft_l3": {
+    "ft_u18.l1": {
+      "filename": "ft_u18.l1",
+      "type": "sound"
+    },
+    "ft-l3.u6": {
+      "filename": "ft-l3.u6",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "ft_l4": {
+    "ft_u18.l1": {
+      "filename": "ft_u18.l1",
+      "type": "sound"
+    },
+    "fshtl_4.rom": {
+      "filename": "fshtl_4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "ft_l5": {
+    "ft_u18.l1": {
+      "filename": "ft_u18.l1",
+      "type": "sound"
+    },
+    "fshtl_5.rom": {
+      "filename": "fshtl_5.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "futurwld": {
+    "futwld_2.lgc": {
+      "filename": "futwld_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "futwld_5.lgc": {
+      "filename": "futwld_5.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "futwld_4.lgc": {
+      "filename": "futwld_4.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "futwld_3.lgc": {
+      "filename": "futwld_3.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "futwld_1.lgc": {
+      "filename": "futwld_1.lgc",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "strngscg": {
+    "cpub_u2.128": {
+      "filename": "cpub_u2.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "sound_u7.256": {
+      "filename": "sound_u7.256",
+      "type": "sound"
+    },
+    "cpub_u3.128": {
+      "filename": "cpub_u3.128",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "sstb": {
+    "surp2732.u2": {
+      "filename": "surp2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "3032d7.bin": {
+      "filename": "3032d7.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "excalibr": {
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "spectra": {
+    "spect_u5.dat": {
+      "filename": "spect_u5.dat",
+      "type": "main"
+    },
+    "spect_u3.dat": {
+      "filename": "spect_u3.dat",
+      "type": "main"
+    },
+    "spect_u4.dat": {
+      "filename": "spect_u4.dat",
+      "type": "main"
+    }
+  },
+  "madrace": {
+    "madrace1.snd": {
+      "filename": "madrace1.snd",
+      "type": "sound"
+    },
+    "madrace.2a0": {
+      "filename": "madrace.2a0",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "madrace.2c0": {
+      "filename": "madrace.2c0",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "madrace2.snd": {
+      "filename": "madrace2.snd",
+      "type": "sound"
+    },
+    "madrace.2b0": {
+      "filename": "madrace.2b0",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "roldisco": {
+    "440.snd": {
+      "filename": "440.snd",
+      "type": "sound"
+    },
+    "6530sys1.bin": {
+      "filename": "6530sys1.bin",
+      "type": "sound"
+    },
+    "440.cpu": {
+      "filename": "440.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "hypbl_l3": {
+    "ic20-l3.532": {
+      "filename": "ic20-l3.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14-l3.532": {
+      "filename": "ic14-l3.532",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "spectr4a": {
+    "868-03_5.716": {
+      "filename": "868-03_5.716",
+      "type": "sound"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "868-02_4.532": {
+      "filename": "868-02_4.532",
+      "type": "sound"
+    },
+    "868-04_2.732": {
+      "filename": "868-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "868-01_3.532": {
+      "filename": "868-01_3.532",
+      "type": "sound"
+    }
+  },
+  "spectru4": {
+    "868-03_5.716": {
+      "filename": "868-03_5.716",
+      "type": "sound"
+    },
+    "868-02_4.532": {
+      "filename": "868-02_4.532",
+      "type": "sound"
+    },
+    "868-04_2.732": {
+      "filename": "868-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "868-01_3.532": {
+      "filename": "868-01_3.532",
+      "type": "sound"
+    }
+  },
+  "spectrua": {
+    "868-03_5.716": {
+      "filename": "868-03_5.716",
+      "type": "sound"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "868-02_4.532": {
+      "filename": "868-02_4.532",
+      "type": "sound"
+    },
+    "868-01_3.532": {
+      "filename": "868-01_3.532",
+      "type": "sound"
+    }
+  },
+  "spectrum": {
+    "868-03_5.716": {
+      "filename": "868-03_5.716",
+      "type": "sound"
+    },
+    "868-02_4.532": {
+      "filename": "868-02_4.532",
+      "type": "sound"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "868-01_3.532": {
+      "filename": "868-01_3.532",
+      "type": "sound"
+    }
+  },
+  "freddy": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    }
+  },
+  "freddy4": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "gprom4.bin": {
+      "filename": "gprom4.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    }
+  },
+  "genie": {
+    "435.snd": {
+      "filename": "435.snd",
+      "type": "sound"
+    },
+    "435.cpu": {
+      "filename": "435.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sys1.bin": {
+      "filename": "6530sys1.bin",
+      "type": "sound"
+    }
+  },
+  "victory": {
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "wpt_140a": {
+    "wpt1400a.bin": {
+      "filename": "wpt1400a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lotr_fr5": {
+    "lotrcpu.500": {
+      "filename": "lotrcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrdspf.500": {
+      "filename": "lotrdspf.500",
+      "type": "dmd"
+    }
+  },
+  "lotr_it5": {
+    "lotrcpu.500": {
+      "filename": "lotrcpu.500",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrdspi.500": {
+      "filename": "lotrdspi.500",
+      "type": "dmd"
+    }
+  },
+  "id4_201f": {
+    "id4dspf.200": {
+      "filename": "id4dspf.200",
+      "type": "dmd"
+    },
+    "id4sdu17.400": {
+      "filename": "id4sdu17.400",
+      "type": "sound"
+    },
+    "id4cpu.201": {
+      "filename": "id4cpu.201",
+      "type": "main",
+      "romType": "se"
+    },
+    "id4sndu7.512": {
+      "filename": "id4sndu7.512",
+      "type": "sound"
+    },
+    "id4sdu21.400": {
+      "filename": "id4sdu21.400",
+      "type": "sound"
+    }
+  },
+  "bmf_fr": {
+    "batnovf.401": {
+      "filename": "batnovf.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bfdrom0f.401": {
+      "filename": "bfdrom0f.401",
+      "type": "dmd"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    },
+    "bfdrom3f.401": {
+      "filename": "bfdrom3f.401",
+      "type": "dmd"
+    }
+  },
+  "grand_l4": {
+    "lzrd_u4.l1": {
+      "filename": "lzrd_u4.l1",
+      "type": "sound"
+    },
+    "lzrd_u22.l1": {
+      "filename": "lzrd_u22.l1",
+      "type": "sound"
+    },
+    "lzrd_u26.l4": {
+      "filename": "lzrd_u26.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "lzrd_u27.l4": {
+      "filename": "lzrd_u27.l4",
+      "type": "main",
+      "romType": "s11"
+    },
+    "lzrd_u21.l1": {
+      "filename": "lzrd_u21.l1",
+      "type": "sound"
+    }
+  },
+  "twd_156": {
+    "twd_156.bin": {
+      "filename": "twd_156.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ssvc_a42": {
+    "sssndf7b.bin": {
+      "filename": "sssndf7b.bin",
+      "type": "sound"
+    },
+    "ssv2f4.rom": {
+      "filename": "ssv2f4.rom",
+      "type": "sound"
+    },
+    "ssv1f6.rom": {
+      "filename": "ssv1f6.rom",
+      "type": "sound"
+    },
+    "ss-b5.256": {
+      "filename": "ss-b5.256",
+      "type": "main",
+      "romType": "de"
+    },
+    "ss-c5.256": {
+      "filename": "ss-c5.256",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "playboy": {
+    "720-30_6.716": {
+      "filename": "720-30_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "743-14_1.716": {
+      "filename": "743-14_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "743-12_2.716": {
+      "filename": "743-12_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    }
+  },
+  "startrek": {
+    "720-30_6.716": {
+      "filename": "720-30_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "745-11_1.716": {
+      "filename": "745-11_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "745-12_2.716": {
+      "filename": "745-12_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "voltan": {
+    "720-30_6.716": {
+      "filename": "720-30_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "744-03_1.716": {
+      "filename": "744-03_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "744-04_2.716": {
+      "filename": "744-04_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "strikext": {
+    "sxvoicea.u37": {
+      "filename": "sxvoicea.u37",
+      "type": "sound"
+    },
+    "sxcpua.102": {
+      "filename": "sxcpua.102",
+      "type": "main",
+      "romType": "se"
+    },
+    "sxvoicea.u21": {
+      "filename": "sxvoicea.u21",
+      "type": "sound"
+    },
+    "sxvoicea.u36": {
+      "filename": "sxvoicea.u36",
+      "type": "sound"
+    },
+    "sxvoicea.u17": {
+      "filename": "sxvoicea.u17",
+      "type": "sound"
+    },
+    "sxdispa.103": {
+      "filename": "sxdispa.103",
+      "type": "dmd"
+    },
+    "sxsounda.u7": {
+      "filename": "sxsounda.u7",
+      "type": "sound"
+    }
+  },
+  "lotr_s51": {
+    "lotrcpul.501": {
+      "filename": "lotrcpul.501",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrlu36.100": {
+      "filename": "lotrlu36.100",
+      "type": "sound"
+    },
+    "lotrlu37.100": {
+      "filename": "lotrlu37.100",
+      "type": "sound"
+    },
+    "lotrdspl.501": {
+      "filename": "lotrdspl.501",
+      "type": "dmd"
+    },
+    "lotrlu7.100": {
+      "filename": "lotrlu7.100",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrlu17.100": {
+      "filename": "lotrlu17.100",
+      "type": "sound"
+    },
+    "lotrlu21.100": {
+      "filename": "lotrlu21.100",
+      "type": "sound"
+    }
+  },
+  "lostwrld": {
+    "729-33_1.716": {
+      "filename": "729-33_1.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "729-48_2.716": {
+      "filename": "729-48_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-28_6.716": {
+      "filename": "720-28_6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "dragfifp": {
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpdf_u5.716": {
+      "filename": "fpdf_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "panther7": {
+    "652.snd": {
+      "filename": "652.snd",
+      "type": "sound"
+    },
+    "652.cpu": {
+      "filename": "652.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "disco_l1": {
+    "white2.716": {
+      "filename": "white2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white1.716": {
+      "filename": "white1.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "httip_l1": {
+    "white2.716": {
+      "filename": "white2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white1.716": {
+      "filename": "white1.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    }
+  },
+  "lucky_l1": {
+    "white2.716": {
+      "filename": "white2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white1.716": {
+      "filename": "white1.716",
+      "type": "main",
+      "romType": "s4"
+    }
+  },
+  "pkrno_l1": {
+    "white2.716": {
+      "filename": "white2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white1.716": {
+      "filename": "white1.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "batmanf1": {
+    "bmfrom0.100": {
+      "filename": "bmfrom0.100",
+      "type": "dmd"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "batcpua.102": {
+      "filename": "batcpua.102",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfrom3.100": {
+      "filename": "bmfrom3.100",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "wpt_111i": {
+    "wpt0111i.bin": {
+      "filename": "wpt0111i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wof_400l": {
+    "wof0401l.bin": {
+      "filename": "wof0401l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_190al": {
+    "spd_1-9_es.bin": {
+      "filename": "spd_1-9_es.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "v1": {
+    "v1.128": {
+      "filename": "v1.128",
+      "type": "main"
+    }
+  },
+  "goldwing": {
+    "yrom2.snd": {
+      "filename": "yrom2.snd",
+      "type": "sound"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    }
+  },
+  "batmanf": {
+    "batnova.401": {
+      "filename": "batnova.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3a.401": {
+      "filename": "bfdrom3a.401",
+      "type": "dmd"
+    },
+    "bfdrom0a.401": {
+      "filename": "bfdrom0a.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "bmf_time": {
+    "batnova.401": {
+      "filename": "batnova.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3t.401": {
+      "filename": "bfdrom3t.401",
+      "type": "dmd"
+    },
+    "bfdrom0t.401": {
+      "filename": "bfdrom0t.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "ironmaid": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "ww_l5": {
+    "wwatr_l5.rom": {
+      "filename": "wwatr_l5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u18.l1": {
+      "filename": "ww_u18.l1",
+      "type": "sound"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    },
+    "ww_u15.l1": {
+      "filename": "ww_u15.l1",
+      "type": "sound"
+    }
+  },
+  "acd_121": {
+    "acd_121.bin": {
+      "filename": "acd_121.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_1100ai": {
+    "fg110ai.bin": {
+      "filename": "fg110ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "starsfp": {
+    "fpstars2.716": {
+      "filename": "fpstars2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fpstars6.716": {
+      "filename": "fpstars6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "sman_192al": {
+    "spd_1-92_es.bin": {
+      "filename": "spd_1-92_es.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lotr_sp4": {
+    "lotrlu36.100": {
+      "filename": "lotrlu36.100",
+      "type": "sound"
+    },
+    "lotrlu37.100": {
+      "filename": "lotrlu37.100",
+      "type": "sound"
+    },
+    "lotrdspl.403": {
+      "filename": "lotrdspl.403",
+      "type": "dmd"
+    },
+    "lotrlu7.100": {
+      "filename": "lotrlu7.100",
+      "type": "sound"
+    },
+    "lotrcpul.401": {
+      "filename": "lotrcpul.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrlu17.100": {
+      "filename": "lotrlu17.100",
+      "type": "sound"
+    },
+    "lotrlu21.100": {
+      "filename": "lotrlu21.100",
+      "type": "sound"
+    }
+  },
+  "lotr_sp6": {
+    "lotrlu36.100": {
+      "filename": "lotrlu36.100",
+      "type": "sound"
+    },
+    "lotrlu37.100": {
+      "filename": "lotrlu37.100",
+      "type": "sound"
+    },
+    "lotrlu7.100": {
+      "filename": "lotrlu7.100",
+      "type": "sound"
+    },
+    "lotrcpul.600": {
+      "filename": "lotrcpul.600",
+      "type": "main",
+      "romType": "se"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrlu17.100": {
+      "filename": "lotrlu17.100",
+      "type": "sound"
+    },
+    "lotrdspl.600": {
+      "filename": "lotrdspl.600",
+      "type": "dmd"
+    },
+    "lotrlu21.100": {
+      "filename": "lotrlu21.100",
+      "type": "sound"
+    }
+  },
+  "flash_l2": {
+    "yellow2.716": {
+      "filename": "yellow2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "gamerom2.716": {
+      "filename": "gamerom2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "yellow1.716": {
+      "filename": "yellow1.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "stlwr_l2": {
+    "yellow2.716": {
+      "filename": "yellow2.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "yellow1.716": {
+      "filename": "yellow1.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "ewf": {
+    "ewf.snd": {
+      "filename": "ewf.snd",
+      "type": "sound"
+    },
+    "zac_boot.lgc": {
+      "filename": "zac_boot.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "ewf_2.lgc": {
+      "filename": "ewf_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "ewf_3.lgc": {
+      "filename": "ewf_3.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "ewf_4.lgc": {
+      "filename": "ewf_4.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "ewf_5.lgc": {
+      "filename": "ewf_5.lgc",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "ts_lh6p": {
+    "shad_h6p.rom": {
+      "filename": "shad_h6p.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "bsv103": {
+    "u1h_v13.bin": {
+      "filename": "u1h_v13.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_v11.bin": {
+      "filename": "u28_v11.bin",
+      "type": "sound"
+    },
+    "u29_v11.bin": {
+      "filename": "u29_v11.bin",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u1l_v13.bin": {
+      "filename": "u1l_v13.bin",
+      "type": "main",
+      "romType": "capcom"
+    }
+  },
+  "cp_16": {
+    "cp_s4.bin": {
+      "filename": "cp_s4.bin",
+      "type": "sound"
+    },
+    "cp_s3.bin": {
+      "filename": "cp_s3.bin",
+      "type": "sound"
+    },
+    "cp_s5.bin": {
+      "filename": "cp_s5.bin",
+      "type": "sound"
+    },
+    "cp_s6.bin": {
+      "filename": "cp_s6.bin",
+      "type": "sound"
+    },
+    "cp_s7.bin": {
+      "filename": "cp_s7.bin",
+      "type": "sound"
+    },
+    "cp_g11.1_6": {
+      "filename": "cp_g11.1_6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "cp_s2.bin": {
+      "filename": "cp_s2.bin",
+      "type": "sound"
+    }
+  },
+  "megaatoa": {
+    "mega_u11.bin": {
+      "filename": "mega_u11.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "mega_u12.bin": {
+      "filename": "mega_u12.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "wpt_105a": {
+    "wpt0105a.bin": {
+      "filename": "wpt0105a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "rambo": {
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom2a.cpu": {
+      "filename": "prom2a.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "lw3_208p": {
+    "lw3u17.dat": {
+      "filename": "lw3u17.dat",
+      "type": "sound"
+    },
+    "lw3u21.dat": {
+      "filename": "lw3u21.dat",
+      "type": "sound"
+    }
+  },
+  "blkhol7s": {
+    "668-a-s.snd": {
+      "filename": "668-a-s.snd",
+      "type": "sound"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "668-a2.cpu": {
+      "filename": "668-a2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "eclipse7": {
+    "671-a-s.snd": {
+      "filename": "671-a-s.snd",
+      "type": "sound"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "671-a.cpu": {
+      "filename": "671-a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "eballdlb": {
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-10_5.532": {
+      "filename": "838-10_5.532",
+      "type": "sound"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    }
+  },
+  "eballdp3": {
+    "838-09_4.716": {
+      "filename": "838-09_4.716",
+      "type": "sound"
+    },
+    "838-16_5.532": {
+      "filename": "838-16_5.532",
+      "type": "sound"
+    },
+    "720-xx.u10": {
+      "filename": "720-xx.U10",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-xx.u14": {
+      "filename": "720-xx.U14",
+      "type": "main",
+      "romType": "by"
+    },
+    "xxx-xx.u13": {
+      "filename": "xxx-xx.U13",
+      "type": "main",
+      "romType": "by"
+    },
+    "838-08_3.532": {
+      "filename": "838-08_3.532",
+      "type": "sound"
+    },
+    "ebd68701.2": {
+      "filename": "ebd68701.2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "countdwn": {
+    "422.cpu": {
+      "filename": "422.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "hurr_l2": {
+    "u14.pp": {
+      "filename": "u14.pp",
+      "type": "sound"
+    },
+    "u18.pp": {
+      "filename": "u18.pp",
+      "type": "sound"
+    },
+    "u15.pp": {
+      "filename": "u15.pp",
+      "type": "sound"
+    },
+    "hurcnl_2.rom": {
+      "filename": "hurcnl_2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "mtl_122": {
+    "mtl122.bin": {
+      "filename": "MTL122.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "potc_300gf": {
+    "potc0300gf.bin": {
+      "filename": "potc0300gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_119h": {
+    "twd119le.bin": {
+      "filename": "TWD119LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "smmanb": {
+    "6mi$2732.u2": {
+      "filename": "6mi$2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "3032d7.bin": {
+      "filename": "3032d7.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "alifp": {
+    "fpali_u5.716": {
+      "filename": "fpali_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpali_u1.716": {
+      "filename": "fpali_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "hh7": {
+    "669-s1.snd": {
+      "filename": "669-s1.snd",
+      "type": "sound"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "669-s2.snd": {
+      "filename": "669-s2.snd",
+      "type": "sound"
+    },
+    "669-2.cpu": {
+      "filename": "669-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "stargat1": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "gprom1.bin": {
+      "filename": "gprom1.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "dsprom1.bin": {
+      "filename": "dsprom1.bin",
+      "type": "dmd"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "stargat2": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "gprom2.bin": {
+      "filename": "gprom2.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "dsprom2.bin": {
+      "filename": "dsprom2.bin",
+      "type": "dmd"
+    }
+  },
+  "stargat3": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "gprom3.bin": {
+      "filename": "gprom3.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "dsprom3.bin": {
+      "filename": "dsprom3.bin",
+      "type": "dmd"
+    }
+  },
+  "stargat4": {
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    },
+    "gprom4.bin": {
+      "filename": "gprom4.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "dsprom3.bin": {
+      "filename": "dsprom3.bin",
+      "type": "dmd"
+    }
+  },
+  "trek_117": {
+    "trek.u17": {
+      "filename": "trek.u17",
+      "type": "sound"
+    },
+    "trekcpu.117": {
+      "filename": "trekcpu.117",
+      "type": "main",
+      "romType": "de"
+    },
+    "trek.u21": {
+      "filename": "trek.u21",
+      "type": "sound"
+    },
+    "trekdspa.109": {
+      "filename": "trekdspa.109",
+      "type": "dmd"
+    },
+    "trek.u7": {
+      "filename": "trek.u7",
+      "type": "sound"
+    }
+  },
+  "trek_201": {
+    "trek.u17": {
+      "filename": "trek.u17",
+      "type": "sound"
+    },
+    "trek.u21": {
+      "filename": "trek.u21",
+      "type": "sound"
+    },
+    "trekdspa.109": {
+      "filename": "trekdspa.109",
+      "type": "dmd"
+    },
+    "trekcpuu.201": {
+      "filename": "trekcpuu.201",
+      "type": "main",
+      "romType": "de"
+    },
+    "trek.u7": {
+      "filename": "trek.u7",
+      "type": "sound"
+    }
+  },
+  "hook_404": {
+    "hokcpua.404": {
+      "filename": "hokcpua.404",
+      "type": "main",
+      "romType": "de"
+    },
+    "hokdspa.401": {
+      "filename": "hokdspa.401",
+      "type": "dmd"
+    },
+    "hooksnd.u7": {
+      "filename": "hooksnd.u7",
+      "type": "sound"
+    },
+    "hook-voi.u17": {
+      "filename": "hook-voi.u17",
+      "type": "sound"
+    },
+    "hook-voi.u21": {
+      "filename": "hook-voi.u21",
+      "type": "sound"
+    }
+  },
+  "potc_400ai": {
+    "potc0400ai.bin": {
+      "filename": "potc0400ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ind250cc": {
+    "e-250cc.bin": {
+      "filename": "e-250cc.bin",
+      "type": "sound"
+    },
+    "c-250cc.bin": {
+      "filename": "c-250cc.bin",
+      "type": "sound"
+    },
+    "0-250cc.bin": {
+      "filename": "0-250cc.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "b-250cc.bin": {
+      "filename": "b-250cc.bin",
+      "type": "sound"
+    },
+    "d-250cc.bin": {
+      "filename": "d-250cc.bin",
+      "type": "sound"
+    },
+    "a-250cc.bin": {
+      "filename": "a-250cc.bin",
+      "type": "sound"
+    }
+  },
+  "usafootb": {
+    "usa_cpu.bin": {
+      "filename": "usa_cpu.bin",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "usa_snd.bin": {
+      "filename": "usa_snd.bin",
+      "type": "sound"
+    },
+    "usa_vox.bin": {
+      "filename": "usa_vox.bin",
+      "type": "sound"
+    }
+  },
+  "zira": {
+    "zira_u8.bin": {
+      "filename": "zira_u8.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "zira.snd": {
+      "filename": "zira.snd",
+      "type": "sound"
+    },
+    "zira_u9.bin": {
+      "filename": "zira_u9.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "trident": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "tmnt_104": {
+    "tmntdsp.104": {
+      "filename": "tmntdsp.104",
+      "type": "dmd"
+    },
+    "tmntf6.rom": {
+      "filename": "tmntf6.rom",
+      "type": "sound"
+    },
+    "tmntf7.rom": {
+      "filename": "tmntf7.rom",
+      "type": "sound"
+    },
+    "tmntf4.rom": {
+      "filename": "tmntf4.rom",
+      "type": "sound"
+    },
+    "tmntc5a.104": {
+      "filename": "tmntc5a.104",
+      "type": "main",
+      "romType": "de"
+    },
+    "tmntb5a.104": {
+      "filename": "tmntb5a.104",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "wof_300g": {
+    "wof0300g.bin": {
+      "filename": "wof0300g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "gransla4": {
+    "gr_slam.u2b": {
+      "filename": "gr_slam.u2b",
+      "type": "main",
+      "romType": "by"
+    },
+    "grndslam.u6": {
+      "filename": "grndslam.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "grndslam.u4": {
+      "filename": "grndslam.u4",
+      "type": "sound"
+    }
+  },
+  "bdk_160": {
+    "bat_v1-6_e.bin": {
+      "filename": "bat_v1-6_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lotr_gr8": {
+    "lotrdspg.800": {
+      "filename": "LOTRDSPG.800",
+      "type": "dmd"
+    },
+    "lotrcpu.800": {
+      "filename": "LOTRCPU.800",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "hirolcat": {
+    "hrsndu36.100": {
+      "filename": "hrsndu36.100",
+      "type": "sound"
+    },
+    "hrsndu17.100": {
+      "filename": "hrsndu17.100",
+      "type": "sound"
+    },
+    "hrccput3.300": {
+      "filename": "hrccput3.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "hrsndu7.100": {
+      "filename": "hrsndu7.100",
+      "type": "sound"
+    },
+    "hrsndu21.100": {
+      "filename": "hrsndu21.100",
+      "type": "sound"
+    },
+    "hrsndu37.100": {
+      "filename": "hrsndu37.100",
+      "type": "sound"
+    },
+    "hrcdspt3.300": {
+      "filename": "hrcdspt3.300",
+      "type": "dmd"
+    }
+  },
+  "ij4_116f": {
+    "indy0116f.bin": {
+      "filename": "indy0116f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cheetah2": {
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "lostspc": {
+    "lisu21.100": {
+      "filename": "lisu21.100",
+      "type": "sound"
+    },
+    "lisu36.100": {
+      "filename": "lisu36.100",
+      "type": "sound"
+    },
+    "lisu17.100": {
+      "filename": "lisu17.100",
+      "type": "sound"
+    },
+    "liscpu.101": {
+      "filename": "liscpu.101",
+      "type": "main",
+      "romType": "se"
+    },
+    "lisu7.100": {
+      "filename": "lisu7.100",
+      "type": "sound"
+    },
+    "lisdspa.102": {
+      "filename": "lisdspa.102",
+      "type": "dmd"
+    },
+    "lisu37.100": {
+      "filename": "lisu37.100",
+      "type": "sound"
+    }
+  },
+  "ts_lm6": {
+    "u6-lm6.rom": {
+      "filename": "u6-lm6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "ts_u2_s.l1": {
+      "filename": "ts_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "embryond": {
+    "embd79u6.bin": {
+      "filename": "embd79u6.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "embd78u2.bin": {
+      "filename": "embd78u2.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "841-02_5.532": {
+      "filename": "841-02_5.532",
+      "type": "sound"
+    },
+    "841-01_4.716": {
+      "filename": "841-01_4.716",
+      "type": "sound"
+    }
+  },
+  "abv106r": {
+    "u31_v11i.bin": {
+      "filename": "u31_v11i.bin",
+      "type": "sound"
+    },
+    "u1l_v16i.bin": {
+      "filename": "u1l_v16i.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u29_v10.bin": {
+      "filename": "u29_v10.bin",
+      "type": "sound"
+    },
+    "u2l_v10.bin": {
+      "filename": "u2l_v10.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u1h_v16i.bin": {
+      "filename": "u1h_v16i.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u2h_v10.bin": {
+      "filename": "u2h_v10.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_v10.bin": {
+      "filename": "u28_v10.bin",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u30_v11.bin": {
+      "filename": "u30_v11.bin",
+      "type": "sound"
+    }
+  },
+  "astannie": {
+    "442.cpu": {
+      "filename": "442.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sys1.bin": {
+      "filename": "6530sys1.bin",
+      "type": "sound"
+    },
+    "442.snd": {
+      "filename": "442.snd",
+      "type": "sound"
+    }
+  },
+  "blakpyra": {
+    "bp_u4.532": {
+      "filename": "bp_u4.532",
+      "type": "sound"
+    },
+    "blkp2732.u2": {
+      "filename": "blkp2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "bp_u3.532": {
+      "filename": "bp_u3.532",
+      "type": "sound"
+    },
+    "720-5332.u6": {
+      "filename": "720-5332.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "blakpyrb": {
+    "bp_u4.532": {
+      "filename": "bp_u4.532",
+      "type": "sound"
+    },
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "blkp2732.u2": {
+      "filename": "blkp2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "bp_u3.532": {
+      "filename": "bp_u3.532",
+      "type": "sound"
+    }
+  },
+  "darkshad": {
+    "bp_u4.532": {
+      "filename": "bp_u4.532",
+      "type": "sound"
+    },
+    "cpu_u7.bin": {
+      "filename": "cpu_u7.bin",
+      "type": "main"
+    },
+    "bp_u3.532": {
+      "filename": "bp_u3.532",
+      "type": "sound"
+    }
+  },
+  "biggamfp": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpbg_u2.716": {
+      "filename": "fpbg_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "stars": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "batmanf3": {
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "batcpua.302": {
+      "filename": "batcpua.302",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfrom0a.300": {
+      "filename": "bmfrom0a.300",
+      "type": "dmd"
+    },
+    "bmfrom3a.300": {
+      "filename": "bmfrom3a.300",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "bmf_cn": {
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3a.401": {
+      "filename": "bfdrom3a.401",
+      "type": "dmd"
+    },
+    "bfdrom0a.401": {
+      "filename": "bfdrom0a.401",
+      "type": "dmd"
+    },
+    "batnovc.401": {
+      "filename": "batnovc.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "bmf_jp": {
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3a.401": {
+      "filename": "bfdrom3a.401",
+      "type": "dmd"
+    },
+    "bfdrom0a.401": {
+      "filename": "bfdrom0a.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    },
+    "batnovj.401": {
+      "filename": "batnovj.401",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "bmf_nl": {
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "batnovd.401": {
+      "filename": "batnovd.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bfdrom0f.401": {
+      "filename": "bfdrom0f.401",
+      "type": "dmd"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    },
+    "bfdrom3f.401": {
+      "filename": "bfdrom3f.401",
+      "type": "dmd"
+    }
+  },
+  "bmf_no": {
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3a.401": {
+      "filename": "bfdrom3a.401",
+      "type": "dmd"
+    },
+    "batnovn.401": {
+      "filename": "batnovn.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bfdrom0a.401": {
+      "filename": "bfdrom0a.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "bmf_sv": {
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3a.401": {
+      "filename": "bfdrom3a.401",
+      "type": "dmd"
+    },
+    "batnovt.401": {
+      "filename": "batnovt.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bfdrom0a.401": {
+      "filename": "bfdrom0a.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "bmf_uk": {
+    "bmfu7.bin": {
+      "filename": "bmfu7.bin",
+      "type": "sound"
+    },
+    "bfdrom3a.401": {
+      "filename": "bfdrom3a.401",
+      "type": "dmd"
+    },
+    "batnove.401": {
+      "filename": "batnove.401",
+      "type": "main",
+      "romType": "de"
+    },
+    "bfdrom0a.401": {
+      "filename": "bfdrom0a.401",
+      "type": "dmd"
+    },
+    "bmfu21.bin": {
+      "filename": "bmfu21.bin",
+      "type": "sound"
+    },
+    "bmfu17.bin": {
+      "filename": "bmfu17.bin",
+      "type": "sound"
+    }
+  },
+  "wsports": {
+    "ws1.bin": {
+      "filename": "ws1.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "ws5.bin": {
+      "filename": "ws5.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "ws4.bin": {
+      "filename": "ws4.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "ws2.bin": {
+      "filename": "ws2.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "ws3.bin": {
+      "filename": "ws3.bin",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "snspare1": {
+    "gprom1.bin": {
+      "filename": "gprom1.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "ts_la4": {
+    "u6-la4.rom": {
+      "filename": "u6-la4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "ts_u2_s.l1": {
+      "filename": "ts_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "lotr_it4": {
+    "lotrdspi.403": {
+      "filename": "lotrdspi.403",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrcpu.401": {
+      "filename": "lotrcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "agent777": {
+    "770c": {
+      "filename": "770c",
+      "type": "main",
+      "romType": "gp"
+    },
+    "770snd": {
+      "filename": "770snd",
+      "type": "sound"
+    },
+    "770b": {
+      "filename": "770b",
+      "type": "main",
+      "romType": "gp"
+    },
+    "770a": {
+      "filename": "770a",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "bighurt": {
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "abv106": {
+    "u1l_v16.bin": {
+      "filename": "u1l_v16.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u29_v10.bin": {
+      "filename": "u29_v10.bin",
+      "type": "sound"
+    },
+    "u2l_v10.bin": {
+      "filename": "u2l_v10.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u1h_v16.bin": {
+      "filename": "u1h_v16.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u2h_v10.bin": {
+      "filename": "u2h_v10.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u28_v10.bin": {
+      "filename": "u28_v10.bin",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u30_v11.bin": {
+      "filename": "u30_v11.bin",
+      "type": "sound"
+    }
+  },
+  "twd_105": {
+    "twdv1-05.ebi": {
+      "filename": "TWDV1-05.EBI",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ww_l4": {
+    "u6-l4.rom": {
+      "filename": "u6-l4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u18.l1": {
+      "filename": "ww_u18.l1",
+      "type": "sound"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    },
+    "ww_u15.l1": {
+      "filename": "ww_u15.l1",
+      "type": "sound"
+    }
+  },
+  "twd_153": {
+    "twd_153.bin": {
+      "filename": "twd_153.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "xmen_104": {
+    "xmen_104.bin": {
+      "filename": "xmen_104.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "acd_168h": {
+    "acd168le.bin": {
+      "filename": "ACD168LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "blkfever": {
+    "blackf11.bin": {
+      "filename": "BLACKF11.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "blackf8.bin": {
+      "filename": "blackf8.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "blackf10.bin": {
+      "filename": "BLACKF10.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "blackf9.bin": {
+      "filename": "BLACKF9.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "gldneye": {
+    "bondcpu.404": {
+      "filename": "bondcpu.404",
+      "type": "main",
+      "romType": "se"
+    },
+    "bondu21.bin": {
+      "filename": "bondu21.bin",
+      "type": "sound"
+    },
+    "bondu7.bin": {
+      "filename": "bondu7.bin",
+      "type": "sound"
+    },
+    "bondispa.400": {
+      "filename": "bondispa.400",
+      "type": "dmd"
+    },
+    "bondu17.bin": {
+      "filename": "bondu17.bin",
+      "type": "sound"
+    }
+  },
+  "lostwldb": {
+    "lost2732.u2": {
+      "filename": "lost2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "72832fn.u6": {
+      "filename": "72832fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "mtl_106": {
+    "mtl_106.bin": {
+      "filename": "mtl_106.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lw3_205": {
+    "lw3gc5.205": {
+      "filename": "lw3gc5.205",
+      "type": "main",
+      "romType": "de"
+    },
+    "lw3u21.dat": {
+      "filename": "lw3u21.dat",
+      "type": "sound"
+    },
+    "lw3dsp1.205": {
+      "filename": "lw3dsp1.205",
+      "type": "dmd"
+    },
+    "lw3u7.dat": {
+      "filename": "lw3u7.dat",
+      "type": "sound"
+    },
+    "lw3dsp0.205": {
+      "filename": "lw3dsp0.205",
+      "type": "dmd"
+    },
+    "lw3u17.dat": {
+      "filename": "lw3u17.dat",
+      "type": "sound"
+    }
+  },
+  "sfight2a": {
+    "gprom1.bin": {
+      "filename": "gprom1.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "dsprom2.bin": {
+      "filename": "dsprom2.bin",
+      "type": "dmd"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    },
+    "arom2.bin": {
+      "filename": "arom2.bin",
+      "type": "sound"
+    },
+    "yrom1.bin": {
+      "filename": "yrom1.bin",
+      "type": "sound"
+    },
+    "drom1.bin": {
+      "filename": "drom1.bin",
+      "type": "sound"
+    }
+  },
+  "gw_p7": {
+    "gwhs2-p7.rom": {
+      "filename": "gwhs2-p7.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "u18-sp1.rom": {
+      "filename": "u18-sp1.rom",
+      "type": "sound"
+    }
+  },
+  "pmv112": {
+    "u28_v10.bin": {
+      "filename": "u28_v10.bin",
+      "type": "sound"
+    },
+    "u29_v10.bin": {
+      "filename": "u29_v10.bin",
+      "type": "sound"
+    },
+    "u2h_v10.bin": {
+      "filename": "u2h_v10.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u30_v16.bin": {
+      "filename": "u30_v16.bin",
+      "type": "sound"
+    },
+    "u1l_v112.bin": {
+      "filename": "u1l_v112.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u2l_v10.bin": {
+      "filename": "u2l_v10.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u1h_v112.bin": {
+      "filename": "u1h_v112.bin",
+      "type": "main",
+      "romType": "capcom"
+    }
+  },
+  "tftc_104": {
+    "sndu17.dat": {
+      "filename": "sndu17.dat",
+      "type": "sound"
+    },
+    "sndu7.dat": {
+      "filename": "sndu7.dat",
+      "type": "sound"
+    },
+    "tftcdspl.103": {
+      "filename": "tftcdspl.103",
+      "type": "dmd"
+    },
+    "sndu21.dat": {
+      "filename": "sndu21.dat",
+      "type": "sound"
+    },
+    "tftccpua.104": {
+      "filename": "tftccpua.104",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "olympic": {
+    "jeutel-sound-j0.bin": {
+      "filename": "Jeutel-Sound-J0.bin",
+      "type": "main"
+    },
+    "jeutel-sound-p.bin": {
+      "filename": "Jeutel-Sound-P.bin",
+      "type": "main"
+    },
+    "jeutel-game-jo1.bin": {
+      "filename": "Jeutel-Game-JO1.bin",
+      "type": "main"
+    },
+    "jeutel-game-v.bin": {
+      "filename": "Jeutel-Game-V.bin",
+      "type": "main"
+    }
+  },
+  "centaura": {
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "848-01_3.532": {
+      "filename": "848-01_3.532",
+      "type": "sound"
+    },
+    "848-08_2.732": {
+      "filename": "848-08_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "848-05_5.716": {
+      "filename": "848-05_5.716",
+      "type": "sound"
+    },
+    "848-02_4.532": {
+      "filename": "848-02_4.532",
+      "type": "sound"
+    }
+  },
+  "m_mpaca": {
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "872-04_2.732": {
+      "filename": "872-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "872-03_5.532": {
+      "filename": "872-03_5.532",
+      "type": "sound"
+    },
+    "872-01_4.532": {
+      "filename": "872-01_4.532",
+      "type": "sound"
+    }
+  },
+  "speake4a": {
+    "7536fn.u6": {
+      "filename": "7536fn.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "877-01_4.716": {
+      "filename": "877-01_4.716",
+      "type": "sound"
+    },
+    "877-04_2.732": {
+      "filename": "877-04_2.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "snspare2": {
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "gprom2.bin": {
+      "filename": "gprom2.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "snspares": {
+    "dsprom.bin": {
+      "filename": "dsprom.bin",
+      "type": "dmd"
+    },
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "arom1.bin": {
+      "filename": "arom1.bin",
+      "type": "sound"
+    }
+  },
+  "titan1": {
+    "titn_s2a.bin": {
+      "filename": "titn_s2a.bin",
+      "type": "sound"
+    },
+    "titn_s1a.bin": {
+      "filename": "titn_s1a.bin",
+      "type": "sound"
+    },
+    "titan1a.bin": {
+      "filename": "titan1a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "titan3.bin": {
+      "filename": "titan3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "titan2.bin": {
+      "filename": "titan2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "titan4.bin": {
+      "filename": "titan4.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "drakor": {
+    "drako_s1.bin": {
+      "filename": "drako_s1.bin",
+      "type": "sound"
+    },
+    "drakor1.bin": {
+      "filename": "drakor1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "drakor2.bin": {
+      "filename": "drakor2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "drakor3.bin": {
+      "filename": "drakor3.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "tf_150h": {
+    "tfle1-50.bin": {
+      "filename": "TFLE1-50.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "totem": {
+    "429.snd": {
+      "filename": "429.snd",
+      "type": "sound"
+    },
+    "429.cpu": {
+      "filename": "429.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sys1.bin": {
+      "filename": "6530sys1.bin",
+      "type": "sound"
+    }
+  },
+  "potc_600as": {
+    "potc0600as.bin": {
+      "filename": "potc0600as.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bowarrow": {
+    "b18.bin": {
+      "filename": "b18.bin",
+      "type": "main"
+    },
+    "b1c.bin": {
+      "filename": "b1c.bin",
+      "type": "main"
+    },
+    "b1a.bin": {
+      "filename": "b1a.bin",
+      "type": "main"
+    },
+    "b16.bin": {
+      "filename": "b16.bin",
+      "type": "main"
+    },
+    "b14.bin": {
+      "filename": "b14.bin",
+      "type": "main"
+    },
+    "b1e.bin": {
+      "filename": "b1e.bin",
+      "type": "main"
+    }
+  },
+  "suprbowl": {
+    "720_u3.snd": {
+      "filename": "720_U3.SND",
+      "type": "sound"
+    },
+    "sbowlu6.732": {
+      "filename": "sbowlu6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "sbowlu2.732": {
+      "filename": "sbowlu2.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "xmen_121h": {
+    "xmen_121h.bin": {
+      "filename": "xmen_121h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ww_lh5": {
+    "ww_lh5.rom": {
+      "filename": "ww_lh5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u18.l1": {
+      "filename": "ww_u18.l1",
+      "type": "sound"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    },
+    "ww_u15.l1": {
+      "filename": "ww_u15.l1",
+      "type": "sound"
+    }
+  },
+  "m_mpac": {
+    "872-04_2.732": {
+      "filename": "872-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "872-03_5.532": {
+      "filename": "872-03_5.532",
+      "type": "sound"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "872-01_4.532": {
+      "filename": "872-01_4.532",
+      "type": "sound"
+    }
+  },
+  "hothand": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "pinclown": {
+    "clown_f.bin": {
+      "filename": "clown_f.bin",
+      "type": "sound"
+    },
+    "clown_e.bin": {
+      "filename": "clown_e.bin",
+      "type": "sound"
+    },
+    "clown_b.bin": {
+      "filename": "clown_b.bin",
+      "type": "sound"
+    },
+    "clown_a.bin": {
+      "filename": "clown_a.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "clown_d.bin": {
+      "filename": "clown_d.bin",
+      "type": "sound"
+    },
+    "clown_c.bin": {
+      "filename": "clown_c.bin",
+      "type": "sound"
+    }
+  },
+  "wpt_140g": {
+    "wpt1400g.bin": {
+      "filename": "wpt1400g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_119": {
+    "twd_119.bin": {
+      "filename": "twd_119.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "newwave": {
+    "blkp2732.u2": {
+      "filename": "blkp2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "newwu4.532": {
+      "filename": "newwu4.532",
+      "type": "sound"
+    },
+    "bp_u3.532": {
+      "filename": "bp_u3.532",
+      "type": "sound"
+    },
+    "newwu6.532": {
+      "filename": "newwu6.532",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wldcp_l1": {
+    "white2wc.716": {
+      "filename": "white2wc.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "white1.716": {
+      "filename": "white1.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "wpt_111l": {
+    "wpt0111l.bin": {
+      "filename": "wpt0111l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "spain82": {
+    "spasnd.bin": {
+      "filename": "SPASND.BIN",
+      "type": "sound"
+    },
+    "spaic11.bin": {
+      "filename": "SPAIC11.BIN",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "spaic12.bin": {
+      "filename": "SPAIC12.BIN",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "ngg_10": {
+    "nggsndl1.s2": {
+      "filename": "nggsndl1.s2",
+      "type": "sound"
+    },
+    "ngg_10.rom": {
+      "filename": "NGG_10.ROM",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nggsndl1.s3": {
+      "filename": "nggsndl1.s3",
+      "type": "sound"
+    },
+    "nggsndl1.s4": {
+      "filename": "nggsndl1.s4",
+      "type": "sound"
+    },
+    "nggsndl1.s6": {
+      "filename": "nggsndl1.s6",
+      "type": "sound"
+    },
+    "nggsndl1.s5": {
+      "filename": "nggsndl1.s5",
+      "type": "sound"
+    }
+  },
+  "ngg_12": {
+    "nggsndl1.s2": {
+      "filename": "nggsndl1.s2",
+      "type": "sound"
+    },
+    "nggsndl1.s3": {
+      "filename": "nggsndl1.s3",
+      "type": "sound"
+    },
+    "nggsndl1.s4": {
+      "filename": "nggsndl1.s4",
+      "type": "sound"
+    },
+    "nggsndl1.s6": {
+      "filename": "nggsndl1.s6",
+      "type": "sound"
+    },
+    "nggsndl1.s5": {
+      "filename": "nggsndl1.s5",
+      "type": "sound"
+    },
+    "go_g11.1_2": {
+      "filename": "go_g11.1_2",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "ngg_13": {
+    "nggsndl1.s2": {
+      "filename": "nggsndl1.s2",
+      "type": "sound"
+    },
+    "go_g11.1_3": {
+      "filename": "go_g11.1_3",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nggsndl1.s3": {
+      "filename": "nggsndl1.s3",
+      "type": "sound"
+    },
+    "nggsndl1.s4": {
+      "filename": "nggsndl1.s4",
+      "type": "sound"
+    },
+    "nggsndl1.s6": {
+      "filename": "nggsndl1.s6",
+      "type": "sound"
+    },
+    "nggsndl1.s5": {
+      "filename": "nggsndl1.s5",
+      "type": "sound"
+    }
+  },
+  "hotwheel": {
+    "zac_boot.lgc": {
+      "filename": "zac_boot.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "htwhls_3.lgc": {
+      "filename": "htwhls_3.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "htwhls_2.lgc": {
+      "filename": "htwhls_2.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "htwhls_4.lgc": {
+      "filename": "htwhls_4.lgc",
+      "type": "main",
+      "romType": "zac"
+    },
+    "htwhls_5.lgc": {
+      "filename": "htwhls_5.lgc",
+      "type": "main",
+      "romType": "zac"
+    }
+  },
+  "ts_la2": {
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "cpu-u6l2.rom": {
+      "filename": "cpu-u6l2.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u2_s.l1": {
+      "filename": "ts_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "ts_la6": {
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "u6-la6.rom": {
+      "filename": "u6-la6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "ts_u2_s.l1": {
+      "filename": "ts_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "ts_lf6": {
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "u6-lf6.rom": {
+      "filename": "u6-lf6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "ts_u2_s.l1": {
+      "filename": "ts_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "ts_lx5": {
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "shad_x5.rom": {
+      "filename": "shad_x5.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u2_s.l1": {
+      "filename": "ts_u2_s.l1",
+      "type": "sound"
+    }
+  },
+  "ts_pa1": {
+    "ts_u7_s.l1": {
+      "filename": "ts_u7_s.l1",
+      "type": "sound"
+    },
+    "ts_u6_s.l1": {
+      "filename": "ts_u6_s.l1",
+      "type": "sound"
+    },
+    "cpu-u6p1.rom": {
+      "filename": "cpu-u6p1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ts_u4_s.l1": {
+      "filename": "ts_u4_s.l1",
+      "type": "sound"
+    },
+    "ts_u5_s.l1": {
+      "filename": "ts_u5_s.l1",
+      "type": "sound"
+    },
+    "ts_u3_s.l1": {
+      "filename": "ts_u3_s.l1",
+      "type": "sound"
+    },
+    "su2-sp2.rom": {
+      "filename": "su2-sp2.rom",
+      "type": "sound"
+    }
+  },
+  "vikingb": {
+    "802-07-4.716": {
+      "filename": "802-07-4.716",
+      "type": "sound"
+    },
+    "vikg2732.u2": {
+      "filename": "vikg2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "twd_141h": {
+    "twd141le.bin": {
+      "filename": "TWD141LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ngndshkr": {
+    "776-15_4.716": {
+      "filename": "776-15_4.716",
+      "type": "sound"
+    },
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "776-11_2.716": {
+      "filename": "776-11_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "776-17_1.716": {
+      "filename": "776-17_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wpt_108l": {
+    "wpt0108l.bin": {
+      "filename": "wpt0108l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_150": {
+    "mtl15.bin": {
+      "filename": "MTL15.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "matatest": {
+    "matat0n.u2": {
+      "filename": "matat0n.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "ptestn.u6": {
+      "filename": "ptestn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "mt_140hb": {
+    "mt_140hb.bin": {
+      "filename": "mt_140hb.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bullseye": {
+    "bull.u6": {
+      "filename": "bull.u6",
+      "type": "main"
+    },
+    "bull.u2": {
+      "filename": "bull.u2",
+      "type": "main"
+    },
+    "bull.snd": {
+      "filename": "bull.snd",
+      "type": "main"
+    }
+  },
+  "forceii7": {
+    "661.snd": {
+      "filename": "661.snd",
+      "type": "sound"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "661-2.cpu": {
+      "filename": "661-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "speakes4": {
+    "877-01_4.716": {
+      "filename": "877-01_4.716",
+      "type": "sound"
+    },
+    "877-04_2.732": {
+      "filename": "877-04_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "lotr_fr8": {
+    "lotrcpu.800": {
+      "filename": "LOTRCPU.800",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrdspf.800": {
+      "filename": "LOTRDSPF.800",
+      "type": "dmd"
+    }
+  },
+  "lotr_it8": {
+    "lotrcpu.800": {
+      "filename": "LOTRCPU.800",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspi.800": {
+      "filename": "LOTRDSPI.800",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "wpt_109f2": {
+    "wpt0109f-2.bin": {
+      "filename": "wpt0109f-2.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wof_500g": {
+    "wof0500g.bin": {
+      "filename": "wof0500g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "tagteam": {
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "698-s.snd": {
+      "filename": "698-s.snd",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "hd_l3": {
+    "harly_l3.rom": {
+      "filename": "harly_l3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "hd_u18.rom": {
+      "filename": "hd_u18.rom",
+      "type": "sound"
+    },
+    "hd_u15.rom": {
+      "filename": "hd_u15.rom",
+      "type": "sound"
+    }
+  },
+  "wof_500": {
+    "wof_500.bin": {
+      "filename": "wof_500.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "xmen_124h": {
+    "xmle1-24.bin": {
+      "filename": "XMLE1-24.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_164": {
+    "mtl164.bin": {
+      "filename": "MTL164.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "shrky_fr": {
+    "sscpu.211": {
+      "filename": "sscpu.211",
+      "type": "main",
+      "romType": "se"
+    },
+    "sssndu36.100": {
+      "filename": "sssndu36.100",
+      "type": "sound"
+    },
+    "sssndu17.100": {
+      "filename": "sssndu17.100",
+      "type": "sound"
+    },
+    "sssndu21.100": {
+      "filename": "sssndu21.100",
+      "type": "sound"
+    },
+    "sssndu7.101": {
+      "filename": "sssndu7.101",
+      "type": "sound"
+    }
+  },
+  "shrky_gr": {
+    "sscpu.211": {
+      "filename": "sscpu.211",
+      "type": "main",
+      "romType": "se"
+    },
+    "sssndu36.100": {
+      "filename": "sssndu36.100",
+      "type": "sound"
+    },
+    "sssndu17.100": {
+      "filename": "sssndu17.100",
+      "type": "sound"
+    },
+    "sssndu21.100": {
+      "filename": "sssndu21.100",
+      "type": "sound"
+    },
+    "sssndu7.101": {
+      "filename": "sssndu7.101",
+      "type": "sound"
+    }
+  },
+  "shrky_it": {
+    "sscpu.211": {
+      "filename": "sscpu.211",
+      "type": "main",
+      "romType": "se"
+    },
+    "sssndu36.100": {
+      "filename": "sssndu36.100",
+      "type": "sound"
+    },
+    "sssndu17.100": {
+      "filename": "sssndu17.100",
+      "type": "sound"
+    },
+    "sssndu21.100": {
+      "filename": "sssndu21.100",
+      "type": "sound"
+    },
+    "sssndu7.101": {
+      "filename": "sssndu7.101",
+      "type": "sound"
+    }
+  },
+  "granslam": {
+    "grndslam.u2": {
+      "filename": "grndslam.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "grndslam.u6": {
+      "filename": "grndslam.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "grndslam.u4": {
+      "filename": "grndslam.u4",
+      "type": "sound"
+    }
+  },
+  "xmen_123h": {
+    "xmen_123h.bin": {
+      "filename": "xmen_123h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lostspcg": {
+    "lisdspg.102": {
+      "filename": "lisdspg.102",
+      "type": "dmd"
+    }
+  },
+  "wpt_109a": {
+    "wpt0109a.bin": {
+      "filename": "wpt0109a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "spiderm7": {
+    "653-1.cpu": {
+      "filename": "653-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "653.snd": {
+      "filename": "653.snd",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    },
+    "653-2.cpu": {
+      "filename": "653-2.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "pop_lx4": {
+    "peye_lx4.rom": {
+      "filename": "peye_lx4.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "mt_145": {
+    "mt_145.bin": {
+      "filename": "mt_145.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "freefafp": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpff_u2.716": {
+      "filename": "fpff_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    }
+  },
+  "freefall": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "snd_u10.716": {
+      "filename": "snd_u10.716",
+      "type": "sound"
+    },
+    "snd_u9.716": {
+      "filename": "snd_u9.716",
+      "type": "sound"
+    }
+  },
+  "swtril41": {
+    "sw0211.u17": {
+      "filename": "sw0211.u17",
+      "type": "sound"
+    },
+    "sw0211.u21": {
+      "filename": "sw0211.u21",
+      "type": "sound"
+    },
+    "swcpu.401": {
+      "filename": "swcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "swsedspa.400": {
+      "filename": "swsedspa.400",
+      "type": "dmd"
+    },
+    "sw0219.u7": {
+      "filename": "sw0219.u7",
+      "type": "sound"
+    }
+  },
+  "swtril43": {
+    "sw0211.u17": {
+      "filename": "sw0211.u17",
+      "type": "sound"
+    },
+    "sw0211.u21": {
+      "filename": "sw0211.u21",
+      "type": "sound"
+    },
+    "swsedspa.400": {
+      "filename": "swsedspa.400",
+      "type": "dmd"
+    },
+    "sw0219.u7": {
+      "filename": "sw0219.u7",
+      "type": "sound"
+    },
+    "swcpu.403": {
+      "filename": "swcpu.403",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "ngg_p06": {
+    "nggsndl1.s3": {
+      "filename": "nggsndl1.s3",
+      "type": "sound"
+    },
+    "nggsndl1.s4": {
+      "filename": "nggsndl1.s4",
+      "type": "sound"
+    },
+    "nggsndl1.s6": {
+      "filename": "nggsndl1.s6",
+      "type": "sound"
+    },
+    "ngg_s2.0_2": {
+      "filename": "ngg_s2.0_2",
+      "type": "sound"
+    },
+    "ngg0_6.rom": {
+      "filename": "ngg0_6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "nggsndl1.s5": {
+      "filename": "nggsndl1.s5",
+      "type": "sound"
+    }
+  },
+  "cityslck": {
+    "u7_snd.512": {
+      "filename": "u7_snd.512",
+      "type": "sound"
+    },
+    "u2.128": {
+      "filename": "u2.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "u3.128": {
+      "filename": "u3.128",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "avr_106": {
+    "av_106.bin": {
+      "filename": "av_106.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cheetah": {
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "cheetah1": {
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "spcteam": {
+    "space team sound.bin": {
+      "filename": "space team sound.bin",
+      "type": "main"
+    },
+    "cpu_top.bin": {
+      "filename": "cpu_top.bin",
+      "type": "main"
+    }
+  },
+  "sman_130af": {
+    "spd_1_30_ef.bin": {
+      "filename": "spd_1_30_ef.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "papillon": {
+    "u6.dat": {
+      "filename": "u6.dat",
+      "type": "main"
+    },
+    "u5.dat": {
+      "filename": "u5.dat",
+      "type": "main"
+    },
+    "u4.dat": {
+      "filename": "u4.dat",
+      "type": "main"
+    }
+  },
+  "twd_111": {
+    "twd111.bin": {
+      "filename": "TWD111.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cavnegr2": {
+    "cn1.bin": {
+      "filename": "cn1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn2.bin": {
+      "filename": "cn2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn_s2.bin": {
+      "filename": "cn_s2.bin",
+      "type": "sound"
+    },
+    "cn_s1.bin": {
+      "filename": "cn_s1.bin",
+      "type": "sound"
+    },
+    "cn4b.bin": {
+      "filename": "cn4b.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "cn3b.bin": {
+      "filename": "cn3b.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "solaride": {
+    "421.cpu": {
+      "filename": "421.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "acd_160": {
+    "acd_160.bin": {
+      "filename": "acd_160.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "jngld_nt": {
+    "ic26.bin": {
+      "filename": "ic26.bin",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.bin": {
+      "filename": "ic14.bin",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "seawitch": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "bdk_240": {
+    "bdk240.bin": {
+      "filename": "bdk240.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "pwerplab": {
+    "powr2732.u2": {
+      "filename": "powr2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "72132fn.u6": {
+      "filename": "72132fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "tagteam2": {
+    "prom2a.cpu": {
+      "filename": "prom2a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1a.cpu": {
+      "filename": "prom1a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "698-s.snd": {
+      "filename": "698-s.snd",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "jamesb7": {
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "658.snd": {
+      "filename": "658.snd",
+      "type": "sound"
+    },
+    "658-1.cpu": {
+      "filename": "658-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "jamesb7b": {
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "658.snd": {
+      "filename": "658.snd",
+      "type": "sound"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "658-x.cpu": {
+      "filename": "658-x.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "mars7": {
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "666-1.cpu": {
+      "filename": "666-1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "666-s1.snd": {
+      "filename": "666-s1.snd",
+      "type": "sound"
+    },
+    "666-s2.snd": {
+      "filename": "666-s2.snd",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "vlcno_b7": {
+    "u3g807dc.bin": {
+      "filename": "u3g807dc.bin",
+      "type": "main"
+    },
+    "667-a-s.snd": {
+      "filename": "667-a-s.snd",
+      "type": "sound"
+    },
+    "667-1b.cpu": {
+      "filename": "667-1b.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "6530sy80.bin": {
+      "filename": "6530sy80.bin",
+      "type": "sound"
+    },
+    "u2g807dc.bin": {
+      "filename": "u2g807dc.bin",
+      "type": "main"
+    }
+  },
+  "bdk_202": {
+    "bdk_220.bin": {
+      "filename": "bdk_220.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "dollyptb": {
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    },
+    "doll2732.u2": {
+      "filename": "doll2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "dollyptn": {
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    },
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "777-13_2.716": {
+      "filename": "777-13_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "777-10_1.716": {
+      "filename": "777-10_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "hglbtrtb": {
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    },
+    "harl2732.u2": {
+      "filename": "harl2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "penthouse": {
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    },
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    },
+    "harl2732.u2": {
+      "filename": "harl2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "paragonb": {
+    "729-51_3.123": {
+      "filename": "729-51_3.123",
+      "type": "sound"
+    },
+    "para2732.u2": {
+      "filename": "para2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "3032d7.bin": {
+      "filename": "3032d7.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "drac_p11": {
+    "u6-p11.rom": {
+      "filename": "u6-p11.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "ufo_x": {
+    "ufoxu3.rom": {
+      "filename": "UFOXU3.ROM",
+      "type": "sound"
+    },
+    "ufoxu4.rom": {
+      "filename": "UFOXU4.ROM",
+      "type": "sound"
+    },
+    "ufoxcpu.rom": {
+      "filename": "UFOXCPU.ROM",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "farfalla": {
+    "cpurom2.bin": {
+      "filename": "cpurom2.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rom2.snd": {
+      "filename": "rom2.snd",
+      "type": "sound"
+    },
+    "cpurom1.bin": {
+      "filename": "cpurom1.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rom1.snd": {
+      "filename": "rom1.snd",
+      "type": "sound"
+    },
+    "rom3.snd": {
+      "filename": "rom3.snd",
+      "type": "sound"
+    }
+  },
+  "farfalli": {
+    "cpurom2.bin": {
+      "filename": "cpurom2.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "rom2.snd": {
+      "filename": "rom2.snd",
+      "type": "sound"
+    },
+    "cpurom1.bin": {
+      "filename": "cpurom1.bin",
+      "type": "main",
+      "romType": "zac"
+    },
+    "farsnd3.bin": {
+      "filename": "farsnd3.bin",
+      "type": "sound"
+    },
+    "farsnd1.bin": {
+      "filename": "farsnd1.bin",
+      "type": "sound"
+    }
+  },
+  "ww_l3": {
+    "ww_u18.l1": {
+      "filename": "ww_u18.l1",
+      "type": "sound"
+    },
+    "u6-l3.rom": {
+      "filename": "u6-l3.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    },
+    "ww_u15.l1": {
+      "filename": "ww_u15.l1",
+      "type": "sound"
+    }
+  },
+  "ww_lh6": {
+    "ww_u18.l1": {
+      "filename": "ww_u18.l1",
+      "type": "sound"
+    },
+    "ww_lh6.rom": {
+      "filename": "ww_lh6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    },
+    "ww_u15.l1": {
+      "filename": "ww_u15.l1",
+      "type": "sound"
+    }
+  },
+  "ww_lh6c": {
+    "ww_u18.l1": {
+      "filename": "ww_u18.l1",
+      "type": "sound"
+    },
+    "ww_lh6c.rom": {
+      "filename": "ww_lh6c.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "ww_u14.l1": {
+      "filename": "ww_u14.l1",
+      "type": "sound"
+    },
+    "ww_u15.l1": {
+      "filename": "ww_u15.l1",
+      "type": "sound"
+    }
+  },
+  "st_140h": {
+    "st_140h.bin": {
+      "filename": "st_140h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "suprnova": {
+    "150c.716": {
+      "filename": "150c.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "150b.716": {
+      "filename": "150b.716",
+      "type": "main",
+      "romType": "gp"
+    },
+    "130a.716": {
+      "filename": "130a.716",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "fldragon": {
+    "fldrcpu2.rom": {
+      "filename": "fldrcpu2.rom",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "fldrcpu1.rom": {
+      "filename": "fldrcpu1.rom",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "xmen_102": {
+    "xmen_102.bin": {
+      "filename": "xmen_102.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "hd_l1": {
+    "u18-sp1.rom": {
+      "filename": "u18-sp1.rom",
+      "type": "sound"
+    },
+    "u6-l1.rom": {
+      "filename": "u6-l1.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "hd_u15.rom": {
+      "filename": "hd_u15.rom",
+      "type": "sound"
+    }
+  },
+  "walkyria": {
+    "wk_game.bin": {
+      "filename": "wk_game.bin",
+      "type": "main"
+    },
+    "wk_sound.bin": {
+      "filename": "wk_sound.bin",
+      "type": "main"
+    }
+  },
+  "hothanfp": {
+    "fphoth_6.716": {
+      "filename": "fphoth_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fphoth_2.716": {
+      "filename": "fphoth_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "sc_18s2": {
+    "su2-24g.rom": {
+      "filename": "su2-24g.rom",
+      "type": "sound"
+    },
+    "safsnds3.rom": {
+      "filename": "safsnds3.rom",
+      "type": "sound"
+    },
+    "safsnds4.rom": {
+      "filename": "safsnds4.rom",
+      "type": "sound"
+    },
+    "safe_18g.rom": {
+      "filename": "safe_18g.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "kissb": {
+    "kiss2732.u2": {
+      "filename": "kiss2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "3032d7.bin": {
+      "filename": "3032d7.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "ij4_114g": {
+    "indy0114g.bin": {
+      "filename": "indy0114g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bsv102r": {
+    "u1h_v12i.bin": {
+      "filename": "u1h_v12i.bin",
+      "type": "main",
+      "romType": "capcom"
+    },
+    "u30_v10i.bin": {
+      "filename": "u30_v10i.bin",
+      "type": "sound"
+    },
+    "u28_v11.bin": {
+      "filename": "u28_v11.bin",
+      "type": "sound"
+    },
+    "u29_v11.bin": {
+      "filename": "u29_v11.bin",
+      "type": "sound"
+    },
+    "u24_v11.bin": {
+      "filename": "u24_v11.bin",
+      "type": "sound"
+    },
+    "u1l_v12i.bin": {
+      "filename": "u1l_v12i.bin",
+      "type": "main",
+      "romType": "capcom"
+    }
+  },
+  "im2_120": {
+    "im2_120.bin": {
+      "filename": "im2_120.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lortium": {
+    "cpulort2.dat": {
+      "filename": "cpulort2.dat",
+      "type": "main",
+      "romType": "jp"
+    }
+  },
+  "wpt_106a": {
+    "wpt0106a.bin": {
+      "filename": "wpt0106a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "buckrgrs": {
+    "437.snd": {
+      "filename": "437.snd",
+      "type": "sound"
+    },
+    "6530sys1.bin": {
+      "filename": "6530sys1.bin",
+      "type": "sound"
+    },
+    "437.cpu": {
+      "filename": "437.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "punchy": {
+    "epc061.r02": {
+      "filename": "epc061.r02",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "eps062.r02": {
+      "filename": "eps062.r02",
+      "type": "sound"
+    },
+    "eps061.r02": {
+      "filename": "eps061.r02",
+      "type": "sound"
+    }
+  },
+  "acd_160h": {
+    "acd_160h.bin": {
+      "filename": "acd_160h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "jplstw22": {
+    "jp2_u7.bin": {
+      "filename": "jp2_u7.bin",
+      "type": "sound"
+    },
+    "jp2_u17.bin": {
+      "filename": "jp2_u17.bin",
+      "type": "sound"
+    },
+    "jp2dspa.201": {
+      "filename": "jp2dspa.201",
+      "type": "dmd"
+    },
+    "jp2_u21.bin": {
+      "filename": "jp2_u21.bin",
+      "type": "sound"
+    },
+    "jp2cpu.202": {
+      "filename": "jp2cpu.202",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "taf_p2": {
+    "afsnd_p2.rom": {
+      "filename": "afsnd_p2.rom",
+      "type": "sound"
+    },
+    "addam_p2.rom": {
+      "filename": "addam_p2.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "punchy3": {
+    "eps062.r02": {
+      "filename": "eps062.r02",
+      "type": "sound"
+    },
+    "epc061.r03": {
+      "filename": "epc061.r03",
+      "type": "main",
+      "romType": "alvin"
+    },
+    "eps061.r02": {
+      "filename": "eps061.r02",
+      "type": "sound"
+    }
+  },
+  "wpt_108i": {
+    "wpt0108i.bin": {
+      "filename": "wpt0108i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "st_161h": {
+    "st_161h.bin": {
+      "filename": "st_161h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lotr_gr4": {
+    "lotrdspg.403": {
+      "filename": "lotrdspg.403",
+      "type": "dmd"
+    },
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrcpu.401": {
+      "filename": "lotrcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "bbh_160": {
+    "bbh_160.bin": {
+      "filename": "bbh_160.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wof_300i": {
+    "wof0300i.bin": {
+      "filename": "wof0300i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sharkt": {
+    "shark_s1.bin": {
+      "filename": "shark_s1.bin",
+      "type": "sound"
+    },
+    "shark3.bin": {
+      "filename": "shark3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "shark4.bin": {
+      "filename": "shark4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "shark2.bin": {
+      "filename": "shark2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "shark1.bin": {
+      "filename": "shark1.bin",
+      "type": "main",
+      "romType": "taito"
+    }
+  },
+  "attack": {
+    "attack10.bin": {
+      "filename": "ATTACK10.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "attack11.bin": {
+      "filename": "ATTACK11.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "attack8.bin": {
+      "filename": "ATTACK8.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "attack9.bin": {
+      "filename": "ATTACK9.bin",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "csi_102": {
+    "csi102a.bin": {
+      "filename": "csi102a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bop_l7": {
+    "tmbopl_7.rom": {
+      "filename": "tmbopl_7.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mach_u14.l1": {
+      "filename": "mach_u14.l1",
+      "type": "sound"
+    },
+    "mach_u18.l1": {
+      "filename": "mach_u18.l1",
+      "type": "sound"
+    },
+    "mach_u15.l1": {
+      "filename": "mach_u15.l1",
+      "type": "sound"
+    }
+  },
+  "sman_160al": {
+    "spd_1-6_es.bin": {
+      "filename": "spd_1-6_es.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "potc_400gf": {
+    "potc0400gf.bin": {
+      "filename": "potc0400gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sf_l1": {
+    "sf_u18.l1": {
+      "filename": "sf_u18.l1",
+      "type": "sound"
+    },
+    "sf_u6.l1": {
+      "filename": "sf_u6.l1",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "sf_u15.l1": {
+      "filename": "sf_u15.l1",
+      "type": "sound"
+    },
+    "sf_u14.l1": {
+      "filename": "sf_u14.l1",
+      "type": "sound"
+    }
+  },
+  "sman_190": {
+    "spd_1-9_e.bin": {
+      "filename": "spd_1-9_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "hoops": {
+    "gprom.bin": {
+      "filename": "gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom.bin": {
+      "filename": "yrom.bin",
+      "type": "sound"
+    },
+    "drom.bin": {
+      "filename": "drom.bin",
+      "type": "sound"
+    }
+  },
+  "brooklyn": {
+    "n10207-1.epr": {
+      "filename": "n10207-1.epr",
+      "type": "main"
+    },
+    "n10207-2.epr": {
+      "filename": "n10207-2.epr",
+      "type": "main"
+    }
+  },
+  "mystic": {
+    "720-35_6.716": {
+      "filename": "720-35_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "798-05_4.716": {
+      "filename": "798-05_4.716",
+      "type": "sound"
+    },
+    "798-04_2.716": {
+      "filename": "798-04_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "798-03_1.716": {
+      "filename": "798-03_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "stwr_g11": {
+    "s-wars.u17": {
+      "filename": "s-wars.u17",
+      "type": "sound"
+    },
+    "s-wars.u21": {
+      "filename": "s-wars.u21",
+      "type": "sound"
+    },
+    "swdsp_g.102": {
+      "filename": "swdsp_g.102",
+      "type": "dmd"
+    },
+    "starcpug.101": {
+      "filename": "starcpug.101",
+      "type": "main",
+      "romType": "de"
+    },
+    "s-wars.u7": {
+      "filename": "s-wars.u7",
+      "type": "sound"
+    }
+  },
+  "voleybal": {
+    "voley_s2.bin": {
+      "filename": "voley_s2.bin",
+      "type": "sound"
+    },
+    "voley_s1.bin": {
+      "filename": "voley_s1.bin",
+      "type": "sound"
+    }
+  },
+  "lectrono": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "nugent": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "obaoba": {
+    "ob2.bin": {
+      "filename": "ob2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ob_s1.bin": {
+      "filename": "ob_s1.bin",
+      "type": "sound"
+    },
+    "ob1.bin": {
+      "filename": "ob1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ob3.bin": {
+      "filename": "ob3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "ob_s2.bin": {
+      "filename": "ob_s2.bin",
+      "type": "sound"
+    }
+  },
+  "wof_300": {
+    "wof0300a.bin": {
+      "filename": "wof0300a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_116i": {
+    "indy0116i.bin": {
+      "filename": "indy0116i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "embryonc": {
+    "embd78u2.bin": {
+      "filename": "embd78u2.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "841-02_5.532": {
+      "filename": "841-02_5.532",
+      "type": "sound"
+    },
+    "embd78u6.bin": {
+      "filename": "embd78u6.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "841-01_4.716": {
+      "filename": "841-01_4.716",
+      "type": "sound"
+    }
+  },
+  "stk_sprb": {
+    "st&s2732.u2": {
+      "filename": "st&s2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "72132fn.u6": {
+      "filename": "72132fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "newdixie": {
+    "10307-1.epr": {
+      "filename": "10307-1.epr",
+      "type": "main"
+    },
+    "10307-2.epr": {
+      "filename": "10307-2.epr",
+      "type": "main"
+    }
+  },
+  "playboyb": {
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "3032d7.bin": {
+      "filename": "3032d7.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "play2732.u2": {
+      "filename": "play2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "voltanb": {
+    "729-18_3.123": {
+      "filename": "729-18_3.123",
+      "type": "sound"
+    },
+    "volt2732.u2": {
+      "filename": "volt2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "3032d7.bin": {
+      "filename": "3032d7.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "centaurj": {
+    "cent3a.bin": {
+      "filename": "cent3a.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "cent4a.bin": {
+      "filename": "cent4a.bin",
+      "type": "main",
+      "romType": "inder"
+    }
+  },
+  "marsf": {
+    "f666-s2.snd": {
+      "filename": "f666-s2.snd",
+      "type": "sound"
+    },
+    "f666-s1.snd": {
+      "filename": "f666-s1.snd",
+      "type": "sound"
+    }
+  },
+  "wpt_140gf": {
+    "wpt1400gf.bin": {
+      "filename": "wpt1400gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "radcl_p3": {
+    "rad_u19.l1": {
+      "filename": "rad_u19.l1",
+      "type": "sound"
+    },
+    "rad_u26.p1": {
+      "filename": "rad_u26.p1",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rad_u20.p3": {
+      "filename": "rad_u20.p3",
+      "type": "sound"
+    },
+    "u27-p1.rom": {
+      "filename": "u27-p1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "rad_u4.p3": {
+      "filename": "rad_u4.p3",
+      "type": "sound"
+    }
+  },
+  "blackblt": {
+    "u2.cpu": {
+      "filename": "u2.cpu",
+      "type": "main",
+      "romType": "by"
+    },
+    "u3.cpu": {
+      "filename": "u3.cpu",
+      "type": "main",
+      "romType": "by"
+    },
+    "blck_u7.snd": {
+      "filename": "blck_u7.snd",
+      "type": "sound"
+    }
+  },
+  "spacejmi": {
+    "spcjam.u36": {
+      "filename": "spcjam.u36",
+      "type": "sound"
+    },
+    "jamcpu.300": {
+      "filename": "jamcpu.300",
+      "type": "main",
+      "romType": "se"
+    },
+    "spcjam.u21": {
+      "filename": "spcjam.u21",
+      "type": "sound"
+    },
+    "spcjam.u7": {
+      "filename": "spcjam.u7",
+      "type": "sound"
+    },
+    "spcjam.u17": {
+      "filename": "spcjam.u17",
+      "type": "sound"
+    },
+    "jamdspi.300": {
+      "filename": "jamdspi.300",
+      "type": "dmd"
+    }
+  },
+  "trn_140h": {
+    "trn_le_1-4_e.bin": {
+      "filename": "TRN_LE_1-4_E.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "megaaton": {
+    "cpumegat.bin": {
+      "filename": "cpumegat.bin",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "smegat.bin": {
+      "filename": "smegat.bin",
+      "type": "sound"
+    },
+    "smogot.bin": {
+      "filename": "smogot.bin",
+      "type": "sound"
+    }
+  },
+  "nineball": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "robowars": {
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    },
+    "prom2.cpu": {
+      "filename": "prom2.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    }
+  },
+  "robotgfp": {
+    "robot_gg.snd": {
+      "filename": "robot_gg.snd",
+      "type": "sound"
+    },
+    "robotfp.ic2": {
+      "filename": "robotfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_dg.snd": {
+      "filename": "robot_dg.snd",
+      "type": "sound"
+    },
+    "robotfp.ic1": {
+      "filename": "robotfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_eg.snd": {
+      "filename": "robot_eg.snd",
+      "type": "sound"
+    }
+  },
+  "ij4_116": {
+    "indy0116a.bin": {
+      "filename": "indy0116a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "kz26": {
+    "kz26.cpu": {
+      "filename": "kz26.cpu",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "sound2.su4": {
+      "filename": "sound2.su4",
+      "type": "sound"
+    },
+    "sound1.su3": {
+      "filename": "sound1.su3",
+      "type": "sound"
+    }
+  },
+  "aftor": {
+    "u52.bin": {
+      "filename": "u52.bin",
+      "type": "main"
+    },
+    "u48.bin": {
+      "filename": "u48.bin",
+      "type": "main"
+    },
+    "u25.bin": {
+      "filename": "u25.bin",
+      "type": "main"
+    }
+  },
+  "st_160h": {
+    "st_160h.bin": {
+      "filename": "st_160h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cleoptra": {
+    "409.cpu": {
+      "filename": "409.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "petacona": {
+    "petacona.bin": {
+      "filename": "petacona.bin",
+      "type": "main",
+      "romType": "jp"
+    }
+  },
+  "acd_165": {
+    "acd_165.bin": {
+      "filename": "acd_165.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "zarza": {
+    "zarza1.bin": {
+      "filename": "zarza1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "zarza3.bin": {
+      "filename": "zarza3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "zarza_s2.bin": {
+      "filename": "zarza_s2.bin",
+      "type": "sound"
+    },
+    "zarza2.bin": {
+      "filename": "zarza2.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "zarza4.bin": {
+      "filename": "zarza4.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "zarza_s1.bin": {
+      "filename": "zarza_s1.bin",
+      "type": "sound"
+    }
+  },
+  "zarza1": {
+    "zarza1.bin": {
+      "filename": "zarza1.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "zarza2a.bin": {
+      "filename": "zarza2a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "zarza3.bin": {
+      "filename": "zarza3.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "zarza_s2.bin": {
+      "filename": "zarza_s2.bin",
+      "type": "sound"
+    },
+    "zarza4a.bin": {
+      "filename": "zarza4a.bin",
+      "type": "main",
+      "romType": "taito"
+    },
+    "zarza_s1.bin": {
+      "filename": "zarza_s1.bin",
+      "type": "sound"
+    }
+  },
+  "wof_200g": {
+    "wof0200g.bin": {
+      "filename": "wof0200g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_116l": {
+    "indy0116l.bin": {
+      "filename": "indy0116l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "empsback": {
+    "sw_ic3.mpu": {
+      "filename": "sw_ic3.mpu",
+      "type": "main",
+      "romType": "hnk"
+    },
+    "sw_ic2.mpu": {
+      "filename": "sw_ic2.mpu",
+      "type": "main",
+      "romType": "hnk"
+    },
+    "sw_ic14.snd": {
+      "filename": "sw_ic14.snd",
+      "type": "sound"
+    },
+    "sw_ic3.snd": {
+      "filename": "sw_ic3.snd",
+      "type": "sound"
+    }
+  },
+  "bdk_130": {
+    "bat_v1-3_e.bin": {
+      "filename": "bat_v1-3_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sinbad": {
+    "412.cpu": {
+      "filename": "412.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "xmen_151": {
+    "xp_v1-51.bin": {
+      "filename": "XP_V1-51.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_116": {
+    "mtl_116.bin": {
+      "filename": "mtl_116.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "avr_120h": {
+    "av_pre_v1-20_e.bin": {
+      "filename": "AV_PRE_V1-20_E.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_124h": {
+    "twd124le.bin": {
+      "filename": "TWD124LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_111h": {
+    "twd111le.bin": {
+      "filename": "TWD111LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "robotffp": {
+    "robotfp.ic2": {
+      "filename": "robotfp.ic2",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_fr.1d": {
+      "filename": "robot_fr.1d",
+      "type": "sound"
+    },
+    "robotfp.ic1": {
+      "filename": "robotfp.ic1",
+      "type": "main",
+      "romType": "zac"
+    },
+    "robot_fr.1g": {
+      "filename": "robot_fr.1g",
+      "type": "sound"
+    },
+    "robot_fr.1e": {
+      "filename": "robot_fr.1e",
+      "type": "sound"
+    }
+  },
+  "wpt_109i": {
+    "wpt0109i.bin": {
+      "filename": "wpt0109i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "centaur": {
+    "848-01_3.532": {
+      "filename": "848-01_3.532",
+      "type": "sound"
+    },
+    "848-08_2.732": {
+      "filename": "848-08_2.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-53_6.732": {
+      "filename": "720-53_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "848-05_5.716": {
+      "filename": "848-05_5.716",
+      "type": "sound"
+    },
+    "848-02_4.532": {
+      "filename": "848-02_4.532",
+      "type": "sound"
+    }
+  },
+  "magic": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "princess": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "myststar": {
+    "rom2.bin": {
+      "filename": "rom2.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "rom1.bin": {
+      "filename": "rom1.bin",
+      "type": "main",
+      "romType": "by"
+    },
+    "rom3.bin": {
+      "filename": "rom3.bin",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "potc_115ai": {
+    "potc0115ai.bin": {
+      "filename": "potc0115ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lotr_f51": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspf.501": {
+      "filename": "lotrdspf.501",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.501": {
+      "filename": "lotrcpu.501",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "lotr_fr": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.900": {
+      "filename": "lotrcpu.900",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrdspf.900": {
+      "filename": "lotrdspf.900",
+      "type": "dmd"
+    }
+  },
+  "lotr_fr4": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrcpu.401": {
+      "filename": "lotrcpu.401",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotrdspf.403": {
+      "filename": "lotrdspf.403",
+      "type": "dmd"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    }
+  },
+  "lotr_fr9": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.900": {
+      "filename": "lotrcpu.900",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrdspf.900": {
+      "filename": "lotrdspf.900",
+      "type": "dmd"
+    }
+  },
+  "lotr_gr": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.900": {
+      "filename": "lotrcpu.900",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrdspg.900": {
+      "filename": "lotrdspg.900",
+      "type": "dmd"
+    }
+  },
+  "lotr_gr9": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.900": {
+      "filename": "lotrcpu.900",
+      "type": "main",
+      "romType": "se"
+    },
+    "lotrdspg.900": {
+      "filename": "lotrdspg.900",
+      "type": "dmd"
+    }
+  },
+  "lotr_it": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspi.900": {
+      "filename": "lotrdspi.900",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.900": {
+      "filename": "lotrcpu.900",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "lotr_it9": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspi.900": {
+      "filename": "lotrdspi.900",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "bios.u8": {
+      "filename": "bios.u8",
+      "type": "main"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpu.900": {
+      "filename": "lotrcpu.900",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "lotr_le": {
+    "lotr-u21.100": {
+      "filename": "lotr-u21.100",
+      "type": "sound"
+    },
+    "lotr-u37.100": {
+      "filename": "lotr-u37.100",
+      "type": "sound"
+    },
+    "lotr-u36.100": {
+      "filename": "lotr-u36.100",
+      "type": "sound"
+    },
+    "lotrdspa.a00": {
+      "filename": "lotrdspa.a00",
+      "type": "dmd"
+    },
+    "lotr-u7.101": {
+      "filename": "lotr-u7.101",
+      "type": "sound"
+    },
+    "lotr-u17.100": {
+      "filename": "lotr-u17.100",
+      "type": "sound"
+    },
+    "lotrcpua.a02": {
+      "filename": "lotrcpua.a02",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "diner_l2": {
+    "u26-la3.rom": {
+      "filename": "u26-la3.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "dinr_u27.lu2": {
+      "filename": "dinr_u27.lu2",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "sman_210al": {
+    "spd_v2-1_es.bin": {
+      "filename": "spd_v2-1_es.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "meteorbf": {
+    "cpu_u2bf.716": {
+      "filename": "cpu_u2bf.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6bf.716": {
+      "filename": "cpu_u6bf.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "mataharb": {
+    "mata2732.u2": {
+      "filename": "mata2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "72132fn.u6": {
+      "filename": "72132fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "zephy": {
+    "zephy.l2": {
+      "filename": "zephy.l2",
+      "type": "main",
+      "romType": "ltd"
+    }
+  },
+  "xmen_150h": {
+    "xmle1-50.bin": {
+      "filename": "XMLE1-50.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sklflite": {
+    "skflcpu1.rom": {
+      "filename": "skflcpu1.rom",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "skflcpu2.rom": {
+      "filename": "skflcpu2.rom",
+      "type": "main",
+      "romType": "playmatic"
+    }
+  },
+  "shark": {
+    "shk_ic14.snd": {
+      "filename": "shk_ic14.snd",
+      "type": "sound"
+    },
+    "shk_ic2.mpu": {
+      "filename": "shk_ic2.mpu",
+      "type": "main",
+      "romType": "hnk"
+    },
+    "shk_ic3.mpu": {
+      "filename": "shk_ic3.mpu",
+      "type": "main",
+      "romType": "hnk"
+    },
+    "shk_ic3.snd": {
+      "filename": "shk_ic3.snd",
+      "type": "sound"
+    }
+  },
+  "wpt_112af": {
+    "wpt0112af.bin": {
+      "filename": "wpt0112af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "grand_l3": {
+    "lzrd_u27.l3": {
+      "filename": "lzrd_u27.l3",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "im2_181": {
+    "im2_181.bin": {
+      "filename": "im2_181.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "skateblb": {
+    "skate02.u2": {
+      "filename": "skate02.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "skate02.u6": {
+      "filename": "skate02.u6",
+      "type": "main",
+      "romType": "by"
+    },
+    "823-02_4.716": {
+      "filename": "823-02_4.716",
+      "type": "sound"
+    }
+  },
+  "wof_400f": {
+    "wof0400f.bin": {
+      "filename": "wof0400f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mt_145hb": {
+    "mt_145hb.bin": {
+      "filename": "mt_145hb.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "avg_140": {
+    "avgv1-40.bin": {
+      "filename": "AVGV1-40.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "charlies": {
+    "425.cpu": {
+      "filename": "425.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "sman_130ai": {
+    "spd_1_30_ei.bin": {
+      "filename": "spd_1_30_ei.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "xmen_120h": {
+    "xmen_120h.bin": {
+      "filename": "xmen_120h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_153h": {
+    "twd153le.bin": {
+      "filename": "TWD153LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "tridenfp": {
+    "fptrid_6.716": {
+      "filename": "fptrid_6.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fptrid_2.716": {
+      "filename": "fptrid_2.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "glxplay2": {
+    "1382-2.cpu": {
+      "filename": "1382-2.cpu",
+      "type": "main"
+    },
+    "1382-1.cpu": {
+      "filename": "1382-1.cpu",
+      "type": "main"
+    }
+  },
+  "trn_17402": {
+    "trn17402.bin": {
+      "filename": "TRN17402.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_163": {
+    "mtl163.bin": {
+      "filename": "MTL163.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twenty4_130": {
+    "24_v1-3_a.bin": {
+      "filename": "24_v1-3_a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "dfndr_l4": {
+    "ic14.532": {
+      "filename": "ic14.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "ic20.532": {
+      "filename": "ic20.532",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "sman_190ai": {
+    "spd_1-9_ei.bin": {
+      "filename": "spd_1-9_ei.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "solarwar": {
+    "solarw2.bin": {
+      "filename": "solarw2.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "solarw1c.bin": {
+      "filename": "solarw1c.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "saturn2": {
+    "spy_u3.532": {
+      "filename": "spy_u3.532",
+      "type": "sound"
+    },
+    "spy-2732.u2": {
+      "filename": "spy-2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "spy_u4.532": {
+      "filename": "spy_u4.532",
+      "type": "sound"
+    },
+    "saturn2.u6": {
+      "filename": "saturn2.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "spyhuntr": {
+    "spy_u3.532": {
+      "filename": "spy_u3.532",
+      "type": "sound"
+    },
+    "spy-2732.u2": {
+      "filename": "spy-2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "spy_u4.532": {
+      "filename": "spy_u4.532",
+      "type": "sound"
+    },
+    "720-5332.u6": {
+      "filename": "720-5332.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wpt_111g": {
+    "wpt0111g.bin": {
+      "filename": "wpt0111g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bop_l6": {
+    "tmbopl_6.rom": {
+      "filename": "tmbopl_6.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mach_u14.l1": {
+      "filename": "mach_u14.l1",
+      "type": "sound"
+    },
+    "mach_u18.l1": {
+      "filename": "mach_u18.l1",
+      "type": "sound"
+    },
+    "mach_u15.l1": {
+      "filename": "mach_u15.l1",
+      "type": "sound"
+    }
+  },
+  "viper": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "viperfp": {
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpvip_u5.716": {
+      "filename": "fpvip_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "wof_400": {
+    "wof0400a.bin": {
+      "filename": "wof0400a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "st_150": {
+    "st_150.bin": {
+      "filename": "st_150.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "theraid": {
+    "theraid.cpu": {
+      "filename": "TheRaid.cpu",
+      "type": "main",
+      "romType": "playmatic"
+    },
+    "theraid.snd": {
+      "filename": "Theraid.snd",
+      "type": "sound"
+    }
+  },
+  "famlyfun": {
+    "family.u12": {
+      "filename": "family.u12",
+      "type": "main",
+      "romType": "gp"
+    },
+    "family.u13": {
+      "filename": "family.u13",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "startrip": {
+    "startrip.u12": {
+      "filename": "startrip.u12",
+      "type": "main",
+      "romType": "gp"
+    },
+    "startrip.u13": {
+      "filename": "startrip.u13",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "sman_260": {
+    "spd26164.bin": {
+      "filename": "SPD26164.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_261": {
+    "spd26164.bin": {
+      "filename": "SPD26164.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "xmen_100": {
+    "xmen_100.bin": {
+      "filename": "xmen_100.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bellring": {
+    "br_drom1.bin": {
+      "filename": "br_drom1.bin",
+      "type": "sound"
+    },
+    "br_gprom.bin": {
+      "filename": "br_gprom.bin",
+      "type": "main",
+      "romType": "gts"
+    },
+    "br_yrom1.bin": {
+      "filename": "br_yrom1.bin",
+      "type": "sound"
+    }
+  },
+  "twd_125h": {
+    "twd125le.bin": {
+      "filename": "TWD125LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "skijump": {
+    "skijump3.bin": {
+      "filename": "skijump3.bin",
+      "type": "main"
+    },
+    "skijump2.bin": {
+      "filename": "skijump2.bin",
+      "type": "main"
+    },
+    "skijump1.bin": {
+      "filename": "skijump1.bin",
+      "type": "main"
+    },
+    "skijump4.bin": {
+      "filename": "skijump4.bin",
+      "type": "main"
+    }
+  },
+  "mtl_103": {
+    "mtl_103.bin": {
+      "filename": "mtl_103.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_106g": {
+    "wpt0106g.bin": {
+      "filename": "wpt0106g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "avg_140h": {
+    "avgle140.bin": {
+      "filename": "AVGLE140.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "potc_115as": {
+    "potc0115as.bin": {
+      "filename": "potc0115as.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "im2_140": {
+    "im2_140.bin": {
+      "filename": "im2_140.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twenty4_150": {
+    "24_v1-5_e.bin": {
+      "filename": "24_V1-5_E.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "potc_110af": {
+    "potc0110af.bin": {
+      "filename": "potc0110af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "petacon": {
+    "petaco-n.dat": {
+      "filename": "petaco-n.dat",
+      "type": "main",
+      "romType": "jp"
+    }
+  },
+  "wpt_140i": {
+    "wpt1400i.bin": {
+      "filename": "wpt1400i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_124": {
+    "twd124.bin": {
+      "filename": "TWD124.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_150h": {
+    "mtl15le.bin": {
+      "filename": "MTL15LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bhol_ltd": {
+    "blackhol.bin": {
+      "filename": "blackhol.bin",
+      "type": "main",
+      "romType": "ltd"
+    }
+  },
+  "acd_165h": {
+    "acd_165h.bin": {
+      "filename": "acd_165h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "acd_168": {
+    "acd_168.bin": {
+      "filename": "ACD_168.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bountyh": {
+    "694-s.snd": {
+      "filename": "694-s.snd",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "ravena": {
+    "drom1.snd": {
+      "filename": "drom1.snd",
+      "type": "sound"
+    },
+    "prom2a.cpu": {
+      "filename": "prom2a.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1.cpu": {
+      "filename": "prom1.cpu",
+      "type": "main",
+      "romType": "gts"
+    },
+    "yrom1.snd": {
+      "filename": "yrom1.snd",
+      "type": "sound"
+    }
+  },
+  "acd_161": {
+    "acd_161.bin": {
+      "filename": "acd_161.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "st_150h": {
+    "st_150h.bin": {
+      "filename": "st_150h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_111ai": {
+    "wpt0111ai.bin": {
+      "filename": "wpt0111ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "blvelvet": {
+    "b1-110.u13": {
+      "filename": "b1-110.u13",
+      "type": "main",
+      "romType": "gp"
+    },
+    "a-110.u12": {
+      "filename": "a-110.u12",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "camlight": {
+    "b1-110.u13": {
+      "filename": "b1-110.u13",
+      "type": "main",
+      "romType": "gp"
+    },
+    "a-110.u12": {
+      "filename": "a-110.u12",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "chucklck": {
+    "b1-110.u13": {
+      "filename": "b1-110.u13",
+      "type": "main",
+      "romType": "gp"
+    },
+    "a-110.u12": {
+      "filename": "a-110.u12",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "foxylady": {
+    "b1-110.u13": {
+      "filename": "b1-110.u13",
+      "type": "main",
+      "romType": "gp"
+    },
+    "a-110.u12": {
+      "filename": "a-110.u12",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "real": {
+    "b1-110.u13": {
+      "filename": "b1-110.u13",
+      "type": "main",
+      "romType": "gp"
+    },
+    "a-110.u12": {
+      "filename": "a-110.u12",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "rio": {
+    "b1-110.u13": {
+      "filename": "b1-110.u13",
+      "type": "main",
+      "romType": "gp"
+    },
+    "a-110.u12": {
+      "filename": "a-110.u12",
+      "type": "main",
+      "romType": "gp"
+    }
+  },
+  "sonstwar": {
+    "sw1.bin": {
+      "filename": "sw1.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "sw3.bin": {
+      "filename": "sw3.bin",
+      "type": "main",
+      "romType": "peyper"
+    },
+    "sw2.bin": {
+      "filename": "sw2.bin",
+      "type": "main",
+      "romType": "peyper"
+    }
+  },
+  "csmic_l1": {
+    "ic26.716": {
+      "filename": "ic26.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic14.716": {
+      "filename": "ic14.716",
+      "type": "main",
+      "romType": "s7"
+    },
+    "sound12.716": {
+      "filename": "sound12.716",
+      "type": "sound"
+    },
+    "ic17.532": {
+      "filename": "ic17.532",
+      "type": "main",
+      "romType": "s7"
+    },
+    "ic20.716": {
+      "filename": "ic20.716",
+      "type": "main",
+      "romType": "s7"
+    }
+  },
+  "spacehaw": {
+    "cybu3.snd": {
+      "filename": "cybu3.snd",
+      "type": "sound"
+    }
+  },
+  "sman_192": {
+    "spd_1-92_e.bin": {
+      "filename": "spd_1-92_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "trn_174h": {
+    "trn_174le.bin": {
+      "filename": "TRN_174LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_190gf": {
+    "spd_1-9_gf.bin": {
+      "filename": "spd_1-9_gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "potc_113gf": {
+    "potc0113gf.bin": {
+      "filename": "potc0113gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "nightrdb": {
+    "nght2732.u2": {
+      "filename": "nght2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "72132fn.u6": {
+      "filename": "72132fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "frontier": {
+    "819-09_4.716": {
+      "filename": "819-09_4.716",
+      "type": "sound"
+    },
+    "819-07_2.716": {
+      "filename": "819-07_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "720-40_6.732": {
+      "filename": "720-40_6.732",
+      "type": "main",
+      "romType": "by"
+    },
+    "819-08_1.716": {
+      "filename": "819-08_1.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wpt_112gf": {
+    "wpt0112gf.bin": {
+      "filename": "wpt0112gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "tf_120": {
+    "tf120.bin": {
+      "filename": "tf120.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_109l": {
+    "wpt0109l.bin": {
+      "filename": "wpt0109l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "avg_120h": {
+    "avg_120h.bin": {
+      "filename": "avg_120h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "closeenc": {
+    "424.cpu": {
+      "filename": "424.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "ij4_114f": {
+    "indy0114f.bin": {
+      "filename": "indy0114f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "cheetafp": {
+    "cpu_u2.716": {
+      "filename": "cpu_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpch_u1.716": {
+      "filename": "fpch_u1.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u6.716": {
+      "filename": "cpu_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fpch_u5.716": {
+      "filename": "fpch_u5.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "sman_230": {
+    "spd_v2-3_e.bin": {
+      "filename": "spd_v2-3_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lostspc1": {
+    "lisdspa.101": {
+      "filename": "lisdspa.101",
+      "type": "dmd"
+    }
+  },
+  "ij4_113": {
+    "indy0113a.bin": {
+      "filename": "indy0113a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "avg_170": {
+    "avgv1-70.bin": {
+      "filename": "AVGV1-70.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_210ai": {
+    "spd_v2-1_ei.bin": {
+      "filename": "spd_v2-1_ei.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bdk_201": {
+    "bat_v2-1_e.bin": {
+      "filename": "bat_v2-1_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_112ai": {
+    "wpt0112ai.bin": {
+      "filename": "wpt0112ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "worlddef": {
+    "worlddef.764": {
+      "filename": "WORLDDEF.764",
+      "type": "main"
+    },
+    "wodefsnd.764": {
+      "filename": "WODEFSND.764",
+      "type": "sound"
+    }
+  },
+  "st_141h": {
+    "stle1-41.bin": {
+      "filename": "STLE1-41.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "gnr_300d": {
+    "gnrcpud.300": {
+      "filename": "gnrcpud.300",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "nba_600": {
+    "nba_v6-0a.bin": {
+      "filename": "nba_v6-0a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_400a": {
+    "fg400a.bin": {
+      "filename": "fg400a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "csi_210": {
+    "csi_v2-1_a.bin": {
+      "filename": "csi_v2-1_a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "scrzy_l1": {
+    "scrzy_20.bin": {
+      "filename": "scrzy_20.bin",
+      "type": "main",
+      "romType": "s9"
+    },
+    "scrzy_49.bin": {
+      "filename": "scrzy_49.bin",
+      "type": "sound"
+    }
+  },
+  "wpt_108f": {
+    "wpt0108f.bin": {
+      "filename": "wpt0108f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "im2_100": {
+    "im2_100.bin": {
+      "filename": "im2_100.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "xmen_130h": {
+    "xmen_130h.bin": {
+      "filename": "xmen_130h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "punkywil": {
+    "pw_sound.bin": {
+      "filename": "pw_sound.bin",
+      "type": "main"
+    }
+  },
+  "sman_170af": {
+    "spd_1-7_ef.bin": {
+      "filename": "spd_1-7_ef.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bnzai_t3": {
+    "banz_u26.l3t": {
+      "filename": "banz_u26.l3t",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "mysticb": {
+    "720-3532.u6b": {
+      "filename": "720-3532.u6b",
+      "type": "main",
+      "romType": "by"
+    },
+    "798-05_4.716": {
+      "filename": "798-05_4.716",
+      "type": "sound"
+    },
+    "myst2732.u2": {
+      "filename": "myst2732.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "mt_130": {
+    "mt-v1-30.bin": {
+      "filename": "MT-V1-30.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "centauri": {
+    "cent4.bin": {
+      "filename": "cent4.bin",
+      "type": "main",
+      "romType": "inder"
+    },
+    "cent3.bin": {
+      "filename": "cent3.bin",
+      "type": "main",
+      "romType": "inder"
+    }
+  },
+  "potc_300af": {
+    "potc0300af.bin": {
+      "filename": "potc0300af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_800al": {
+    "fg800al.bin": {
+      "filename": "fg800al.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_160ai": {
+    "spd_1-6_ei.bin": {
+      "filename": "spd_1-6_ei.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_108g": {
+    "wpt0108g.bin": {
+      "filename": "wpt0108g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "blackbl2": {
+    "cpu_u2.128": {
+      "filename": "cpu_u2.128",
+      "type": "main",
+      "romType": "by"
+    },
+    "cpu_u3.128": {
+      "filename": "cpu_u3.128",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wof_500l": {
+    "wof0500l.bin": {
+      "filename": "wof0500l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_210": {
+    "ind_v2-1_a.bin": {
+      "filename": "IND_V2-1_A.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_112a": {
+    "wpt0112a.bin": {
+      "filename": "wpt0112a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_170ai": {
+    "spd_1-7_ei.bin": {
+      "filename": "spd_1-7_ei.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "dvlridef": {
+    "fr01snd1.1d": {
+      "filename": "fr01snd1.1d",
+      "type": "sound"
+    },
+    "fr01snd3.1g": {
+      "filename": "fr01snd3.1g",
+      "type": "sound"
+    }
+  },
+  "nba_802": {
+    "nba_802.bin": {
+      "filename": "nba_802.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_1200af": {
+    "fg120af.bin": {
+      "filename": "FG120af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twenty4_140": {
+    "24_v1-4_a.bin": {
+      "filename": "24_v1-4_a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_700af": {
+    "fg700af.bin": {
+      "filename": "fg700af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "acd_152h": {
+    "acd_152h.bin": {
+      "filename": "acd_152h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_128h": {
+    "twd128le.bin": {
+      "filename": "TWD128LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "uboat65": {
+    "snd_ic5.256": {
+      "filename": "SND_IC5.256",
+      "type": "main"
+    },
+    "snd_ic3.256": {
+      "filename": "SND_IC3.256",
+      "type": "main"
+    },
+    "cpu_u7.256": {
+      "filename": "CPU_U7.256",
+      "type": "main"
+    }
+  },
+  "wpt_108a": {
+    "wpt0108a.bin": {
+      "filename": "wpt0108a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bop_l3": {
+    "mach_u14.l1": {
+      "filename": "mach_u14.l1",
+      "type": "sound"
+    },
+    "bop_l3.u6": {
+      "filename": "bop_l3.u6",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mach_u18.l1": {
+      "filename": "mach_u18.l1",
+      "type": "sound"
+    },
+    "mach_u15.l1": {
+      "filename": "mach_u15.l1",
+      "type": "sound"
+    }
+  },
+  "bop_l4": {
+    "mach_u14.l1": {
+      "filename": "mach_u14.l1",
+      "type": "sound"
+    },
+    "tmbopl_4.rom": {
+      "filename": "tmbopl_4.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "mach_u18.l1": {
+      "filename": "mach_u18.l1",
+      "type": "sound"
+    },
+    "mach_u15.l1": {
+      "filename": "mach_u15.l1",
+      "type": "sound"
+    }
+  },
+  "bop_l5": {
+    "mach_u14.l1": {
+      "filename": "mach_u14.l1",
+      "type": "sound"
+    },
+    "mach_u18.l1": {
+      "filename": "mach_u18.l1",
+      "type": "sound"
+    },
+    "mach_u15.l1": {
+      "filename": "mach_u15.l1",
+      "type": "sound"
+    },
+    "tmbopl_5.rom": {
+      "filename": "tmbopl_5.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "bop_l8": {
+    "mach_u14.l1": {
+      "filename": "mach_u14.l1",
+      "type": "sound"
+    },
+    "mach_u18.l1": {
+      "filename": "mach_u18.l1",
+      "type": "sound"
+    },
+    "mach_u15.l1": {
+      "filename": "mach_u15.l1",
+      "type": "sound"
+    },
+    "tmbopl_8.rom": {
+      "filename": "tmbopl_8.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "mtl_113": {
+    "mtl113.bin": {
+      "filename": "MTL113.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mt_120": {
+    "mt-v1-20.bin": {
+      "filename": "MT-V1-20.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_140af": {
+    "wpt1400af.bin": {
+      "filename": "wpt1400af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_111gf": {
+    "wpt0111gf.bin": {
+      "filename": "wpt0111gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "csi_230": {
+    "csi_v2-3_e.bin": {
+      "filename": "csi_v2-3_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "gw_pb": {
+    "u6-p-b.rom": {
+      "filename": "u6-p-b.rom",
+      "type": "main",
+      "romType": "wpc"
+    },
+    "u18-sp1.rom": {
+      "filename": "u18-sp1.rom",
+      "type": "sound"
+    }
+  },
+  "mtl_160": {
+    "mtl16.bin": {
+      "filename": "MTL16.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "pinpool": {
+    "427.cpu": {
+      "filename": "427.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "st_140": {
+    "st-v1-40.bin": {
+      "filename": "ST-V1-40.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "tz_f97": {
+    "ftz0_97.rom": {
+      "filename": "ftz0_97.rom",
+      "type": "main",
+      "romType": "wpc"
+    }
+  },
+  "draculfp": {
+    "fpdrac_2.716": {
+      "filename": "fpdrac_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fpdrac_6.716": {
+      "filename": "fpdrac_6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "wildfyfp": {
+    "fpwldf_2.716": {
+      "filename": "fpwldf_2.716",
+      "type": "main",
+      "romType": "by"
+    },
+    "fpwldf_6.716": {
+      "filename": "fpwldf_6.716",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "atla_ltd": {
+    "atlantis.bin": {
+      "filename": "atlantis.bin",
+      "type": "main",
+      "romType": "ltd"
+    }
+  },
+  "im2_182": {
+    "im2_182.bin": {
+      "filename": "im2_182.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "flicker": {
+    "flicker.rom": {
+      "filename": "flicker.rom",
+      "type": "main"
+    }
+  },
+  "topaz_l1": {
+    "b_ic20.716": {
+      "filename": "b_ic20.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "gamerom.716": {
+      "filename": "gamerom.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "b_ic17.716": {
+      "filename": "b_ic17.716",
+      "type": "main",
+      "romType": "s4"
+    },
+    "sound1.716": {
+      "filename": "sound1.716",
+      "type": "sound"
+    }
+  },
+  "ninebafp": {
+    "cpu_u5.716": {
+      "filename": "cpu_u5.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fp9b_u6.716": {
+      "filename": "fp9b_u6.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "fp9b_u2.716": {
+      "filename": "fp9b_u2.716",
+      "type": "main",
+      "romType": "st"
+    },
+    "cpu_u1.716": {
+      "filename": "cpu_u1.716",
+      "type": "main",
+      "romType": "st"
+    }
+  },
+  "hardbdyg": {
+    "sound_u7.512": {
+      "filename": "sound_u7.512",
+      "type": "sound"
+    },
+    "hrdbdy-g.u3": {
+      "filename": "hrdbdy-g.u3",
+      "type": "main",
+      "romType": "by"
+    },
+    "hrdbdy-g.u2": {
+      "filename": "hrdbdy-g.u2",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "sman_192af": {
+    "spd_1-92_ef.bin": {
+      "filename": "spd_1-92_ef.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_160h": {
+    "mtl16le.bin": {
+      "filename": "MTL16LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_113f": {
+    "indy0113f.bin": {
+      "filename": "indy0113f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_103a": {
+    "wpt0103a.bin": {
+      "filename": "wpt0103a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "tf_170": {
+    "tf_v1-70.bin": {
+      "filename": "TF_V1-70.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "potc_110gf": {
+    "potc0110gf.bin": {
+      "filename": "potc0110gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "st_160": {
+    "st_160.bin": {
+      "filename": "st_160.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "lah_113": {
+    "lahcpua.113": {
+      "filename": "lahcpua.113",
+      "type": "main",
+      "romType": "de"
+    }
+  },
+  "sman_160af": {
+    "spd_1-6_ef.bin": {
+      "filename": "spd_1-6_ef.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_1200al": {
+    "fg120al.bin": {
+      "filename": "fg120al.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "evelknib": {
+    "evel2732.u2": {
+      "filename": "evel2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "72132fn.u6": {
+      "filename": "72132fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "sman_140af": {
+    "spd_1_4_ef.bin": {
+      "filename": "spd_1_4_ef.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_210f": {
+    "ind_v2-1_f.bin": {
+      "filename": "IND_V2-1_F.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_1100ag": {
+    "fg110ag.bin": {
+      "filename": "fg110ag.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "petaco": {
+    "petaco2.cpu": {
+      "filename": "petaco2.cpu",
+      "type": "main",
+      "romType": "jp"
+    },
+    "petaco1.cpu": {
+      "filename": "petaco1.cpu",
+      "type": "main",
+      "romType": "jp"
+    }
+  },
+  "bsktball": {
+    "bsktball.256": {
+      "filename": "bsktball.256",
+      "type": "main"
+    }
+  },
+  "wof_200f": {
+    "wof0200f.bin": {
+      "filename": "wof0200f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "spctrain": {
+    "mbm27128.25": {
+      "filename": "mbm27128.25",
+      "type": "main"
+    }
+  },
+  "fg_1100al": {
+    "fg110al.bin": {
+      "filename": "fg110al.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "eightblb": {
+    "8bal2732.u2": {
+      "filename": "8bal2732.u2",
+      "type": "main",
+      "romType": "by"
+    },
+    "72132fn.u6": {
+      "filename": "72132fn.u6",
+      "type": "main",
+      "romType": "by"
+    }
+  },
+  "acd_130": {
+    "acd_130e.bin": {
+      "filename": "ACD_130E.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_114i": {
+    "indy0114i.bin": {
+      "filename": "indy0114i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_190af": {
+    "spd_1-9_ef.bin": {
+      "filename": "spd_1-9_ef.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_151": {
+    "mtl151.bin": {
+      "filename": "MTL151.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "avr_200": {
+    "avt200v.bin": {
+      "filename": "AVT200V.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_240": {
+    "spd_v2-4_e.bin": {
+      "filename": "spd_v2-4_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mt_130h": {
+    "mtle1-30.bin": {
+      "filename": "MTLE1-30.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "st_120": {
+    "st-v1-20.bin": {
+      "filename": "ST-V1-20.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_163d": {
+    "mtl163d.bin": {
+      "filename": "MTL163D.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "triplaya": {
+    "696-s.snd": {
+      "filename": "696-s.snd",
+      "type": "main",
+      "romType": "gts"
+    },
+    "prom1a.cpu": {
+      "filename": "prom1a.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "bdk_294": {
+    "bdk_v2-94_e.bin": {
+      "filename": "BDK_V2-94_E.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "avr_110": {
+    "avr110.bin": {
+      "filename": "avr110.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "fg_300ai": {
+    "fg300ai.bin": {
+      "filename": "fg300ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_106l": {
+    "wpt0106l.bin": {
+      "filename": "wpt0106l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wpt_111af": {
+    "wpt0111af.bin": {
+      "filename": "wpt0111af.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "pb_l1": {
+    "u26-l1.rom": {
+      "filename": "u26-l1.rom",
+      "type": "main",
+      "romType": "s11"
+    },
+    "u27-l1.rom": {
+      "filename": "u27-l1.rom",
+      "type": "main",
+      "romType": "s11"
+    }
+  },
+  "im2_183": {
+    "im2183ve.bin": {
+      "filename": "IM2183VE.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_113l": {
+    "indy0113l.bin": {
+      "filename": "indy0113l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "xmen_105": {
+    "xp_v1-05.bin": {
+      "filename": "XP_V1-05.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "potc_300as": {
+    "potc0300as.bin": {
+      "filename": "potc0300as.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "st_161": {
+    "st_161.bin": {
+      "filename": "st_161.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "strxt_uk": {
+    "sxsounda.u7": {
+      "filename": "sxsounda.u7",
+      "type": "sound"
+    },
+    "sxcpue.101": {
+      "filename": "sxcpue.101",
+      "type": "main",
+      "romType": "se"
+    }
+  },
+  "potc_113ai": {
+    "potc0113ai.bin": {
+      "filename": "potc0113ai.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_114l": {
+    "indy0114l.bin": {
+      "filename": "indy0114l.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mtl_164h": {
+    "mtl164le.bin": {
+      "filename": "MTL164LE.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "csi_200": {
+    "csi200a.bin": {
+      "filename": "csi200a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "im2_160": {
+    "im2_v1-6_e.bin": {
+      "filename": "IM2_V1-6_E.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "bdk_150": {
+    "bat_v1-5_e.bin": {
+      "filename": "bat_v1-5_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wof_400g": {
+    "wof0400g.bin": {
+      "filename": "wof0400g.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "faeton": {
+    "faeton.cpu": {
+      "filename": "faeton.cpu",
+      "type": "main",
+      "romType": "jp"
+    }
+  },
+  "wpt_106f": {
+    "wpt0106f.bin": {
+      "filename": "wpt0106f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_192ai": {
+    "spd_1-92_ei.bin": {
+      "filename": "spd_1-92_ei.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_140gf": {
+    "spd_1_4_gf.bin": {
+      "filename": "spd_1_4_gf.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "twd_141": {
+    "twd_141.bin": {
+      "filename": "twd_141.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wof_100": {
+    "wof0100a.bin": {
+      "filename": "wof0100a.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "rsn_110": {
+    "rs_v1-10_e.bin": {
+      "filename": "RS_V1-10_E.BIN",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "shr_141": {
+    "shr_141.bin": {
+      "filename": "shr_141.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "st_130": {
+    "st-v1-30.bin": {
+      "filename": "ST-V1-30.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "rsn_110h": {
+    " rsn_110h.bin": {
+      "filename": " rsn_110h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sinbadn": {
+    "412no1.cpu": {
+      "filename": "412no1.cpu",
+      "type": "main",
+      "romType": "gts"
+    }
+  },
+  "potc_400as": {
+    "potc0400as.bin": {
+      "filename": "potc0400as.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_210": {
+    "spd_v2-1_e.bin": {
+      "filename": "spd_v2-1_e.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "gamatron": {
+    "gamatron.764": {
+      "filename": "gamatron.764",
+      "type": "main",
+      "romType": "ps"
+    }
+  },
+  "wpt_111al": {
+    "wpt0111al.bin": {
+      "filename": "wpt0111al.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "xmen_150": {
+    "xp_v1-50.bin": {
+      "filename": "XP_V1-50.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "ij4_113i": {
+    "indy0113i.bin": {
+      "filename": "indy0113i.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "mt_140h": {
+    "mt_140h.bin": {
+      "filename": "mt_140h.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "sman_140al": {
+    "spd_1_4_es.bin": {
+      "filename": "spd_1_4_es.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  },
+  "wof_300f": {
+    "wof0300f.bin": {
+      "filename": "wof0300f.bin",
+      "type": "main",
+      "romType": "sam"
+    }
+  }
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -150,6 +150,29 @@
 				"vary": "^1.1.2"
 			}
 		},
+		"@nodelib/fs.scandir": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"requires": {
+				"@nodelib/fs.stat": "2.0.3",
+				"run-parallel": "^1.1.9"
+			}
+		},
+		"@nodelib/fs.stat": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+		},
+		"@nodelib/fs.walk": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"requires": {
+				"@nodelib/fs.scandir": "2.1.3",
+				"fastq": "^1.6.0"
+			}
+		},
 		"@sindresorhus/is": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
@@ -3713,6 +3736,66 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
 		},
+		"fast-glob": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+			"integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+			"requires": {
+				"@nodelib/fs.stat": "^2.0.2",
+				"@nodelib/fs.walk": "^1.2.3",
+				"glob-parent": "^5.1.0",
+				"merge2": "^1.3.0",
+				"micromatch": "^4.0.2"
+			},
+			"dependencies": {
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+					"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+				},
+				"micromatch": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"requires": {
+						"braces": "^3.0.1",
+						"picomatch": "^2.0.5"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				}
+			}
+		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -3740,6 +3823,14 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
 			"integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
+		},
+		"fastq": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
+			"integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
+			"requires": {
+				"reusify": "^1.0.0"
+			}
 		},
 		"fd-slicer": {
 			"version": "1.1.0",
@@ -4010,7 +4101,8 @@
 				"ansi-regex": {
 					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -4031,12 +4123,14 @@
 				"balanced-match": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -4051,17 +4145,20 @@
 				"code-point-at": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -4178,7 +4275,8 @@
 				"inherits": {
 					"version": "2.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -4190,6 +4288,7 @@
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -4204,6 +4303,7 @@
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -4211,12 +4311,14 @@
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"minipass": {
 					"version": "2.3.5",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.2",
 						"yallist": "^3.0.0"
@@ -4235,6 +4337,7 @@
 					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -4315,7 +4418,8 @@
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -4327,6 +4431,7 @@
 					"version": "1.4.0",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -4412,7 +4517,8 @@
 				"safe-buffer": {
 					"version": "5.1.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -4448,6 +4554,7 @@
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -4467,6 +4574,7 @@
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -4510,12 +4618,14 @@
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				},
 				"yallist": {
 					"version": "3.0.3",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"optional": true
 				}
 			}
 		},
@@ -5506,8 +5616,7 @@
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.0.2",
@@ -5531,7 +5640,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -6519,6 +6627,11 @@
 					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 				}
 			}
+		},
+		"merge2": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -9083,6 +9196,11 @@
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
 			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
+		"picomatch": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
+			"integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
+		},
 		"pidtree": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
@@ -9953,6 +10071,11 @@
 			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
 			"integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
 		},
+		"reusify": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+		},
 		"rimraf": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -10036,6 +10159,11 @@
 			"requires": {
 				"is-promise": "^2.1.0"
 			}
+		},
+		"run-parallel": {
+			"version": "1.1.9",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
 		},
 		"rxjs": {
 			"version": "6.5.3",

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
 		"cross-env": "6.0.3",
 		"expect.js": "0.3.1",
 		"faker": "4.1.0",
+		"fast-glob": "3.1.0",
 		"form-data": "2.5.1",
 		"json-stable-stringify": "1.0.1",
 		"mocha": "5.2.0",

--- a/src/app/roms/rom.document.d.ts
+++ b/src/app/roms/rom.document.d.ts
@@ -30,6 +30,8 @@ export interface RomDocument extends GameReferenceDocument, PrettyIdDocument, Fi
 		bytes: number;
 		crc: number;
 		modified_at: Date;
+		type?: string;
+		system?: string;
 	}>;
 	version: string;
 	languages: string[];

--- a/src/app/roms/rom.schema.ts
+++ b/src/app/roms/rom.schema.ts
@@ -44,6 +44,8 @@ export const romFields = {
 		bytes: { type: Number },
 		crc: { type: Number },
 		modified_at: { type: Date },
+		type: { type: String },
+		system: { type: String },
 	}],
 	version: { type: String },
 	languages: { type: [String] },

--- a/src/app/roms/rom.serializer.ts
+++ b/src/app/roms/rom.serializer.ts
@@ -50,7 +50,7 @@ export class RomSerializer extends Serializer<RomDocument> {
 
 	protected _simple(ctx: Context, doc: RomDocument, opts: SerializerOptions): RomDocument {
 		const rom = pick(doc, ['id', 'version', 'notes', 'languages']) as RomDocument;
-		rom.rom_files = doc.rom_files.map((f: any) => pick(f, ['filename', 'bytes', 'crc', 'modified_at']));
+		rom.rom_files = doc.rom_files.map((f: any) => pick(f, ['filename', 'bytes', 'crc', 'modified_at', 'type', 'system']));
 
 		// file
 		if (this._populated(doc, '_file')) {

--- a/src/scripts/migrations/23-9525653-add-rom-types.ts
+++ b/src/scripts/migrations/23-9525653-add-rom-types.ts
@@ -1,0 +1,65 @@
+/*
+ * VPDB - Virtual Pinball Database
+ * Copyright (C) 2019 freezy <freezy@vpdb.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import { logger } from '../../app/common/logger';
+import { state } from '../../app/state';
+import { apiCache } from '../../app/common/api.cache';
+
+/**
+ * Updates most ROM files with the type, so we know which is the main ROM,
+ * which is the sound ROM etc.
+ *
+ * @see https://github.com/vpdb/vpx-js/issues/130
+ */
+export async function up() {
+
+	// read the parsed types
+	const romTypes = require('../../../data/rom-types.json');
+
+	// fetch all roms
+	const roms = await state.models.Rom.find({}).exec();
+	logger.info(null, '[migrate-23] Updating %s ROMs with file types...', roms.length);
+
+	// loop through roms and rom files
+	let count = 0;
+	for (const rom of roms) {
+		if (!romTypes[rom.id]) {
+			continue;
+		}
+		for (const romFile of rom.rom_files) {
+			const romType = romTypes[rom.id][romFile.filename.toLowerCase()];
+			if (!romType) {
+				continue;
+			}
+
+			// update with new data
+			romFile.type = romType.type;
+			if (romType.romType) {
+				romFile.system = romType.romType;
+			}
+			count++;
+		}
+		await rom.save();
+	}
+	logger.info(null, '[migrate-23] Updated %s ROM files!', count);
+
+	// clear all caches
+	await apiCache.invalidateAll();
+	logger.info(null, '[migrate-23] Cache invalidated.');
+}

--- a/src/scripts/parse-rom-files.js
+++ b/src/scripts/parse-rom-files.js
@@ -1,0 +1,261 @@
+const { readFileSync, writeFileSync } = require('fs');
+const fg = require('fast-glob');
+
+const PROD_EXPORT = '../../roms-production.json';
+const PROD_SIMPLE = '../../roms-production-simplified.json';
+
+(async () => {
+
+	const db = JSON.parse(readFileSync(PROD_SIMPLE).toString());
+	const mame = await parseRoms();
+	const dbByCrc = indexDbByCrc(db);
+	const mameByCrc = indexMameByCrc(mame);
+	const mameByFilename = indexMameByFilename(mame);
+
+	let matchedCount = 0;
+	let notInDbCount = 0;
+	let notInMameCount = 0;
+	let notInMame = [];
+	const notInDb = [];
+	const matched = {};
+
+	for (const crc of Object.keys(dbByCrc)) {
+		const rows = dbByCrc[crc];
+		if (mameByCrc[crc]) {
+			matchedCount += collect(rows, mameByCrc[crc], matched);
+
+		} else {
+			let hasMatched = false;
+			for (const row of rows) {
+				if (mameByFilename[row.filename]) {
+					hasMatched = true;
+					matchedCount += collect(rows, mameByFilename[row.filename], matched);
+				}
+			}
+			if (!hasMatched) {
+				notInMameCount++;
+				notInMame.push(dbByCrc[crc][0]);
+			}
+		}
+	}
+
+	for (const mameCrc of Object.keys(mameByCrc)) {
+		if (!dbByCrc[mameCrc]) {
+			notInDbCount++;
+			notInDb.push(...mameByCrc[mameCrc].map(m => m.filename));
+		}
+	}
+
+	writeFileSync('../../rom-types.json', JSON.stringify(matched, null, '  '));
+
+	notInMame = notInMame
+		.filter(e => !e.filename.toLowerCase().endsWith('.txt'))
+		.filter(e => !e.filename.toLowerCase().endsWith('.doc'))
+		.filter(e => !e.filename.toLowerCase().endsWith('.pdf'));
+
+	console.log('========================================================================');
+	console.log('Matched: %s', matchedCount);
+	console.log('------------------------------------------------------------------------');
+	console.log('Not in DB (%s):\n%s', notInDbCount, notInDb);
+	console.log('------------------------------------------------------------------------');
+	console.log('Not in Mame (%s):\n   %s', notInMame.length, notInMame.map(e => `${e.id}: ${e.filename}`).join('\n   '));
+
+})();
+
+function collect(rows, mames, matched) {
+	let n = 0;
+	for (const row of rows) {
+		if (!matched[row.id]) {
+			matched[row.id] = {};
+		}
+		for (const mame of mames) {
+			if (!matched[row.id][row.filename.toLowerCase()]) {
+				n++;
+			}
+			matched[row.id][row.filename.toLowerCase()] = {
+				filename: row.filename,
+				type: mame.type,
+				romType: mame.romType,
+			};
+		}
+	}
+	return n;
+}
+
+function indexMameByCrc(mameRoms) {
+	const mameByCrc = {};
+	for (const rom of mameRoms) {
+		if (!mameByCrc[rom.crc]) {
+			mameByCrc[rom.crc] = [];
+		}
+		mameByCrc[rom.crc].push(rom);
+	}
+	return mameByCrc;
+}
+
+function indexMameByFilename(mameRoms) {
+	const mameByFilename = {};
+	for (const rom of mameRoms) {
+		if (!mameByFilename[rom.filename]) {
+			mameByFilename[rom.filename] = [];
+		}
+		mameByFilename[rom.filename].push(rom);
+	}
+	return mameByFilename;
+}
+
+function indexDbByCrc(prodRoms) {
+	const indexByCrc = {};
+	for (const rom of prodRoms) {
+		for (const file of rom.rom_files) {
+			if (!indexByCrc[file.crc]) {
+				indexByCrc[file.crc] = [];
+			}
+			indexByCrc[file.crc].push({ id: rom.id, filename: file.filename });
+		}
+	}
+	return indexByCrc;
+}
+
+async function parseRoms() {
+
+	const entries = await fg(['../../../pinmame/src/**/*.c'], { dot: true });
+	//const entries = await fg(['../../../pinmame/src/**/mm.c'], { dot: true });
+
+	const reFilenameCrc = /"(?<filename>[^"]+)"\s*,\s*CRC\((?<crc>[^)]+)\)/gi;
+	const reId1Id2FilenameId3Crc = /(?<id>[^,]+),[^,]+,\s*"(?<filename>[^"]+)"\s*,[^,]+,\s*CRC\s*\((?<crc>[^)]+)/gi;
+	const reFilenameId1Id2Crc = /"(?<filename>[^"]+)"\s*,[^,]*,[^,]*,\s*CRC\((?<crc>[^)]+)/gi;
+	const reIdFilenameCrc = /\s*\((?<id>[^,]+),\s*"(?<filename>[^"]+)"\s*,\s*CRC\s*\((?<crc>[^)]+)/gi;
+
+	const nLiners = [
+		{ type: 'main', romType: 'wpc', outer: outerRe(/WPC_ROMSTART/gi), inner: reId1Id2FilenameId3Crc },
+		{ type: 'main', romType: 'capcom', outer: outerRe(/CC_ROMSTART_\w+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'gts', outer: outerRe(/GTS80_\d+_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'gts', outer: outerRe(/GTS\d+ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'jp', outer: outerRe(/JP_ROMSTART\d+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'de', outer: outerRe(/DE_ROMSTARTx?\d+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'se', outer: outerRe(/SE128_ROMSTART/gi), inner: reIdFilenameCrc },
+		{ type: 'main', romType: 'sam', outer: outerRe(/SAM\d+_ROM\d+MB/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'gts', outer: outerRe(/GTS\w+_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 's4', outer: outerRe(/S4_ROMSTART\d*x?/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 's6', outer: outerRe(/S6_ROMSTART[0-9a-z]*/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 's7', outer: outerRe(/S7_ROMSTART\d+x?/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 's9', outer: outerRe(/S9_ROMSTART\w+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 's11', outer: outerRe(/S11_ROMSTART\d+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'st', outer: outerRe(/ST200_ROMSTART\d+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'by', outer: outerRe(/BY[\dvp]+_ROMSTART\d*x?\d+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'by', outer: outerRe(/BY\d+_ROMSTART_[a-z0-9]+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'by', outer: outerRe(/BY8035_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'zac', outer: outerRe(/ZAC_ROMSTART\d+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'playmatic', outer: outerRe(/PLAYMATIC_ROMSTART\w+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'atari', outer: outerRe(/ATARI_\d+_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'atari', outer: outerRe(/ATARI_\dx\d_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'spinball', outer: outerRe(/SPINB_ROMSTART\d*/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'mrgame', outer: outerRe(/MRGAME_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'taito', outer: outerRe(/TAITO_ROMSTART\w+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'sleic', outer: outerRe(/SLEIC_ROMSTART\d+/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'inder', outer: outerRe(/INDER_ROMSTART\w*/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'gp', outer: outerRe(/GP_ROMSTART\w*/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'peyper', outer: outerRe(/PEYPER_ROMSTART\d*/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'ltd', outer: outerRe(/LTD_\d+_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'alvin', outer: outerRe(/ALVGROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'hnk', outer: outerRe(/HNK_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'main', romType: 'ps', outer: outerRe(/PS_ROMSTART\d+K/gi), inner: reFilenameCrc },
+		{ type: 'main', outer: outerRe(/ROM_LOAD/i), inner: reFilenameId1Id2Crc },
+		{ type: 'sound', outer: outerRe(/S\d+[CX]*S_SOUNDROM\d*/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/BY[\dsd]+_SOUNDROM\d*x*\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/BY\w+_SOUNDROM\w*/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/DCS_SOUNDROM\d+[xm]*/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/GTS80SS22_ROMSTART/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/GTS80BSSOUND\w+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/GTS80S1K_ROMSTART+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/ZAC_SOUNDROM_de2g/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/MRGAME_SOUNDROM\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/JP_SNDROM\w*/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/S67S_SPEECHROMS\d+x?/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/S67S_SOUNDROMS\d+x?/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/VSU100_SOUNDROM_U\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/GTS\d+SOUND\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/DE\d+S[AC]?_SOUNDROM\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/WPCS?_SOUNDROM\w*/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/SPINB_SNDROM\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/INDER_SNDROM\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/ZAC_SOUNDROM_[a-z0-9]+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/PLAYMATIC_SOUNDROM\w*/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/MRGAME_SOUNDROM\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/TAITO_SOUNDROMS\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/CAPCOMS_SOUNDROM\w*/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/ALVGS_SOUNDROM\w*/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/HNK_SOUNDROMS/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/GP_SOUNDROM\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/VSU\d+_SOUNDROM_\w+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/TECHNO_SOUNDROM\d+/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/ATARI_SNDSTART/gi), inner: reFilenameCrc },
+		{ type: 'sound', outer: outerRe(/S11JS_SOUNDROM/gi), inner: reFilenameCrc },
+		{ type: 'dmd', outer: outerRe(/DE_DMD\d+ROM\d+x?/i), inner: reFilenameCrc },
+		{ type: 'dmd', outer: outerRe(/ALVGDMD_SPLIT_ROM/i), inner: reFilenameCrc },
+		{ type: 'dmd', outer: outerRe(/SPINB_DMDROM\d+/i), inner: reFilenameCrc },
+		{ type: 'dmd', outer: outerRe(/MRGAME_VIDEOROM\d+/i), inner: reFilenameCrc },
+		{ type: 'dmd', outer: outerRe(/GTS\d+_DMD\d+_ROMSTART\d*/i), inner: reFilenameCrc },
+		{ type: 'dmd', outer: outerRe(/ALVGDMD_ROM\w*/i), inner: reFilenameCrc },
+		{ type: 'dmd', outer: outerRe(/VIDEO_ROMSTART/i), inner: reFilenameCrc },
+	];
+
+	const roms = [];
+	for (const entry of entries) {
+		const src = readFileSync(entry).toString();
+		for (const matcher of nLiners) {
+			let outer;
+			do {
+				outer = matcher.outer.exec(src);
+				if (outer) {
+					let inner;
+					do {
+						inner = matchInner(matcher, matcher.inner.exec(outer[0]), roms);
+					} while (inner);
+				}
+			} while (outer);
+		}
+	}
+	return roms;
+}
+
+function outerRe(id) {
+	const suffix = /\s*\([\s\S]*?(\)|0x[0-9a-f]{8})\s*\)/gi;
+	return concatRegex(id, suffix);
+}
+
+function concatRegex(regex1, regex2) {
+	const flags = (regex1.flags + regex2.flags).split("").sort().join("").replace(/(.)(?=.*\1)/g, "");
+	return new RegExp(regex1.source + regex2.source, flags);
+}
+
+function matchInner(matcher, match, roms) {
+	if (match) {
+		const g = match.groups;
+		roms.push({
+			type: matcher.type,
+			romType: matcher.romType,
+			//gameId: g.id ? g.id.trim() : undefined,
+			filename: g.filename.trim(),
+			crc: parseInt(g.crc.trim(), 16),
+		});
+		return true;
+	}
+	return false;
+}
+
+function simplifyDbExport() {
+	const prodRoms = JSON.parse(readFileSync(PROD_EXPORT).toString());
+	const prodRomsSimple = [];
+	for (const rom of prodRoms) {
+		prodRomsSimple.push({
+			id: rom.id,
+			rom_files: rom.rom_files.map(f => ({
+				filename: f.filename,
+				crc: parseInt(f.crc[Object.keys(f.crc)[0]], 10),
+			}))
+		});
+	}
+	writeFileSync(PROD_SIMPLE, JSON.stringify(prodRomsSimple, null, '  '));
+}


### PR DESCRIPTION
A ROM contains multiple files. VPM knows how to deal with them, but other emulators don't. This adds a `type` property to the ROM file listing that indicates if a file is the main ROM, a sound ROM or video ROM.

This PR contains a script `parse-rom-files.js` which retrieves the ROM type from the PinMAME source code. Its result is also part of this PR, so all this does is add the props to the model, and run a migration script that updates the database with the additional data.

This PR closes vpdb/vpx-js#130.